### PR TITLE
RLP encoding for bytearrays and lists

### DIFF
--- a/arb_os/codeSegment.mini
+++ b/arb_os/codeSegment.mini
@@ -22,7 +22,6 @@ import func bytestream_bytesRemaining(bs: ByteStream) -> uint;
 import func bytestream_truncate(bs: ByteStream, nbytes: uint) -> ByteStream;
 import func bytestream_getByte(bs: ByteStream) -> option<(ByteStream, uint)>;
 import func bytestream_get64(bs: ByteStream) -> option<(ByteStream, uint)>;
-import func bytestream_getUint(bs: ByteStream) -> option<(ByteStream, uint)>;
 import func bytestream_skipBytes(bs: ByteStream, nbytes: uint) -> option<ByteStream>;
 
 import func evmOp_address();

--- a/arb_os/messageBatch.mini
+++ b/arb_os/messageBatch.mini
@@ -18,16 +18,36 @@ import type MarshalledBytes;
 import type ByteArray;
 import type ByteStream;
 
+import func bytearray_size(ba: ByteArray) -> uint;
 import func bytearray_getByte(ba: ByteArray, offset: uint) -> uint;
 import func bytearray_get256(ba: ByteArray, offset: uint) -> uint;
 import func bytearray_unmarshalBytes(mb: MarshalledBytes) -> ByteArray;
 import func bytearray_marshalFull(ba: ByteArray) -> MarshalledBytes;
+import func bytearray_extract(ba: ByteArray, offset: uint, nbytes: uint) -> ByteArray;
 import func bytestream_new(ba: ByteArray) -> ByteStream;
 import func bytestream_get64(bs: ByteStream) -> option<(ByteStream, uint)>;
 import func bytestream_getN(bs: ByteStream, nbytes: uint) -> option<(ByteStream, ByteArray)>;
 import func bytestream_skipBytes(bs: ByteStream, nbytes: uint) -> option<ByteStream>;
 import func marshalledBytes_firstByte(mb: MarshalledBytes) -> uint;
 import func marshalledBytes_hash(mb: MarshalledBytes) -> bytes32;
+
+import func rlp_encodeMessageInfo(
+    seqNum: uint,
+    gasPrice: uint,
+    gasLimit: uint,
+    to: address,
+    value: uint,
+    data: ByteArray,
+    v: uint,
+    r: uint,
+    s: uint
+) -> ByteArray;
+
+import impure func chainParams_chainAddress() -> address;
+
+import impure func keccak256(ba: ByteArray, offset: uint, nbytes: uint) -> bytes32;
+
+
 
 // This is the structure that the Arbitrum protocol gives us, for each incoming message.
 // It is declared identically in inbox.mini and elsewhere
@@ -62,7 +82,7 @@ public func messageBatch_tryNew(msg: MessageFromL1) -> option<MessageBatch> {
 }
 
 public func messageBatch_get(batch: MessageBatch) -> option<(MessageFromL1, MessageBatch)> {
-    // returns None if no more messages in the batch
+    // returns next message in the batch (and updated batch), or None if no more messages in batch
     let (stream, calldataLength) = bytestream_get64(batch.stream)?;
 
     let (bs, extractedL2data) = bytestream_getN(stream, 1 + 5*32 + calldataLength)?;
@@ -74,15 +94,13 @@ public func messageBatch_get(batch: MessageBatch) -> option<(MessageFromL1, Mess
         return None;   // sub-message must be of subtype 0
     }
 
-    let marshalledL2data = bytearray_marshalFull(extractedL2data);
-
-    let signer = recoverSigner(marshalledL2data, extractedSig)?;
+    let signer = recoverSigner(extractedL2data, extractedSig)?;
 
     return Some((
         batch.template with {
             sender: signer
         } with {
-            msgData: marshalledL2data
+            msgData: bytearray_marshalFull(extractedL2data)
         },
         batch with {
             stream: stream
@@ -90,12 +108,29 @@ public func messageBatch_get(batch: MessageBatch) -> option<(MessageFromL1, Mess
     ));
 }
 
-func recoverSigner(marshalledData: MarshalledBytes, signature: ByteArray) -> option<address> {
+func recoverSigner(msgData: ByteArray, signature: ByteArray) -> option<address> {
+    let maxGas = bytearray_get256(msgData, 1);
+    let gasPriceBid = bytearray_get256(msgData, 32+1);
+    let sequenceNum = bytearray_get256(msgData, 2*32+1);
+    let destAddress = address(bytearray_get256(msgData, 3*32+1));
+    let payment = bytearray_get256(msgData, 4*32+1);
+    let rlpEncoded = rlp_encodeMessageInfo(
+        sequenceNum,
+        gasPriceBid,
+        maxGas,
+        destAddress,
+        payment,
+        bytearray_extract(msgData, 5*32+1, bytearray_size(msgData)-(5*32+1)),
+        0,
+        0,
+        uint(chainParams_chainAddress()),  // use chainAddress as the chain ID
+    );
+
     let signer = asm(
         bytearray_get256(signature, 0),
         bytearray_get256(signature, 32),
         bytearray_getByte(signature, 64),
-        marshalledBytes_hash(marshalledData)
+        keccak256(rlpEncoded, 0, bytearray_size(rlpEncoded)),
     ) address { ecrecover };
 
     if (signer == address(0)) {

--- a/arb_os/messages.mini
+++ b/arb_os/messages.mini
@@ -99,7 +99,7 @@ import func bytearray_marshalFull(ba: ByteArray) -> MarshalledBytes;
 
 import func bytestream_new(ba: ByteArray) -> ByteStream;
 import func bytestream_getByte(bs: ByteStream) -> option<(ByteStream, uint)>;
-import func bytestream_getUint(bs: ByteStream) -> option<(ByteStream, uint)>;
+import func bytestream_get256(bs: ByteStream) -> option<(ByteStream, uint)>;
 import func bytestream_skipBytes(bs: ByteStream, nbytes: uint) -> option<ByteStream>;
 import func bytestream_getRemainingBytes(bs: ByteStream) -> ByteArray;
 
@@ -129,10 +129,10 @@ public impure func handleMessageFromL1(
 
     if (msg.kind == 0) {
         // ethdeposit message
-        let (bs, destination) = bytestream_getUint(inStream)?;
+        let (bs, destination) = bytestream_get256(inStream)?;
         inStream = bs;
 
-        let (bs, amount) = bytestream_getUint(inStream)?;
+        let (bs, amount) = bytestream_get256(inStream)?;
         inStream = bs;
 
         let globalAS = getGlobalAccountStore();
@@ -148,13 +148,13 @@ public impure func handleMessageFromL1(
         return Some(());
     } elseif (msg.kind == 1) {
         // ERC20 deposit message
-        let (bs, tokenAddress) = bytestream_getUint(inStream)?;
+        let (bs, tokenAddress) = bytestream_get256(inStream)?;
         inStream = bs;
 
-        let (bs, payeeAddress) = bytestream_getUint(inStream)?;
+        let (bs, payeeAddress) = bytestream_get256(inStream)?;
         inStream = bs;
 
-        let (bs, amount) = bytestream_getUint(inStream)?;
+        let (bs, amount) = bytestream_get256(inStream)?;
         inStream = bs;
 
         tokens_erc20deposit(
@@ -167,13 +167,13 @@ public impure func handleMessageFromL1(
         return None;
     } elseif (msg.kind == 2) {
          // ERC721 deposit message
-         let (bs, tokenAddress) = bytestream_getUint(inStream)?;
+         let (bs, tokenAddress) = bytestream_get256(inStream)?;
          inStream = bs;
 
-         let (bs, payeeAddress) = bytestream_getUint(inStream)?;
+         let (bs, payeeAddress) = bytestream_get256(inStream)?;
          inStream = bs;
 
-         let (bs, id) = bytestream_getUint(inStream)?;
+         let (bs, id) = bytestream_get256(inStream)?;
          inStream = bs;
 
          tokens_erc721deposit(
@@ -242,7 +242,7 @@ impure func handleL2Message(
 
     let sequenceNum = (~0);  // impossible value for sequence number
     if (msgType == 0) {
-        let(bs, sn) = bytestream_getUint(inStream)?;
+        let(bs, sn) = bytestream_get256(inStream)?;
         inStream = bs;
         sequenceNum = sn;
 
@@ -253,13 +253,13 @@ impure func handleL2Message(
         }
     }
 
-    let (bs, calleeAddressAsUint) = bytestream_getUint(inStream)?;
+    let (bs, calleeAddressAsUint) = bytestream_get256(inStream)?;
     inStream = bs;
 
     // Get value of Eth payment that accompanies the message.
     let value = 0;
     if ( (msgType==0) || (msgType==1) ) {
-        let (bs, val) = bytestream_getUint(inStream)?;
+        let (bs, val) = bytestream_get256(inStream)?;
         inStream = bs;
         value = val;
     }

--- a/src/uint256.rs
+++ b/src/uint256.rs
@@ -105,6 +105,7 @@ impl Uint256 {
         }
     }
 
+    #[cfg(test)]
     pub fn to_bytes_minimal(&self) -> Vec<u8> {
         self.val.to_bytes_be()
     }

--- a/src/uint256.rs
+++ b/src/uint256.rs
@@ -105,10 +105,14 @@ impl Uint256 {
         }
     }
 
+    pub fn to_bytes_minimal(&self) -> Vec<u8> {
+        self.val.to_bytes_be()
+    }
+
     #[cfg(test)]
     pub fn rlp_encode(&self) -> Vec<u8> {
         // RLP encode the minimal byte representation of self
-        rlp::encode(&self.val.to_bytes_be())
+        rlp::encode(&self.to_bytes_minimal())
     }
 
     pub fn zero() -> Self {

--- a/stdlib/bytestream.mini
+++ b/stdlib/bytestream.mini
@@ -106,7 +106,7 @@ public func bytestream_get64(bs: ByteStream) -> option<(ByteStream, uint)> {
     }
 }
 
-public func bytestream_getUint(bs: ByteStream) -> option<(ByteStream, uint)> {
+public func bytestream_get256(bs: ByteStream) -> option<(ByteStream, uint)> {
     if (bs.currentOffset+32 > bs.capacity) {
         return None;
     } else {

--- a/stdlib/rlp.mini
+++ b/stdlib/rlp.mini
@@ -18,8 +18,15 @@ import type ByteArray;
 import type ByteStream;
 
 import func bytearray_new(capacity: uint) -> ByteArray;
+import func bytearray_getByte(ba: ByteArray, offset: uint) -> uint;
+import func bytearray_get256(ba: ByteArray, offset: uint) -> uint;
 import func bytearray_setByte(ba: ByteArray, offset: uint, val: uint) -> ByteArray;
+import func bytearray_set256(ba: ByteArray, offset: uint, val: uint) -> ByteArray;
+import func bytearray_copy(from: ByteArray, fromOffset: uint, to: ByteArray, toOffset: uint, nbytes: uint) -> ByteArray;
+
 import func bytestream_getByte(bs: ByteStream) -> option<(ByteStream, uint)>;
+import func bytestream_get256(bs: ByteStream) -> option<(ByteStream, uint)>;
+
 import impure func keccak256(ba: ByteArray, offset: uint, nbytes: uint) -> bytes32;
 
 
@@ -50,6 +57,99 @@ public func rlp_encodeAddress(addr: address, ba: ByteArray, offset: uint) -> (By
     return rlp_encodeUint(uint(addr), ba, offset);
 }
 
+public func rlp_encodeBytes(
+    inBytes: ByteArray, inOffset: uint, nbytes: uint,
+    outBytes: ByteArray, outOffset: uint
+) -> (ByteArray, uint) {
+    if (nbytes == 0) {
+        return (
+            bytearray_setByte(outBytes, outOffset, 0x80),
+            1
+        );
+    }
+
+    let firstByte = bytearray_getByte(inBytes, inOffset);
+    if ( (nbytes == 1) && (firstByte <= 0x7f) ) {
+        return (
+            bytearray_setByte(outBytes, outOffset, firstByte),
+            1
+        );
+    }
+
+    if (nbytes <= 55) {
+        outBytes = bytearray_setByte(outBytes, outOffset, 0x80+nbytes);
+        outOffset = outOffset + 1;
+        return (
+            bytearray_copy(inBytes, inOffset, outBytes, outOffset, nbytes),
+            1+nbytes
+        );
+    };
+
+    let sizeOfSize = bytesNeededToRepresentUint(nbytes);
+    outBytes = bytearray_setByte(outBytes, outOffset, 0xb7+sizeOfSize);
+    outOffset = outOffset + 1;
+
+    let i = sizeOfSize;
+    while (i > 0) {
+        i = i-1;
+        outBytes = bytearray_setByte(outBytes, outOffset, (nbytes / asm(256, i) uint { exp }) & 0xff);
+        outOffset = outOffset + 1;
+    }
+    return (
+        bytearray_copy(inBytes, inOffset, outBytes, outOffset, nbytes),
+        1 + sizeOfSize + nbytes
+    );
+}
+
+public func rlp_decodeBytes(inStream: ByteStream) -> option<(ByteStream, ByteArray)> {
+    let (uis, firstByte) = bytestream_getByte(inStream)?;
+    inStream = uis;
+    let result = bytearray_new(0);
+
+    if (firstByte <= 0x7f) {
+        return Some( (inStream, bytearray_setByte(result, 0, firstByte)) );
+    }
+
+    if (firstByte <= 0xb7) {
+        return copyFromStreamToArray(inStream, result, 0, firstByte - 0x80);
+    }
+
+    let sizeOfSize = firstByte - 0xb7;
+    let i = 0;
+    let nbytes = 0;
+    while (i < sizeOfSize) {
+        let (uis, b) = bytestream_getByte(inStream)?;
+        inStream = uis;
+        nbytes = 256*nbytes + b;
+        i = i+1;
+    }
+    return copyFromStreamToArray(inStream, result, 0, nbytes);
+}
+
+func copyFromStreamToArray(
+    inStream: ByteStream,
+    ba: ByteArray,
+    offset: uint,
+    nbytes: uint
+) -> option<(ByteStream, ByteArray)> {
+    let offset = 0;
+    while (nbytes >= 32) {
+        let (uis, word) = bytestream_get256(inStream)?;
+        inStream = uis;
+        ba = bytearray_set256(ba, offset, word);
+        offset = offset + 32;
+        nbytes = nbytes - 32;
+    }
+    while (nbytes > 0) {
+        let (uis, b) = bytestream_getByte(inStream)?;
+        inStream = uis;
+        ba = bytearray_setByte(ba, offset, b);
+        offset = offset + 1;
+        nbytes = nbytes - 1;
+    }
+    return Some( (inStream, ba) );
+}
+
 public func rlp_encodeAddrUintPair(
     addr: address,
     ui: uint,
@@ -67,7 +167,7 @@ public func rlp_encodeAddrUintPair(
     return (ba, 1+rlpAddrLen+rlpUiLen);
 }
 
-public func keccakOfRlpEncodedAddrUintPair(addr: address, ui: uint) -> bytes32 {
+public impure func keccakOfRlpEncodedAddrUintPair(addr: address, ui: uint) -> bytes32 {
     let ba = bytearray_new(64);
     let (uba, nbytes) = rlp_encodeAddrUintPair(addr, ui, ba, 0);
     return keccak256(uba, 0, nbytes);

--- a/stdlib/rlp.mini
+++ b/stdlib/rlp.mini
@@ -186,9 +186,8 @@ public func rlp_encodeMessageInfo(
     r: uint,
     s: uint
 ) -> ByteArray {
-    // create an array of ByteArrays; unsafecast is needed as a workaround for issue #120
+    let encodedPieces = unsafecast<[]ByteArray>(newarray<any>(9));  // workaround for issue #120
     // after #120 is fixed, use this:  let encodedPieces = newarray<ByteArray>(9);
-    let encodedPieces = unsafecast<[]ByteArray>(newarray<any>(9));
 
     encodedPieces = encodedPieces with {
         [0] = rlp_encodeUint(seqNum, bytearray_new(0), 0).0

--- a/stdlib/rlp.mini
+++ b/stdlib/rlp.mini
@@ -17,7 +17,10 @@
 import type ByteArray;
 import type ByteStream;
 
+import func builtin_arrayGetSafe(arr: []any, index: uint) -> option<any>;
+
 import func bytearray_new(capacity: uint) -> ByteArray;
+import func bytearray_size(ba: ByteArray) -> uint;
 import func bytearray_getByte(ba: ByteArray, offset: uint) -> uint;
 import func bytearray_get256(ba: ByteArray, offset: uint) -> uint;
 import func bytearray_setByte(ba: ByteArray, offset: uint, val: uint) -> ByteArray;
@@ -124,6 +127,95 @@ public func rlp_decodeBytes(inStream: ByteStream) -> option<(ByteStream, ByteArr
         i = i+1;
     }
     return copyFromStreamToArray(inStream, result, 0, nbytes);
+}
+
+public func rlp_encodeList(
+    encodedItems: []ByteArray,
+    encItemsOffset: uint,
+    numEncItems: uint,
+    outBytes: ByteArray,
+    outOffset: uint,
+) -> option<(ByteArray, uint)> {
+    let totalSize = 0;
+    let totalWritten = 0;
+    let i = 0;
+    while (i < numEncItems) {
+        let item = unsafecast<ByteArray>(builtin_arrayGetSafe(encodedItems, encItemsOffset+i)?);
+        totalSize = totalSize + bytearray_size(item);
+        i = i+1;
+    }
+
+    if (totalSize <= 55) {
+        outBytes = bytearray_setByte(outBytes, outOffset, 0xc0 + totalSize);
+        outOffset = outOffset+1;
+        totalWritten = 1 + totalSize;
+    } else {
+        let sizeOfSize = bytesNeededToRepresentUint(totalSize);
+        outBytes = bytearray_setByte(outBytes, outOffset, 0xf7 + sizeOfSize);
+        outOffset = outOffset+1;
+        let i = sizeOfSize;
+        while (i > 0) {
+            i = i-1;
+            let b = (totalSize / asm(256, i) uint { exp }) & 0xff;
+            outBytes = bytearray_setByte(outBytes, outOffset, b);
+            outOffset = outOffset+1;
+        }
+        totalWritten = 1 + sizeOfSize + totalSize;
+    }
+
+    let i = 0;
+    while (i < numEncItems) {
+        let item = encodedItems[encItemsOffset+i];  // safe, because we already read this item above
+        let size = bytearray_size(item);
+        outBytes = bytearray_copy(item, 0, outBytes, outOffset, size);
+        outOffset = outOffset + size;
+        i = i+1;
+    }
+
+    return Some((outBytes, totalWritten));
+}
+
+public func rlp_encodeMessageInfo(
+    seqNum: uint,
+    gasPrice: uint,
+    gasLimit: uint,
+    to: address,
+    value: uint,
+    data: ByteArray,
+    v: uint,
+    r: uint,
+    s: uint
+) -> ByteArray {
+    // create an array of ByteArrays; unsafecast is needed as a workaround for issue #120
+    // after #120 is fixed, use this:  let encodedPieces = newarray<ByteArray>(9);
+    let encodedPieces = unsafecast<[]ByteArray>(newarray<any>(9));
+
+    encodedPieces = encodedPieces with {
+        [0] = rlp_encodeUint(seqNum, bytearray_new(0), 0).0
+    } with {
+        [1] = rlp_encodeUint(gasPrice, bytearray_new(0), 0).0
+    } with {
+        [2] = rlp_encodeUint(gasLimit, bytearray_new(0), 0).0
+    } with {
+        [3] = rlp_encodeAddress(to, bytearray_new(0), 0).0
+    } with {
+        [4] = rlp_encodeUint(value, bytearray_new(0), 0).0
+    } with {
+        [5] = rlp_encodeBytes(data, 0, bytearray_size(data), bytearray_new(0), 0).0
+    } with {
+        [6] = rlp_encodeUint(v, bytearray_new(0), 0).0
+    } with {
+        [7] = rlp_encodeUint(r, bytearray_new(0), 0).0
+    } with {
+        [8] = rlp_encodeUint(s, bytearray_new(0), 0).0
+    };
+
+    if let Some(res) = rlp_encodeList(encodedPieces, 0, 9, bytearray_new(0), 0) {
+        return res.0;
+    } else {
+        // This can't happen, because we know encodedPieces is big enough that accesses will be in-bounds
+        panic;
+    }
 }
 
 func copyFromStreamToArray(

--- a/stdlib/rlptest.mini
+++ b/stdlib/rlptest.mini
@@ -19,32 +19,65 @@ import type ByteStream;
 import type MarshalledBytes;
 
 import func bytearray_new(capacity: uint) -> ByteArray;
+import func bytearray_size(ba: ByteArray) -> uint;
 import func bytearray_marshalFull(ba: ByteArray) -> MarshalledBytes;
+import func bytearray_unmarshalBytes(mb: MarshalledBytes) -> ByteArray;
+import func bytearray_getByte(ba: ByteArray, offset: uint) -> uint;
 
 import func bytestream_new(ba: ByteArray) -> ByteStream;
 
 import func rlp_encodeUint(val: uint, ba: ByteArray, offset: uint) -> (ByteArray, uint);
 import func rlp_encodeAddress(addr: address, ba: ByteArray, offset: uint) -> (ByteArray, uint);
+import func rlp_encodeBytes(
+    inBytes: ByteArray, inOffset: uint, nbytes: uint,
+    outBytes: ByteArray, outOffset: uint
+) -> (ByteArray, uint);
 
 import func rlp_decodeUint(bs: ByteStream) -> option<(ByteStream, uint)>;
 import func rlp_decodeAddress(bs: ByteStream) -> option<(ByteStream, address)>;
+import func rlp_decodeBytes(inStream: ByteStream) -> option<(ByteStream, ByteArray)>;
 
 import func bytesNeededToRepresentUint(val: uint) -> uint;
 
 
-impure func main(ui: uint) {
-    let ba = bytearray_new(0);
-    let (uba, _) = rlp_encodeUint(ui, ba, 0);
-    ba = uba;
+impure func main(kind: uint, value: any) {
+    if (kind == 0) {
+        let ui = unsafecast<uint>(value);
+        let ba = bytearray_new(0);
+        let (uba, _) = rlp_encodeUint(ui, ba, 0);
+        ba = uba;
 
-    // decode and verify no difference
-    if let Some(res) = rlp_decodeUint(bytestream_new(ba)) {
-        if (res.1 == ui) {
-            asm(bytearray_marshalFull(ba),) { log };
+        // decode and verify no difference
+        if let Some(res) = rlp_decodeUint(bytestream_new(ba)) {
+            if (res.1 == ui) {
+                asm(bytearray_marshalFull(ba),) { log };
+            } else {
+                asm(0,) { log };
+            }
         } else {
-            asm(0,) { log };
+            asm(1,) { log };
         }
-    } else {
-        asm(1,) { log };
+    } elseif (kind == 1) {
+        let mb = unsafecast<MarshalledBytes>(value);
+        let in = bytearray_unmarshalBytes(mb);
+        let encoded = rlp_encodeBytes(
+            in,
+            0,
+            bytearray_size(in),
+            bytearray_new(0),
+            0
+        ).0;
+
+        // decode and verify no difference
+        if let Some(res) = rlp_decodeBytes(bytestream_new(encoded)) {
+            let marshDec = bytearray_marshalFull(res.1);
+            if (marshDec == mb) {
+                asm(bytearray_marshalFull(encoded),) { log };
+            } else {
+                asm( (20, bytearray_marshalFull(encoded)), ) { log };
+            }
+        } else {
+            asm(3,) { log };
+        }
     }
 }

--- a/stdlib/rlptest.mini
+++ b/stdlib/rlptest.mini
@@ -32,6 +32,13 @@ import func rlp_encodeBytes(
     inBytes: ByteArray, inOffset: uint, nbytes: uint,
     outBytes: ByteArray, outOffset: uint
 ) -> (ByteArray, uint);
+import func rlp_encodeList(
+    encodedItems: []ByteArray,
+    encItemsOffset: uint,
+    numEncItems: uint,
+    outBytes: ByteArray,
+    outOffset: uint,
+) -> option<(ByteArray, uint)>;
 
 import func rlp_decodeUint(bs: ByteStream) -> option<(ByteStream, uint)>;
 import func rlp_decodeAddress(bs: ByteStream) -> option<(ByteStream, address)>;
@@ -78,6 +85,22 @@ impure func main(kind: uint, value: any) {
             }
         } else {
             asm(3,) { log };
+        }
+    } elseif (kind == 2) {
+        let vals = unsafecast<(uint, MarshalledBytes, uint)>(value);
+        let data = bytearray_unmarshalBytes(vals.1);
+        let encodedPieces = unsafecast<[]ByteArray>(newarray<any>(3));  // workaround issue #120
+        encodedPieces = encodedPieces with {
+            [0] = rlp_encodeUint(vals.0, bytearray_new(0), 0).0
+        } with {
+            [1] = rlp_encodeBytes(data, 0, bytearray_size(data), bytearray_new(0), 0).0
+        } with {
+            [2] = rlp_encodeUint(vals.2, bytearray_new(0), 0).0
+        };
+        if let Some(res) = rlp_encodeList(encodedPieces, 0, 3, bytearray_new(0), 0) {
+            asm(bytearray_marshalFull(res.0),) { log };
+        } else {
+            asm(4,) { log };
         }
     }
 }


### PR DESCRIPTION
* Add RLP encoding/decoding of bytearrays
* Add RLP encoding of lists of items (no decoding yet)
* Tests for the above
* Use Ethereum-compatible schema for signing of batched messages (not yet tested)