### PR TITLE
Fix bug in if let codegen

### DIFF
--- a/src/compile/codegen.rs
+++ b/src/compile/codegen.rs
@@ -643,6 +643,7 @@ fn mavm_codegen_statements<'a>(
                 code.push(Instruction::from_opcode(Opcode::Label(outside_label), *loc));
                 lg3
             } else {
+                can_continue = true;
                 code.push(Instruction::from_opcode(Opcode::Label(after_label), *loc));
                 lg
             };


### PR DESCRIPTION
When generating code for an if let, if there is no else branch, and the Some branch does not terminate, the compiler would mistakenly report the if let statement as not terminating.