### PR TITLE
Guard all panics with error recovery code

### DIFF
--- a/arb_os/arbsys.mini
+++ b/arb_os/arbsys.mini
@@ -19,6 +19,8 @@ import type Account;
 import type ByteArray;
 import type MarshalledBytes;
 
+import impure func errorHandler();
+
 import impure func evmCallStack_topFrame() -> option<EvmCallFrame>;
 import impure func evmCallStack_setAccount(addr: address, acct: Account) -> bool;
 import impure func evmCallStack_getTopFrameMemoryOrDie() -> ByteArray;
@@ -89,8 +91,8 @@ public impure func arbsys_txcall() {
             evmOp_revert(0, 0);
         }
     } else {
-        // this shouldn't happen -- should be called in an EVM call
-        panic;
+        // this shouldn't happen -- should always be called in an EVM tx
+        errorHandler();
     }
 }
 
@@ -113,7 +115,8 @@ impure func arbsys_withdrawErc20(topFrame: EvmCallFrame, calldata: ByteArray) {
 }
 
 func arbsys_withdrawErc721(topFrame: EvmCallFrame, calldata: ByteArray) {
-    panic;
+    //BUGBUG: not yet implemented
+    errorHandler();
 }
 
 impure func arbsys_withdrawEth(topFrame: EvmCallFrame, calldata: ByteArray) {

--- a/arb_os/chainParameters.mini
+++ b/arb_os/chainParameters.mini
@@ -16,6 +16,8 @@
 
 import type MarshalledBytes;
 
+import impure func errorHandler();
+
 
 type ChainParams = struct {
     chainAddress: address,
@@ -39,6 +41,8 @@ public impure func chainParams_chainAddress() -> address {
     if let Some(params) = globalChainParams {
         return params.chainAddress;
     } else {
+        // If we get here, the chain never received its initialization message.
+        errorHandler();
         panic;
     }
 }

--- a/arb_os/codeSegment.mini
+++ b/arb_os/codeSegment.mini
@@ -16,6 +16,8 @@
 
 import type ByteStream;
 
+import impure func errorHandler();
+
 import func bytestream_atEof(bs: ByteStream) -> bool;
 import func bytestream_bytesReadSoFar(bs: ByteStream) -> uint;
 import func bytestream_bytesRemaining(bs: ByteStream) -> uint;
@@ -332,7 +334,9 @@ public impure func translateEvmCodeSegment(
                                     evmJumpTable
                                 ));
                             } else {
-                                panic; // should never happen; pushEvmInsnCall always returns Some
+                                // should never happen; pushEvmInsnCall always returns Some
+                                errorHandler();
+                                return None;
                             }
                         }
                     }

--- a/arb_os/errorHandler.mini
+++ b/arb_os/errorHandler.mini
@@ -30,7 +30,7 @@ public impure func errorHandler_init() {
     asm(pushAndJump,) { errset };
 }
 
-impure func errorHandler() {
+public impure func errorHandler() {
     // If we got here, it's because some AVM instruction hit an Error
     // This could happen for several reasons.
     //   1.  untrusted application code tried to do something erroneous, like dividing by zero

--- a/arb_os/evmCallStack.mini
+++ b/arb_os/evmCallStack.mini
@@ -24,6 +24,8 @@ import type ByteStream;
 import type MarshalledBytes;
 import type Stack;
 
+import impure func errorHandler();
+
 import impure func getGlobalAccountStore() -> AccountStore;
 import impure func setGlobalAccountStore(acctStore: AccountStore);
 import func accountStore_get(store: AccountStore, addr: address) -> Account;
@@ -286,6 +288,7 @@ public impure func evmCallStack_doCall(
     }
 
     if (kind == 1) {
+        errorHandler();  // should never return
         panic;  // callcode call type not yet implemented
     }
 
@@ -353,6 +356,7 @@ public impure func evmCallStack_doCall(
     let _ = gasAccounting_resumeTxCharges(gas);
     startCodePoint();
 
+    errorHandler();
     panic;
 }
 
@@ -414,6 +418,7 @@ public impure func evmCallStack_returnFromCall(
         let _ = gasAccounting_resumeTxCharges(leftoverGas + resumeInfo.savedGas);
         asm(resumeInfo.codePoint,) { jump };         // jump to resume point in caller; this should never return
 
+        errorHandler();
         panic;  // shouldn't happen -- previous instruction jumped away
     } else {
         // top-level call completed; will need to return to external caller
@@ -431,7 +436,7 @@ public impure func evmCallStack_returnFromCall(
                     if let Some(sm) = account_getAllStorage(topFrame.runningAsAccount) {
                         storageMap = sm;
                     } else {
-                        // Somehow the constructor didn't have storage; report error and panic.
+                        // Somehow the constructor didn't have storage; report error and recover.
                         emitLog(
                             globalCurrentEthMessage,
                             6,
@@ -440,6 +445,7 @@ public impure func evmCallStack_returnFromCall(
                             gasUsed,
                             gasPrice
                         );
+                        errorHandler();
                         panic;
                     }
 
@@ -533,6 +539,7 @@ public impure func evmCallStack_returnFromCall(
         // Now discard any AVM stack contents and jump back to the main run loop.
         emptyAvmStack();
         cleanAvmAuxStackAndCall(mainRunLoop,);  // should never return
+        errorHandler();
         panic;
     }
 }
@@ -701,6 +708,7 @@ public impure func evmCallStack_getTopFrameMemoryOrDie() -> ByteArray {
     if let Some(topFrame) = globalCallStack {
         return topFrame.memory;
     } else {
+        errorHandler();
         panic;
     }
 }
@@ -872,6 +880,7 @@ public impure func evmCallStack_callHitError() {
         // recover by clearing the evmCallStack, refunding unused gas, and jumping back to the error handler
         globalCallStack = None<EvmCallFrame>;
         let _ = gasAccounting_endTxCharges();
+        errorHandler();
         panic;
     }
 }

--- a/arb_os/evmOps.mini
+++ b/arb_os/evmOps.mini
@@ -21,6 +21,8 @@ import type ByteArray;
 import type ByteStream;
 import type MarshalledBytes;
 
+import impure func errorHandler();
+
 import impure func evmCallStack_topFrame() -> option<EvmCallFrame>;
 import impure func evmCallStack_oldestCallFrame() -> option<EvmCallFrame>;
 import impure func evmCallStack_setAccount(addr: address, acct: Account) -> bool;
@@ -375,12 +377,14 @@ public impure func evmOp_getjumpaddr(evm_pc: uint) -> impure func() {
                 return codept;
             } else {
                 evm_error();   // EVM code tried to jump to a forbidden EVM jump destination
+                errorHandler();
                 panic;
             }
         }
     }
 
     evm_runtimePanic();
+    errorHandler();
     panic;
 }
 
@@ -579,6 +583,7 @@ public impure func evmOp_call(
         return false;  // couldn't make a call, return failure
     } else {
         // should never get here -- control should have been thrown elsewhere
+        errorHandler();
         panic;
     }
 }
@@ -617,6 +622,7 @@ public impure func evmOp_callcode(
         return false;  // couldn't make a call, return failure
     } else {
         // should never get here -- control should have been thrown elsewhere
+        errorHandler();
         panic;
     }
 }
@@ -654,6 +660,7 @@ public impure func evmOp_delegatecall(
          return false;  // couldn't make a call, return failure
      } else {
          // should never get here -- control should have been thrown elsewhere
+         errorHandler();
          panic;
      }}
 
@@ -690,6 +697,7 @@ public impure func evmOp_staticcall(
         return false;  // couldn't make a call, return failure
     } else {
         // should never get here -- control should have been thrown elsewhere
+        errorHandler();
         panic;
     }
 }
@@ -915,9 +923,11 @@ func evm_runtimePanic() {
     // This should be called when something that "shouldn't ever happen" has occurred.
     // It should only be called if something has gone wrong in the trusted code.
     // If untrusted code has encountered an error, that will be handled elsewhere.
+    errorHandler();
     panic;
 }
 
 func evm_notYetImplemented(op: uint) {
+    errorHandler();
     panic;
 }


### PR DESCRIPTION
This PR ensures that all instances of `panic` in ArbOS are guarded by a call to the `errorHandler`.  Because the `errorHandler` never returns, this means ArbOS should never encounter a `panic` statement.