### PR TITLE
Return result from main

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@
 
 #![allow(unused_parens)]
 
-use compile::compile_from_file;
+use compile::{compile_from_file, CompileError};
 use evm::{compile_evm_file, make_evm_jumptable_mini};
 use link::{link, postlink_compile};
 use mavm::Value;
@@ -39,7 +39,7 @@ mod run;
 mod stringtable;
 mod uint256;
 
-fn main() {
+fn main() -> Result<(), CompileError> {
     let matches = App::new("Mini compiler")
         .version("0.1")
         .author("Ed Felten <ed@offchainlabs.com")
@@ -161,6 +161,7 @@ fn main() {
                 }
                 Err(e) => {
                     println!("Compilation error: {:?}", e);
+                    return Err(e);
                 }
             }
         } else {
@@ -173,7 +174,7 @@ fn main() {
                     }
                     Err(e) => {
                         println!("Compilation error: {}", e);
-                        return;
+                        return Err(e);
                     }
                 }
             }
@@ -187,12 +188,13 @@ fn main() {
                         }
                         Err(e) => {
                             println!("Linking error: {}", e);
-                            return;
+                            return Err(e);
                         }
                     }
                 }
                 Err(e) => {
                     println!("Linking error: {}", e);
+                    return Err(e);
                 }
             }
         }
@@ -225,7 +227,8 @@ fn main() {
                 }
             }
             Err(e) => {
-                panic!("Compilation error: {}", e);
+                println!("Compilation error: {}", e);
+                return Err(e);
             }
         }
     }
@@ -248,6 +251,7 @@ fn main() {
             println!("{}", log);
         }
     }
+    Ok(())
 }
 
 fn get_output(output_filename: Option<&str>) -> Result<Box<dyn io::Write>, io::Error> {


### PR DESCRIPTION
By returning result from main we can stop make from running after a compilation error has occurred.