### PR TITLE
Codegen while loops more efficiently

### DIFF
--- a/src/compile/codegen.rs
+++ b/src/compile/codegen.rs
@@ -475,7 +475,7 @@ fn mavm_codegen_statements(
             ));
             code.push(Instruction::from_opcode_imm(
                 Opcode::SetLocal,
-                slot_num,
+                slot_num.clone(),
                 *loc,
             ));
             code.push(Instruction::from_opcode_imm(
@@ -510,9 +510,9 @@ fn mavm_codegen_statements(
             )?;
             label_gen = lg;
             code = c;
-            code.push(Instruction::from_opcode_imm(
+            code.push(Instruction::from_opcode_imm(Opcode::GetLocal, slot_num, *loc));
+            code.push(Instruction::from_opcode(
                 Opcode::AVMOpcode(AVMOpcode::Cjump),
-                Value::Label(top_label),
                 *loc,
             ));
             let (lg, nl, more, hm) = mavm_codegen_statements(


### PR DESCRIPTION
On entry to a while loop, we store the address at the top of the loop in a local variable.  To jump back to the top we can grab that variable, rather than having to access the static tree.

Previously, we saved the local variable at the top, but to jump back we used the inefficient static tree.

Fixes #102 