### PR TITLE
Add sideload AVM instruction

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -23,8 +23,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="0ec1045c-8109-4aac-8eaa-9c4e0575ccb5" name="Default Changelist" comment="">
-      <change beforePath="$PROJECT_DIR$/builtin/kvs.mini" beforeDir="false" afterPath="$PROJECT_DIR$/builtin/kvs.mini" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/builtin/kvstest.mini" beforeDir="false" afterPath="$PROJECT_DIR$/builtin/kvstest.mini" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/mavm.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/mavm.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/run/emulator.rs" beforeDir="false" afterPath="$PROJECT_DIR$/src/run/emulator.rs" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -40,6 +41,20 @@
   <component name="PropertiesComponent">
     <property name="org.rust.cargo.project.model.PROJECT_DISCOVERY" value="true" />
   </component>
+  <component name="RunManager">
+    <configuration name="cargo build" type="CargoCommandRunConfiguration" factoryName="Cargo Command">
+      <option name="channel" value="DEFAULT" />
+      <option name="command" value="build" />
+      <option name="allFeatures" value="false" />
+      <option name="emulateTerminal" value="false" />
+      <option name="backtrace" value="SHORT" />
+      <option name="workingDirectory" value="file://$PROJECT_DIR$" />
+      <envs />
+      <method v="2">
+        <option name="CARGO.BUILD_TASK_PROVIDER" enabled="true" />
+      </method>
+    </configuration>
+  </component>
   <component name="RustProjectSettings">
     <option name="toolchainHomeDirectory" value="$USER_HOME$/.cargo/bin" />
     <option name="version" value="2" />
@@ -49,5 +64,27 @@
   </component>
   <component name="Vcs.Log.Tabs.Properties">
     <option name="oldMeFiltersMigrated" value="true" />
+  </component>
+  <component name="WindowStateProjectService">
+    <state x="1203" y="393" key="#com.intellij.execution.impl.EditConfigurationsDialog" timestamp="1593796371455">
+      <screen x="37" y="23" width="3403" height="1417" />
+    </state>
+    <state x="1203" y="393" key="#com.intellij.execution.impl.EditConfigurationsDialog/37.23.3403.1417@37.23.3403.1417" timestamp="1593796371455" />
+    <state width="1093" height="409" key="GridCell.Tab.0.bottom" timestamp="1593796570596">
+      <screen x="37" y="23" width="3403" height="1417" />
+    </state>
+    <state width="1093" height="409" key="GridCell.Tab.0.bottom/37.23.3403.1417@37.23.3403.1417" timestamp="1593796570596" />
+    <state width="1093" height="409" key="GridCell.Tab.0.center" timestamp="1593796570595">
+      <screen x="37" y="23" width="3403" height="1417" />
+    </state>
+    <state width="1093" height="409" key="GridCell.Tab.0.center/37.23.3403.1417@37.23.3403.1417" timestamp="1593796570595" />
+    <state width="1093" height="409" key="GridCell.Tab.0.left" timestamp="1593796570594">
+      <screen x="37" y="23" width="3403" height="1417" />
+    </state>
+    <state width="1093" height="409" key="GridCell.Tab.0.left/37.23.3403.1417@37.23.3403.1417" timestamp="1593796570594" />
+    <state width="1093" height="409" key="GridCell.Tab.0.right" timestamp="1593796570595">
+      <screen x="37" y="23" width="3403" height="1417" />
+    </state>
+    <state width="1093" height="409" key="GridCell.Tab.0.right/37.23.3403.1417@37.23.3403.1417" timestamp="1593796570595" />
   </component>
 </project>

--- a/src/mavm.rs
+++ b/src/mavm.rs
@@ -570,6 +570,7 @@ pub enum AVMOpcode {
     PushInsn,
     PushInsnImm,
     OpenInsn,
+    Sideload,
     DebugPrint = 0x90,
 }
 
@@ -590,7 +591,8 @@ impl MiniProperties for Opcode {
             | Opcode::AVMOpcode(AVMOpcode::SetGas)
             | Opcode::AVMOpcode(AVMOpcode::GetGas)
             | Opcode::AVMOpcode(AVMOpcode::Jump)
-            | Opcode::AVMOpcode(AVMOpcode::Cjump) => false,
+            | Opcode::AVMOpcode(AVMOpcode::Cjump)
+            | Opcode::AVMOpcode(AVMOpcode::Sideload) => false,
             _ => true,
         }
     }
@@ -654,6 +656,7 @@ impl Opcode {
             "setgas" => Opcode::AVMOpcode(AVMOpcode::SetGas),
             "getgas" => Opcode::AVMOpcode(AVMOpcode::GetGas),
             "errset" => Opcode::AVMOpcode(AVMOpcode::ErrSet),
+            "sideload" => Opcode::AVMOpcode(AVMOpcode::Sideload),
             _ => {
                 panic!("opcode not supported in asm segment: {}", name);
             }
@@ -725,6 +728,7 @@ impl Opcode {
             0x78 => Some(Opcode::AVMOpcode(AVMOpcode::PushInsn)),
             0x79 => Some(Opcode::AVMOpcode(AVMOpcode::PushInsnImm)),
             0x7a => Some(Opcode::AVMOpcode(AVMOpcode::OpenInsn)),
+            0x7b => Some(Opcode::AVMOpcode(AVMOpcode::Sideload)),
             0x90 => Some(Opcode::AVMOpcode(AVMOpcode::DebugPrint)),
             _ => None,
         }
@@ -795,6 +799,7 @@ impl Opcode {
             Opcode::AVMOpcode(AVMOpcode::PushInsn) => Some(0x78),
             Opcode::AVMOpcode(AVMOpcode::PushInsnImm) => Some(0x79),
             Opcode::AVMOpcode(AVMOpcode::OpenInsn) => Some(0x7a),
+            Opcode::AVMOpcode(AVMOpcode::Sideload) => Some(0x7b),
             Opcode::AVMOpcode(AVMOpcode::DebugPrint) => Some(0x90),
             _ => None,
         }

--- a/src/run/emulator.rs
+++ b/src/run/emulator.rs
@@ -1323,6 +1323,11 @@ impl Machine {
                         self.incr_pc();
                         Ok(true)
                     },
+                    Opcode::AVMOpcode(AVMOpcode::Sideload) => {
+                        self.stack.push(Value::none());
+                        self.incr_pc();
+                        Ok(true)
+                    }
 					Opcode::GetLocal |  // these opcodes are for intermediate use in compilation only
 					Opcode::SetLocal |  // they should never appear in fully compiled code
 					Opcode::MakeFrame(_, _) |


### PR DESCRIPTION
Add the `sideload` AVM instruction. It simply pushes an empty Tuple onto the stack.

This is intended for use as a way to "sideload" messages into a machine, by a service provider who is executing non-mutating calls on behalf of a client.  The idea is that whenever the OS would be prepared to execute a non-mutating call, it does a sideload instruction, and if the result is other than an empty tuple, it interprets the result as a message and executes it.   

In normal execution, the result will always be an empty tuple. That's the only result that can happen on a live chain, because it's what the one-step proof for the instruction requires.