### PR TITLE
Constructors are txcalls to address zero

### DIFF
--- a/arb_os/messages.mini
+++ b/arb_os/messages.mini
@@ -107,10 +107,7 @@ public impure func handleMessageFromL1(msg: MessageFromL1) -> option<()> {
 
     if (msgType == 0) {
         // txcall message
-        let (bs, sequenceNum) = bytestream_getUint(inStream)?;
-        inStream = bs;
-        verifyAndIncrSequenceNum(msg.sender, sequenceNum)?;
-        return handleValidTxMessage(inStream, msg, true);
+        return handleTxMessage(inStream, msg, true, true);
     } elseif (msgType == 1) {
         // ethtransfer message
 
@@ -153,39 +150,16 @@ public impure func handleMessageFromL1(msg: MessageFromL1) -> option<()> {
         return None; // NOT YET IMPLEMENTED
     } elseif (msgType == 4) {
         // contract txcall message (just like a normal txcall, but this doesn't have a sequence number)
-        return handleValidTxMessage(inStream, msg, true);
+        return handleTxMessage(inStream, msg, true, false);
     } elseif (msgType == 5) {
         // (non-mutating) call message
-        return handleValidTxMessage(inStream, msg, false);
-    } elseif (msgType == 6) {
-        // EVM constructor/code upload message
-        asm(600,) { debugprint };
-        let (bs, sequenceNum) = bytestream_getUint(inStream)?;
-        inStream = bs;
-        verifyAndIncrSequenceNum(msg.sender, sequenceNum)?;
-
-        asm(601,) { debugprint };
-        let codeBytes = bytestream_getRemainingBytes(bs);
-        let (codept, evmJumpTable) = translateEvmCodeSegment(bytestream_new(codeBytes))?;
-
-        asm(602,) { debugprint };
-        // Generate an address for the new contract.  //TODO: Switch this to use the same method as Ethereum.
-        let newAddress = address(hash(bytes32(msg.sender), bytes32(sequenceNum)));
-
-        asm(603,) { debugprint };
-        initEvmCallStackForConstructor(
-            msg,
-            newAddress,
-            msg.sender,
-            codeBytes,
-            evmJumpTable,
-            codept,
-            bytearray_new(0),   // no arguments to the call -- they're packed into the code
-            1000000000000,            //TODO: limit gas used by constructor
-        );  // should never return
-        return None;
+        return handleTxMessage(inStream, msg, false, false);
+    // msgType 6 is not used
     } elseif (msgType == 7) {
-        // EVM code load message -- this is deprecated
+        // DEPRECATED
+        // EVM code load message
+        // It's better to send a constructor (msgType 0 with destination address 0)
+
         let (bs, contractAddressAsUint) = bytestream_getUint(inStream)?;
         inStream = bs;
 
@@ -247,7 +221,20 @@ func parseStorageMap(bs: ByteStream) -> option<(map<uint, uint>, ByteStream)> {
     }
 }
 
-impure func handleValidTxMessage(inStream: ByteStream, fullMsg: MessageFromL1, isMutating: bool) -> option<()> {
+impure func handleTxMessage(
+    inStream: ByteStream,
+    fullMsg: MessageFromL1,
+    isMutating: bool,
+    needsSeqNumCheck: bool,
+) -> option<()> {
+    let sequenceNum = 0;
+    if (needsSeqNumCheck) {
+        let (bs, sn) = bytestream_getUint(inStream)?;
+        inStream = bs;
+        sequenceNum = sn;
+        verifyAndIncrSequenceNum(fullMsg.sender, sequenceNum)?;
+    }
+
     let (bs, calleeAddressAsUint) = bytestream_getUint(inStream)?;
     inStream = bs;
 
@@ -271,20 +258,43 @@ impure func handleValidTxMessage(inStream: ByteStream, fullMsg: MessageFromL1, i
         gasPriceBid = gpb;
     }
 
-    let callKind = 3;  // staticcall
-    if (isMutating) {
-        callKind = 0;  // call
-    }
+    if (calleeAddressAsUint == 0) {
+        // this is a constructor call
+        if ( ! isMutating) {
+            return None;   // constructor must be mutating
+        }
+        let codeBytes = bytestream_getRemainingBytes(inStream);
+        let (codept, evmJumpTable) = translateEvmCodeSegment(bytestream_new(codeBytes))?;
 
-    initEvmCallStack(
-        callKind,
-        fullMsg,
-        address(calleeAddressAsUint),
-        fullMsg.sender,
-        bytestream_getRemainingBytes(inStream),  // remaining bytes of message passed to contract as calldata
-        value,
-        maxGas,
-    );  // should never return
+        let newAddress = address(hash(bytes32(fullMsg.sender), bytes32(sequenceNum)));
+
+        initEvmCallStackForConstructor(
+            fullMsg,
+            newAddress,
+            fullMsg.sender,
+            codeBytes,
+            evmJumpTable,
+            codept,
+            bytearray_new(0),   // no arguments to the call -- they're packed into the code
+            maxGas
+        );  // should never return
+    } else {
+        // this is a non-constructor call
+        let callKind = 3;  // staticcall
+        if (isMutating) {
+            callKind = 0;  // call
+        }
+
+        initEvmCallStack(
+            callKind,
+            fullMsg,
+            address(calleeAddressAsUint),
+            fullMsg.sender,
+            bytestream_getRemainingBytes(inStream),  // remaining bytes of message passed to contract as calldata
+            value,
+            maxGas,
+        );  // should never return
+    }
 
     return None;
 }

--- a/src/evm/abi.rs
+++ b/src/evm/abi.rs
@@ -290,9 +290,13 @@ impl AbiForContract {
             self.code_bytes.clone()
         };
 
-        machine
-            .runtime_env
-            .insert_deploy_contract_message(&augmented_code);
+        machine.runtime_env.insert_txcall_message(
+            Uint256::zero(),
+            Uint256::zero(),
+            Uint256::from_usize(1000000000000),
+            Uint256::zero(),
+            &augmented_code,
+        );
         let _gas_used = if debug {
             machine.debug(None)
         } else {

--- a/src/minitests.rs
+++ b/src/minitests.rs
@@ -227,9 +227,10 @@ pub fn make_logs_for_all_arbos_tests() {
     );
 
     let _ = crate::evm::evm_xcontract_call_with_constructors(
-        Some(Path::new("testlogs/evm_xcontract_call_with_constructors.aoslog")),
+        Some(Path::new(
+            "testlogs/evm_xcontract_call_with_constructors.aoslog",
+        )),
         false,
         false,
     );
 }
-

--- a/src/run/runtime_env.rs
+++ b/src/run/runtime_env.rs
@@ -94,16 +94,6 @@ impl RuntimeEnvironment {
         self.insert_eth_message(sender_addr, &buf);
     }
 
-    pub fn insert_deploy_contract_message(&mut self, contract_code: &[u8]) {
-        let sender_addr = Uint256::from_usize(1025);
-        let mut buf = vec![6u8];
-        let seq_num = self.get_and_incr_seq_num(&sender_addr);
-        buf.extend(seq_num.to_bytes_be());
-        buf.extend(contract_code);
-
-        self.insert_eth_message(sender_addr, &buf);
-    }
-
     #[cfg(test)]
     pub fn insert_erc20_deposit_message(
         &mut self,


### PR DESCRIPTION
* Special-case txcalls to address zero, so they're treated as constructor calls, consistent with what Ethereum does
* Switch over test code to use this mechanism
* Remove obsolete code that implemented and used the old mechanism

Fixes #78 