### PR TITLE
Make jump and cjump opcodes impure

### DIFF
--- a/src/mavm.rs
+++ b/src/mavm.rs
@@ -571,7 +571,9 @@ impl MiniProperties for Opcode {
             | Opcode::PushInsnImm
             | Opcode::ErrCodePoint
             | Opcode::ErrSet
-            | Opcode::ErrPush => false,
+            | Opcode::ErrPush
+            | Opcode::Jump
+            | Opcode::Cjump => false,
             _ => true,
         }
     }


### PR DESCRIPTION
This resolves #50, as it is necessary to use the jump opcode to enter a region of memory that is not pure.