### PR TITLE
Translate illegal instructions more safely

### DIFF
--- a/arb_os/codeSegment.mini
+++ b/arb_os/codeSegment.mini
@@ -272,7 +272,7 @@ public impure func translateEvmCodeSegment(
                         if (opcode == 0x43) { // NUMBER
                             return pushEvmInsnCall(evmOp_number, restOfCode, evmJumpTable);
                         } elseif (opcode == 0x44) { // DIFFICULTY
-                             return Some((restOfCode, evmJumpTable));  // no-op
+                             return Some((pushValue(2500000000000000, restOfCode), evmJumpTable));
                         }
                     }
                 } else {

--- a/arb_os/codeSegment.mini
+++ b/arb_os/codeSegment.mini
@@ -272,8 +272,7 @@ public impure func translateEvmCodeSegment(
                         if (opcode == 0x43) { // NUMBER
                             return pushEvmInsnCall(evmOp_number, restOfCode, evmJumpTable);
                         } elseif (opcode == 0x44) { // DIFFICULTY
-                             return Some((restOfCode, evmJumpTable));
-                            //return None<(AvmCodePoint, map<uint, AvmCodePoint>)>;
+                             return Some((restOfCode, evmJumpTable));  // no-op
                         }
                     }
                 } else {
@@ -338,7 +337,8 @@ public impure func translateEvmCodeSegment(
                     }
                 } else {
                     if (opcode == 0x58) {  // GETPC
-                        return Some((pushValue(bytestream_bytesReadSoFar(bs), restOfCode), evmJumpTable));
+                        // we know the current PC, so we can push it directly as a constant
+                        return Some((pushValue(bytestream_bytesReadSoFar(bs)-1, restOfCode), evmJumpTable));
                     } elseif (opcode == 0x59) { // MSIZE
                         return pushEvmInsnCall(evmOp_msize, restOfCode, evmJumpTable);
                     } elseif (opcode == 0x5a) { // GAS

--- a/arb_os/codeSegment.mini
+++ b/arb_os/codeSegment.mini
@@ -61,13 +61,9 @@ import func evmOp_selfdestruct();
 import func evmOp_sha3();
 import func evmOp_sload();
 import func evmOp_sstore();
-import func evmOp_sloadbytes();
-import func evmOp_sstorebytes();
-import func evmOp_ssize();
 import func evmOp_staticcall();
 import func evmOp_stop();
 import func evmOp_timestamp();
-import func evmOp_txexecgas();
 import func evmOp_create();
 import func evmOp_create2();
 
@@ -276,7 +272,7 @@ public impure func translateEvmCodeSegment(
                         if (opcode == 0x43) { // NUMBER
                             return pushEvmInsnCall(evmOp_number, restOfCode, evmJumpTable);
                         } elseif (opcode == 0x44) { // DIFFICULTY
-                            return Some((pushValue(0, restOfCode), evmJumpTable));
+                             return Some((restOfCode, evmJumpTable));
                             //return None<(AvmCodePoint, map<uint, AvmCodePoint>)>;
                         }
                     }
@@ -342,7 +338,7 @@ public impure func translateEvmCodeSegment(
                     }
                 } else {
                     if (opcode == 0x58) {  // GETPC
-                        return Some((pushValue(restOfCode, restOfCode), evmJumpTable));
+                        return Some((pushValue(bytestream_bytesReadSoFar(bs), restOfCode), evmJumpTable));
                     } elseif (opcode == 0x59) { // MSIZE
                         return pushEvmInsnCall(evmOp_msize, restOfCode, evmJumpTable);
                     } elseif (opcode == 0x5a) { // GAS
@@ -399,24 +395,14 @@ public impure func translateEvmCodeSegment(
             }
         } else {
             if (opcode < 0xf4) {
-                if (opcode < 0xf0) {
-                    if (opcode == 0xe1) { // SLOADBYTES
-                        return pushEvmInsnCall(evmOp_sloadbytes, restOfCode, evmJumpTable);
-                    } elseif (opcode == 0xe2) { // SSTOREBYTES
-                        return pushEvmInsnCall(evmOp_sstorebytes, restOfCode, evmJumpTable);
-                    } elseif (opcode == 0xe3) { // SSIZE
-                        return pushEvmInsnCall(evmOp_ssize, restOfCode, evmJumpTable);
-                    }
-                } else {
-                    if (opcode == 0xf0) {  // CREATE
-                        return pushEvmInsnCall(evmOp_create, restOfCode, evmJumpTable);
-                    } elseif (opcode == 0xf1) { // CALL
-                        return pushEvmInsnCall(evmOp_call, restOfCode, evmJumpTable);
-                    } elseif (opcode == 0xf2) { // CALLCODE
-                        return pushEvmInsnCall(evmOp_ssize, restOfCode, evmJumpTable);
-                    } elseif (opcode == 0xf3) { // RETURN
-                        return pushEvmInsnCall(evmOp_return, restOfCode, evmJumpTable);
-                    }
+                if (opcode == 0xf0) {  // CREATE
+                    return pushEvmInsnCall(evmOp_create, restOfCode, evmJumpTable);
+                } elseif (opcode == 0xf1) { // CALL
+                    return pushEvmInsnCall(evmOp_call, restOfCode, evmJumpTable);
+                } elseif (opcode == 0xf2) { // CALLCODE
+                    return pushEvmInsnCall(evmOp_callcode, restOfCode, evmJumpTable);
+                } elseif (opcode == 0xf3) { // RETURN
+                    return pushEvmInsnCall(evmOp_return, restOfCode, evmJumpTable);
                 }
             } else {
                 if (opcode < 0xfc) {
@@ -428,9 +414,7 @@ public impure func translateEvmCodeSegment(
                         return pushEvmInsnCall(evmOp_staticcall, restOfCode, evmJumpTable);
                     }
                 } else {
-                    if (opcode == 0xfc) { // TXEXECGAS
-                        return pushEvmInsnCall(evmOp_txexecgas, restOfCode, evmJumpTable);
-                    } elseif (opcode == 0xfd) { // REVERT
+                    if (opcode == 0xfd) { // REVERT
                         return pushEvmInsnCall(evmOp_revert, restOfCode, evmJumpTable);
                     } elseif (opcode == 0xfe) { // INVALID
                         let (doCall, jumpTable) = pushEvmInsnCall(

--- a/arb_os/evmOps.mini
+++ b/arb_os/evmOps.mini
@@ -529,21 +529,6 @@ public impure func evmOp_log4(
     panic;
 }
 
-public impure func evmOp_sloadbytes() {
-    // believe this is a non-standard opcode
-    evm_notYetImplemented(14,);
-}
-
-public impure func evmOp_sstorebytes() {
-    // believe this is a non-standard opcode
-    evm_notYetImplemented(15,);
-}
-
-public impure func evmOp_ssize() {
-    // believe this is a non-standard opcode
-    evm_notYetImplemented(16,);
-}
-
 public impure func evmOp_call(
     gas: uint,
     callee: address,
@@ -712,11 +697,6 @@ public impure func evmOp_return(memOffset: uint, memNbytes: uint) {
     let _ = evmCallStack_returnFromCall(true, memOffset, memNbytes);
 
     evm_runtimePanic();
-}
-
-public impure func evmOp_txexecgas() {
-    // believe this is a non-standard opcode
-    evm_notYetImplemented(23,);
 }
 
 public impure func evmOp_selfdestruct(owner: address) {
@@ -927,7 +907,3 @@ impure func evm_runtimePanic() {
     panic;
 }
 
-impure func evm_notYetImplemented(op: uint) {
-    errorHandler();
-    panic;
-}


### PR DESCRIPTION
This modifies the EVM->AVM translator to do something reasonable for all invalid or unsupported EVM instructions.  