### PR TITLE
Allow L1 contracts to launch buddy contracts at same address at L2

### DIFF
--- a/arb_os/arbsys.mini
+++ b/arb_os/arbsys.mini
@@ -205,7 +205,7 @@ impure func getCallerAddress() -> option<address> {
     );
 }
 
-impure func sendMessage(msgType: uint, sender: address, data: ByteArray) {
+public impure func sendMessage(msgType: uint, sender: address, data: ByteArray) {
     asm(
         (
             msgType,

--- a/arb_os/evmCallStack.mini
+++ b/arb_os/evmCallStack.mini
@@ -97,6 +97,9 @@ import impure func translateEvmCodeSegment(
 
 import impure func mainRunLoop();
 
+import impure func sendMessage(msgType: uint, sender: address, data: ByteArray);
+
+
 // This callframe is used to represent an EVM call in progress.
 // The callframe will have a full copy of the system state, but
 //        that state will be contingent on the call succeeding.
@@ -135,10 +138,19 @@ type ResumeInfo = struct {  // information used to resume a call after a subcall
     savedGas: uint,         // how much of the caller's gas was not lent to the subcall
 }
 
-//FIXME:  add OrDie variants of the getters that return options; use in evmOps
-
 var globalCallStack: option<EvmCallFrame>;   // call frame of currently running call, if any
 var globalCurrentEthMessage: MessageFromL1;  // the message that launched the top-level call
+
+// This is the structure that the Arbitrum protocol gives us, for each incoming message.
+// It is declared identically in inbox.mini and elsewhere
+type MessageFromL1 = struct {
+    kind: uint,               // type of message
+    blockNumber: uint,        // block number of the L1 block
+    timestamp: uint,          // timestamp of the L1 block
+    sender: address,          // address of the sender
+    inboxSeqNum: uint,        // sequence number in L1 inbox
+    msgData: MarshalledBytes  // contents of the message, as a marshalled bytearray
+}
 
 public impure func evmCallStack_init() {
     globalCallStack = None<EvmCallFrame>;
@@ -479,6 +491,11 @@ public impure func evmCallStack_returnFromCall(
                         gasUsed,
                         gasPrice
                     );
+
+                    if (globalCurrentEthMessage.kind == 5) {
+                        // successfully created a buddy contract -- announce that as a message
+                        sendMessage(5, globalCurrentEthMessage.sender, bytearray_new(0));
+                    }
                 } else {
                     // Compilation of resulting code failed; report an error.
                     emitLog(

--- a/arb_os/messages.mini
+++ b/arb_os/messages.mini
@@ -186,7 +186,11 @@ public impure func handleMessageFromL1(
          return None;
     } elseif (msg.kind == 3) {
         // L2 message
-        handleL2Message(inStream, msg, maxGas, gasPrice)?;
+        handleL2Message(inStream, msg, maxGas, gasPrice, false)?;
+        return Some(());
+    // msg.kind == 4 is treated as unrecognized--they should already have been handled elsewhere
+    } elseif (msg.kind == 5) {
+        handleL2Message(inStream, msg, maxGas, gasPrice, true)?;
         return Some(());
     } else {
         // not a valid message type
@@ -232,10 +236,16 @@ impure func handleL2Message(
     inStream: ByteStream,
     fullMsg: MessageFromL1,
     maxGas: uint,
-    gasPrice: uint
+    gasPrice: uint,
+    isBuddyLaunch: bool,
 ) -> option<()> {   // return None if message is malformatted; otherwise handle errors and return Some(()); if no error, never return
     let (bs, msgType) = bytestream_getByte(inStream)?;
     inStream = bs;
+
+    if (isBuddyLaunch && (msgType != 1)) {
+        // buddy launch messages are required to be of "tx from contract" type
+        return None;
+    }
 
     // skip maxGas and gasPriceBid fields of message
     inStream = bytestream_skipBytes(inStream, 64)?;
@@ -274,7 +284,7 @@ impure func handleL2Message(
         let codeBytes = bytestream_getRemainingBytes(inStream);
         let (codept, evmJumpTable) = translateEvmCodeSegment(bytestream_new(codeBytes))?;
 
-        if (sequenceNum == (~0)) {
+        if ( (!isBuddyLaunch) && (sequenceNum == (~0)) ) {
             sequenceNum = fetchAndIncrSequenceNum(fullMsg.sender);
         }
         let newAddress = address(keccakOfRlpEncodedAddrUintPair(fullMsg.sender, sequenceNum));
@@ -292,6 +302,11 @@ impure func handleL2Message(
             gasPrice
         );  // should never return
     } else {
+        if (isBuddyLaunch) {
+            // buddy launch messages must be sent to address zero
+            return None;
+        }
+
         // this is a non-constructor call
         let callKind = 0;
         if (msgType == 2) {

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -54,7 +54,7 @@ pub fn evm_xcontract_call_with_constructors(
 
     let mut fib_contract =
         AbiForContract::new_from_file("contracts/fibonacci/build/contracts/Fibonacci.json")?;
-    if fib_contract.deploy(&[], &mut machine, debug) == None {
+    if fib_contract.deploy(&[], &mut machine, false, debug) == None {
         panic!("failed to deploy Fibonacci contract");
     }
 
@@ -65,6 +65,7 @@ pub fn evm_xcontract_call_with_constructors(
             &fib_contract.address.to_bytes_be()[12..],
         ))],
         &mut machine,
+        false,
         debug,
     ) == None
     {
@@ -133,7 +134,7 @@ pub fn evm_test_create(
 
     let mut fib_contract =
         AbiForContract::new_from_file("contracts/fibonacci/build/contracts/Fibonacci.json")?;
-    if fib_contract.deploy(&[], &mut machine, debug) == None {
+    if fib_contract.deploy(&[], &mut machine,false, debug) == None {
         panic!("failed to deploy Fibonacci contract");
     }
 
@@ -144,6 +145,7 @@ pub fn evm_test_create(
             &fib_contract.address.to_bytes_be()[12..],
         ))],
         &mut machine,
+        false,
         debug,
     ) == None
     {
@@ -196,7 +198,7 @@ pub fn evm_xcontract_call_using_batch(
 
     let mut fib_contract =
         AbiForContract::new_from_file("contracts/fibonacci/build/contracts/Fibonacci.json")?;
-    if fib_contract.deploy(&[], &mut machine, debug) == None {
+    if fib_contract.deploy(&[], &mut machine, false, debug) == None {
         panic!("failed to deploy Fibonacci contract");
     }
 
@@ -207,6 +209,7 @@ pub fn evm_xcontract_call_using_batch(
             &fib_contract.address.to_bytes_be()[12..],
         ))],
         &mut machine,
+        false,
         debug,
     ) == None
     {
@@ -274,7 +277,7 @@ pub fn evm_direct_deploy_add(log_to: Option<&Path>, debug: bool) {
 
     match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
         Ok(mut contract) => {
-            let result = contract.deploy(&[], &mut machine, debug);
+            let result = contract.deploy(&[], &mut machine, false, debug);
             if let Some(contract_addr) = result {
                 assert_ne!(contract_addr, Uint256::zero());
             } else {
@@ -285,6 +288,32 @@ pub fn evm_direct_deploy_add(log_to: Option<&Path>, debug: bool) {
             panic!("error loading contract: {:?}", e);
         }
     }
+
+    if let Some(path) = log_to {
+        machine.runtime_env.recorder.to_file(path).unwrap();
+    }
+}
+
+pub fn evm_deploy_buddy_contract(log_to: Option<&Path>, debug: bool) {
+    let rt_env = RuntimeEnvironment::new(Uint256::from_usize(1111));
+    let mut machine = load_from_file(Path::new("arb_os/arbos.mexe"), rt_env);
+    machine.start_at_zero();
+
+    match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
+        Ok(mut contract) => {
+            let result = contract.deploy(&[], &mut machine, true, debug);
+            if let Some(contract_addr) = result {
+                assert_ne!(contract_addr, Uint256::zero());
+            } else {
+                panic!("deploy failed");
+            }
+        }
+        Err(e) => {
+            panic!("error loading contract: {:?}", e);
+        }
+    }
+
+
 
     if let Some(path) = log_to {
         machine.runtime_env.recorder.to_file(path).unwrap();
@@ -311,7 +340,7 @@ pub fn evm_test_arbsys(log_to: Option<&Path>, debug: bool) {
 
     let contract = match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
         Ok(mut contract) => {
-            let result = contract.deploy(&vec![], &mut machine, debug);
+            let result = contract.deploy(&vec![], &mut machine, false, debug);
             if let Some(contract_addr) = result {
                 assert_ne!(contract_addr, Uint256::zero());
                 contract
@@ -410,7 +439,7 @@ pub fn evm_direct_deploy_and_call_add(log_to: Option<&Path>, debug: bool) {
     let my_addr = Uint256::from_usize(1025);
     let contract = match AbiForContract::new_from_file("contracts/add/build/contracts/Add.json") {
         Ok(mut contract) => {
-            let result = contract.deploy(&[], &mut machine, debug);
+            let result = contract.deploy(&[], &mut machine, false, debug);
             if let Some(contract_addr) = result {
                 assert_ne!(contract_addr, Uint256::zero());
                 contract

--- a/src/minitests.rs
+++ b/src/minitests.rs
@@ -247,6 +247,11 @@ fn test_direct_deploy_add() {
 }
 
 #[test]
+fn test_deploy_buddy_contract() {
+    crate::evm::evm_deploy_buddy_contract(None, false);
+}
+
+#[test]
 fn test_direct_deploy_and_call_add() {
     let _log = crate::evm::evm_direct_deploy_and_call_add(None, false);
 }


### PR DESCRIPTION
Support a new incoming message type that any L1 contract can use to deploy a "buddy contract" at L2. The buddy contract will live on the L2 chain at the same address that the originating contract occupies at L1.  

On success, in addition to the normal return code and returndata, ArbOS emits an outgoing message announcing the successful creation of a buddy contract at a specified address.