### PR TITLE
Rename incoming request object type

### DIFF
--- a/arb_os/evmCallStack.mini
+++ b/arb_os/evmCallStack.mini
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-import type MessageFromL1;
+import type IncomingRequest;
 import type AccountStore;
 import type Account;
 import type EvmLogs;
@@ -138,7 +138,7 @@ type ResumeInfo = struct {  // information used to resume a call after a subcall
 //FIXME:  add OrDie variants of the getters that return options; use in evmOps
 
 var globalCallStack: option<EvmCallFrame>;   // call frame of currently running call, if any
-var globalCurrentEthMessage: MessageFromL1;  // the message that launched the top-level call
+var globalCurrentEthMessage: IncomingRequest;  // the message that launched the top-level call
 
 public impure func evmCallStack_init() {
     globalCallStack = None<EvmCallFrame>;
@@ -146,7 +146,7 @@ public impure func evmCallStack_init() {
 
 public impure func initEvmCallStack(
     callKind: uint,
-    ethMessage: MessageFromL1,
+    ethMessage: IncomingRequest,
     addr: address,
     caller: address,
     calldata: ByteArray,
@@ -209,7 +209,7 @@ public impure func initEvmCallStack(
 }
 
 public impure func initEvmCallStackForConstructor(
-    ethMessage: MessageFromL1,
+    ethMessage: IncomingRequest,
     addr: address,
     caller: address,
     code: ByteArray,
@@ -554,7 +554,7 @@ public impure func evmCallStack_returnFromCall(
 //    6    message format error
 //    255  unknown error
 public impure func emitLog(
-    l1message: MessageFromL1,
+    l1message: IncomingRequest,
     resultCode: uint,
     maybeReturnData: option<ByteArray>,
     maybeEvmLogs: option<EvmLogs>,

--- a/arb_os/gasAccounting.mini
+++ b/arb_os/gasAccounting.mini
@@ -43,7 +43,7 @@ import impure func inbox_get() -> IncomingRequest;
 import func messageBatch_tryNew(msg: IncomingRequest) -> option<MessageBatch>;
 import func messageBatch_get(batch: MessageBatch) -> option<(IncomingRequest, MessageBatch)>;
 
-import func translateSignedTx(req: MessageFromL1) -> option<MessageFromL1>;
+import func translateSignedTx(req: IncomingRequest) -> option<IncomingRequest>;
 
 var gasAccountingInfo: struct {
     gasUsedByOS: uint,            // amount of gas used by OS that validators haven't yet been compensated for

--- a/arb_os/gasAccounting.mini
+++ b/arb_os/gasAccounting.mini
@@ -37,10 +37,10 @@ import func queue_isEmpty(q: Queue) -> bool;
 import func queue_put(q: Queue, item: any) -> Queue;
 import func queue_get(q: Queue) -> option<(Queue, any)>;
 
-import impure func inbox_get() -> MessageFromL1;
+import impure func inbox_get() -> IncomingRequest;
 
-import func messageBatch_tryNew(msg: MessageFromL1) -> option<MessageBatch>;
-import func messageBatch_get(batch: MessageBatch) -> option<(MessageFromL1, MessageBatch)>;
+import func messageBatch_tryNew(msg: IncomingRequest) -> option<MessageBatch>;
+import func messageBatch_get(batch: MessageBatch) -> option<(IncomingRequest, MessageBatch)>;
 
 
 var gasAccountingInfo: struct {
@@ -220,12 +220,12 @@ impure func switchToChargingOS() -> uint {
 
 // This is the structure that the Arbitrum protocol gives us, for each incoming message.
 // It is declared identically in inbox.mini and elsewhere
-type MessageFromL1 = struct {
+type IncomingRequest = struct {
     kind: uint,               // type of message
     blockNumber: uint,        // block number of the L1 block
     timestamp: uint,          // timestamp of the L1 block
     sender: address,          // address of the sender
-    inboxSeqNum: uint,        // sequence number in L1 inbox
+    requestId: uint,          // sequence number in L1 inbox
     msgData: MarshalledBytes  // contents of the message, as a marshalled bytearray
 }
 
@@ -242,13 +242,13 @@ type MessageFromL1 = struct {
 //     "rehydrates" the items with valid signatures into regular messages, and enqueues them.
 
 public impure func getNextMsgFromCongestionAuction() -> (
-    MessageFromL1,  // a message
+    IncomingRequest,  // a message
     bool,           // was it approved for execution
     uint,           // maxGas it's allowed to use
     uint,           // gas price it will pay
 ) {
     // For now, the gas auction is a no-op.  It just approves every message at zero gas price.
-    let msg = unsafecast<MessageFromL1>(());   // value will be re-initialized before use
+    let msg = unsafecast<IncomingRequest>(());   // value will be re-initialized before use
     loop {
         if let Some(sideloadedTuple) = trySideload() {
             return sideloadedTuple;
@@ -259,7 +259,7 @@ public impure func getNextMsgFromCongestionAuction() -> (
             gasAccountingInfo = gasAccountingInfo with {
                 queuedFromBatch: newQ
             };
-            msg = unsafecast<MessageFromL1>(rawMsg);
+            msg = unsafecast<IncomingRequest>(rawMsg);
         } else {
             msg = inbox_get();
         }
@@ -308,14 +308,14 @@ public impure func getNextMsgFromCongestionAuction() -> (
 //     onto the stack a pair (message, gasLimit).  This function will then return that
 //     pair, which will cause (the private clone of) the chain to run that call, with the
 //     given gasLimit and zero gas price.
-impure func trySideload() -> option<(MessageFromL1, bool, uint, uint)> {
+impure func trySideload() -> option<(IncomingRequest, bool, uint, uint)> {
     let sideloadedVal = asm() any { sideload };
     if (sideloadedVal == ()) {
         // normal case; the official chain will always be in this case
         return None;
     } else {
         // don't worry about the unsafecast; this can't execute on the official chain
-        let (msg, gasLimit) = unsafecast<(MessageFromL1, uint)>(sideloadedVal);
+        let (msg, gasLimit) = unsafecast<(IncomingRequest, uint)>(sideloadedVal);
         return Some((msg, true, gasLimit, 0));
     }
 }

--- a/arb_os/inbox.mini
+++ b/arb_os/inbox.mini
@@ -26,12 +26,12 @@ import type MarshalledBytes;
 
 // This is the structure that the Arbitrum protocol gives us, for each incoming message.
 // It is declared identically in messages.mini
-type MessageFromL1 = struct {
+type IncomingRequest = struct {
     kind: uint,               // type of message
     blockNumber: uint,        // block number of the L1 block
     timestamp: uint,          // timestamp of the L1 block
     sender: address,          // address of the sender
-    inboxSeqNum: uint,        // sequence number in L1 inbox
+    requestId: uint,          // sequence number in L1 inbox
     msgData: MarshalledBytes  // contents of the message, as a marshalled bytearray
 }
 
@@ -51,7 +51,7 @@ public impure func inbox_init() {
     };
 }
 
-public impure func inbox_get() -> MessageFromL1 {
+public impure func inbox_get() -> IncomingRequest {
     // Get the next message, in order of arrival.
     // If no messages have arrived, this will block until one arrives.
     // Put this in a loop so we can special-case the very first "chain parameters" message.
@@ -62,7 +62,7 @@ public impure func inbox_get() -> MessageFromL1 {
             inbox = getFromL1Inbox(inbox);
         }
         let (updatedQ, ret,) = queueGetOrDie(inbox.queue);
-        let ebMsg = unsafecast<MessageFromL1>(ret);
+        let ebMsg = unsafecast<IncomingRequest>(ret);
 
         // We got a message. Update the blocknum and timestamp of inbox, if necessary.
         if (inbox.blockNum < ebMsg.blockNumber) {

--- a/arb_os/main.mini
+++ b/arb_os/main.mini
@@ -18,7 +18,7 @@ import type AccountStore;
 import type MarshalledBytes;
 import type ByteArray;
 import type ByteStream;
-import type MessageFromL1;
+import type IncomingRequest;
 import type EvmLogs;
 
 import impure func errorHandler_init();
@@ -60,20 +60,20 @@ import func getErc20storage() -> map<uint, uint>;
 import func getErc721storage() -> map<uint, uint>;
 import func getArbInfoStorage() -> map<uint, uint>;
 
-import impure func inbox_get() -> MessageFromL1;
+import impure func inbox_get() -> IncomingRequest;
 import impure func getNextMsgFromCongestionAuction() -> (
-    MessageFromL1,  // a message
+    IncomingRequest,  // a message
     bool,           // was it approved for execution
     uint,           // maxGas it's allowed to use
     uint,           // gas price it will pay
 ) ;
-import impure func handleMessageFromL1(
-    msg: MessageFromL1,
+import impure func handleIncomingRequest(
+    msg: IncomingRequest,
     maxGas: uint,
     gasPrice: uint
 ) -> option<()>; // return None if message format error; Some(()) if other error; if no error, never return
 import impure func emitLog(
-    l1message: MessageFromL1,
+    l1message: IncomingRequest,
     resultCode: uint,
     maybeReturnData: option<ByteArray>,
     maybeEvmLogs: option<EvmLogs>,
@@ -102,7 +102,7 @@ public impure func mainRunLoop() {
     loop {
         let (msg, approved, maxGas, gasPrice) = getNextMsgFromCongestionAuction();
         if (approved) {
-            if (handleMessageFromL1(msg, maxGas, gasPrice) == None<()>) {
+            if (handleIncomingRequest(msg, maxGas, gasPrice) == None<()>) {
                 // reject for message format error
                 emitLog(msg, 6, None<ByteArray>, None<EvmLogs>, 0, 0);
             }

--- a/arb_os/messageBatch.mini
+++ b/arb_os/messageBatch.mini
@@ -103,9 +103,24 @@ public func messageBatch_get(batch: MessageBatch) -> option<(MessageFromL1, Mess
             0
         );
 
+        let rlpForId = rlp_encodeMessageInfo(
+            bytearray_get256(extractedL2data, 2*32),                   // seqNum: uint,
+            bytearray_get256(extractedL2data, 1*32),                   // gasPrice: uint,
+            bytearray_get256(extractedL2data, 0),                      // gasLimit: uint,
+            address(bytearray_get256(extractedL2data, 3*32)),          // to: address,
+            bytearray_get256(extractedL2data, 4*32),                   // value: uint,
+            bytearray_extract(extractedL2data, 5*32, preSigSize-5*32), // data: ByteArray,
+            bytearray_getByte(extractedL2data, preSigSize+64),         // v: uint,
+            bytearray_get256(extractedL2data, preSigSize),             // r: uint,
+            bytearray_get256(extractedL2data, preSigSize+32)           // s: uint
+        );
+        let txId = keccak256(rlpForId, 0, bytearray_size(rlpForId));
+
         return Some((
             batch.template with {
                 sender: signer
+            } with {
+                inboxSeqNum: uint(txId)
             } with {
                 msgData: bytearray_marshalFull(newL2message)
             },

--- a/arb_os/messageBatch.mini
+++ b/arb_os/messageBatch.mini
@@ -52,21 +52,21 @@ import impure func keccak256(ba: ByteArray, offset: uint, nbytes: uint) -> bytes
 
 // This is the structure that the Arbitrum protocol gives us, for each incoming message.
 // It is declared identically in inbox.mini and elsewhere
-type MessageFromL1 = struct {
+type IncomingRequest = struct {
     kind: uint,               // type of message
     blockNumber: uint,        // block number of the L1 block
     timestamp: uint,          // timestamp of the L1 block
     sender: address,          // address of the sender
-    inboxSeqNum: uint,        // sequence number in L1 inbox
+    requestId: uint,          // sequence number in L1 inbox
     msgData: MarshalledBytes  // contents of the message, as a marshalled bytearray
 }
 
 type MessageBatch = struct {
-    template: MessageFromL1,
+    template: IncomingRequest,
     stream: ByteStream,
 }
 
-public func messageBatch_tryNew(msg: MessageFromL1) -> option<MessageBatch> {
+public func messageBatch_tryNew(msg: IncomingRequest) -> option<MessageBatch> {
     if ( (msg.kind == 3) && (marshalledBytes_firstByte(msg.msgData) == 3) ) {
         let stream = bytestream_new(bytearray_unmarshalBytes(msg.msgData));
         stream = bytestream_skipBytes(stream, 1)?;
@@ -82,7 +82,7 @@ public func messageBatch_tryNew(msg: MessageFromL1) -> option<MessageBatch> {
     }
 }
 
-public func messageBatch_get(batch: MessageBatch) -> option<(MessageFromL1, MessageBatch)> {
+public func messageBatch_get(batch: MessageBatch) -> option<(IncomingRequest, MessageBatch)> {
     // returns next message in the batch (and updated batch), or None if no more messages in batch
     let (stream, l2MsgLength) = bytestream_get64(batch.stream)?;
 
@@ -120,7 +120,7 @@ public func messageBatch_get(batch: MessageBatch) -> option<(MessageFromL1, Mess
             batch.template with {
                 sender: signer
             } with {
-                inboxSeqNum: uint(txId)
+                requestId: uint(txId)
             } with {
                 msgData: bytearray_marshalFull(newL2message)
             },

--- a/arb_os/messages.mini
+++ b/arb_os/messages.mini
@@ -49,7 +49,7 @@ import func account_getStartCodePoint(acct: Account) -> option<impure func()>;
 
 import impure func initEvmCallStack(
     callKind: uint,
-    ethMessage: MessageFromL1,
+    ethMessage: IncomingRequest,
     addr: address,
     caller: address,
     calldata: ByteArray,
@@ -58,7 +58,7 @@ import impure func initEvmCallStack(
     gasPrice: uint
 );
 import impure func initEvmCallStackForConstructor(
-    ethMessage: MessageFromL1,
+    ethMessage: IncomingRequest,
     addr: address,
     caller: address,
     code: ByteArray,
@@ -71,7 +71,7 @@ import impure func initEvmCallStackForConstructor(
 );
 import func evmCallStack_runningCodeFromAccount() -> option<Account>;
 import impure func emitLog(
-    l1message: MessageFromL1,
+    l1message: IncomingRequest,
     resultCode: uint,
     maybeReturnData: option<ByteArray>,
     maybeEvmLogs: option<EvmLogs>,
@@ -83,13 +83,13 @@ import impure func tokens_erc20deposit(
     tokenAddr: address,
     payee: address,
     amount: uint,
-    msg: MessageFromL1
+    msg: IncomingRequest
 ) -> option<()>;
 import impure func tokens_erc721deposit(
     tokenAddr: address,
     payee: address,
     id: uint,
-    msg: MessageFromL1
+    msg: IncomingRequest
 ) -> option<()>;
 
 import func bytearray_new(capacity: uint) -> ByteArray;
@@ -110,17 +110,17 @@ import func translateEvmCodeSegment(bs: ByteStream) -> option<(impure func(), ma
 
 // This is the structure that the Arbitrum protocol gives us, for each incoming message.
 // It is declared identically in inbox.mini
-type MessageFromL1 = struct {
+type IncomingRequest = struct {
     kind: uint,               // type of message
     blockNumber: uint,        // block number of the L1 block
     timestamp: uint,          // timestamp of the L1 block
     sender: address,          // address of the sender
-    inboxSeqNum: uint,        // sequence number in L1 inbox
+    requestId: uint,          // sequence number in L1 inbox
     msgData: MarshalledBytes  // contents of the message, as a marshalled bytearray
 }
 
-public impure func handleMessageFromL1(
-    msg: MessageFromL1,
+public impure func handleIncomingRequest(
+    msg: IncomingRequest,
     maxGas: uint,
     gasPrice: uint
 ) -> option<()> {   // return None if message format error; Some(()) if other error; if no error, never return
@@ -230,7 +230,7 @@ impure func fetchAndIncrSequenceNum(addr: address) -> uint {
 
 impure func handleL2Message(
     inStream: ByteStream,
-    fullMsg: MessageFromL1,
+    fullMsg: IncomingRequest,
     maxGas: uint,
     gasPrice: uint
 ) -> option<()> {   // return None if message is malformatted; otherwise handle errors and return Some(()); if no error, never return

--- a/arb_os/tokens.mini
+++ b/arb_os/tokens.mini
@@ -17,7 +17,7 @@
 import type AccountStore;
 import type Account;
 import type ByteArray;
-import type MessageFromL1;
+import type IncomingRequest;
 
 import impure func getGlobalAccountStore() -> AccountStore;
 import impure func setGlobalAccountStore(acctStore: AccountStore);
@@ -32,7 +32,7 @@ import func bytearray_set256(ba: ByteArray, offset: uint, val: uint) -> ByteArra
 
 import impure func initEvmCallStack(
     callKind: uint,
-    ethMessage: MessageFromL1,
+    ethMessage: IncomingRequest,
     addr: address,
     caller: address,
     calldata: ByteArray,
@@ -45,7 +45,7 @@ public impure func tokens_erc20deposit(
     tokenAddress: address,
     payee: address,
     amount: uint,
-    fullMsg: MessageFromL1
+    fullMsg: IncomingRequest
 ) -> option<()> {
     let globalAS = getGlobalAccountStore();
     if(account_isEmpty(accountStore_get(globalAS, tokenAddress))) {
@@ -96,7 +96,7 @@ public impure func tokens_erc721deposit(
     tokenAddress: address,
     payee: address,
     id: uint,
-    fullMsg: MessageFromL1
+    fullMsg: IncomingRequest
 ) -> option<()> {
     let globalAS = getGlobalAccountStore();
     if(account_isEmpty(accountStore_get(globalAS, tokenAddress))) {


### PR DESCRIPTION
This PR just renames a data type. The new name is more intuitive given how the code has changed over time.