### PR TITLE
Calculate requestId for non-signed tx

### DIFF
--- a/arb_os/gasAccounting.mini
+++ b/arb_os/gasAccounting.mini
@@ -45,7 +45,7 @@ import impure func inbox_get() -> IncomingRequest;
 import func messageBatch_tryNew(msg: IncomingRequest) -> option<MessageBatch>;
 import func messageBatch_get(batch: MessageBatch) -> option<(IncomingRequest, MessageBatch)>;
 
-import func hashL2messageInfo(l2msgData: ByteArray, chainId: uint, sender: address) -> bytes32;
+import func hashL2messageInfo(l2msg: MarshalledBytes, chainId: uint, sender: address) -> bytes32;
 
 import func translateSignedTx(req: IncomingRequest) -> option<IncomingRequest>;
 
@@ -306,7 +306,7 @@ public impure func getNextMsgFromCongestionAuction() -> (
                         // it's an unsigned tx; compute unique requestId
                         msg = msg with {
                             requestId: uint(hashL2messageInfo(
-                                ba,
+                                msg.msgData,
                                 chainParams_chainId(),
                                 msg.sender
                             ))

--- a/arb_os/gasAccounting.mini
+++ b/arb_os/gasAccounting.mini
@@ -21,6 +21,8 @@ import type MarshalledBytes;
 import type MessageBatch;
 import type Queue;
 
+import func chainParams_chainId() -> uint;
+
 import func getGlobalAccountStore() -> AccountStore;
 import func setGlobalAccountStore(acctStore: AccountStore);
 import func accountStore_get(acctStore: AccountStore, addr: address) -> Account;
@@ -42,6 +44,8 @@ import impure func inbox_get() -> IncomingRequest;
 
 import func messageBatch_tryNew(msg: IncomingRequest) -> option<MessageBatch>;
 import func messageBatch_get(batch: MessageBatch) -> option<(IncomingRequest, MessageBatch)>;
+
+import func hashL2messageInfo(l2msgData: ByteArray, chainId: uint, sender: address) -> bytes32;
 
 import func translateSignedTx(req: IncomingRequest) -> option<IncomingRequest>;
 
@@ -287,7 +291,8 @@ public impure func getNextMsgFromCongestionAuction() -> (
             // get its maxGas amount -- for now, set the limit high, unless caller asked for less
             let maxGas = 1000000000;
             if (msg.kind == 3) {
-                if (marshalledBytes_firstByte(msg.msgData) == 4) {
+                let firstByte = marshalledBytes_firstByte(msg.msgData);
+                if (firstByte == 4) {
                     // it's a signed tx; verify sig and then process request or discard
                     if let Some(verifiedMsg) = translateSignedTx(msg) {
                         let ba = bytearray_unmarshalBytes(verifiedMsg.msgData);
@@ -297,6 +302,16 @@ public impure func getNextMsgFromCongestionAuction() -> (
                     // else signature was invalid, ignore msg and execute loop again to get another
                 } else {
                     let ba = bytearray_unmarshalBytes(msg.msgData);
+                    if (firstByte == 0) {
+                        // it's an unsigned tx; compute unique requestId
+                        msg = msg with {
+                            requestId: uint(hashL2messageInfo(
+                                ba,
+                                chainParams_chainId(),
+                                msg.sender
+                            ))
+                        };
+                    }
                     let maxGas = bytearray_get256(ba, 1);
                     return (msg, true, maxGas, 0);
                 }

--- a/arb_os/signedTx.mini
+++ b/arb_os/signedTx.mini
@@ -66,11 +66,11 @@ public impure func translateSignedTx(req: MessageFromL1) -> option<MessageFromL1
     );
 
    let rlpEncoded = rlp_encodeMessageInfo(
-        bytearray_get256(extractedL2data, 2*32),             // sequenceNum,
-        bytearray_get256(extractedL2data, 1*32),             // gasPriceBid
-        bytearray_get256(extractedL2data, 0),                // maxGas
-        address(bytearray_get256(extractedL2data, 3*32)),    // destAddress
-        bytearray_get256(extractedL2data, 4*32),             // payment
+        bytearray_get256(extractedL2data, 2*32+1),             // sequenceNum,
+        bytearray_get256(extractedL2data, 1*32+1),             // gasPriceBid
+        bytearray_get256(extractedL2data, 1),                // maxGas
+        address(bytearray_get256(extractedL2data, 3*32+1)),    // destAddress
+        bytearray_get256(extractedL2data, 4*32+1),             // payment
         bytearray_extract(extractedL2data, 5*32+1, preSigSize-(5*32+1)),  // calldata
         bytearray_getByte(extractedL2data, preSigSize+64),
         bytearray_get256(extractedL2data, preSigSize),

--- a/arb_os/signedTx.mini
+++ b/arb_os/signedTx.mini
@@ -124,7 +124,6 @@ func rlpAndHash(msgData: ByteArray, preSigSize: uint, v: uint, r: uint, s: uint)
 }
 
 public func hashL2messageInfo(l2msg: MarshalledBytes, chainId: uint, sender: address) -> bytes32 {
-    asm(300,) { debugprint };
     return hash(
         bytes32(sender),
         hash(

--- a/arb_os/signedTx.mini
+++ b/arb_os/signedTx.mini
@@ -65,14 +65,10 @@ public impure func translateSignedTx(req: MessageFromL1) -> option<MessageFromL1
         0
     );
 
-   let rlpEncoded = rlp_encodeMessageInfo(
-        bytearray_get256(extractedL2data, 2*32+1),             // sequenceNum,
-        bytearray_get256(extractedL2data, 1*32+1),             // gasPriceBid
-        bytearray_get256(extractedL2data, 1),                // maxGas
-        address(bytearray_get256(extractedL2data, 3*32+1)),    // destAddress
-        bytearray_get256(extractedL2data, 4*32+1),             // payment
-        bytearray_extract(extractedL2data, 5*32+1, preSigSize-(5*32+1)),  // calldata
-        bytearray_getByte(extractedL2data, preSigSize+64),
+    let rlpHash = rlpAndHash(
+        extractedL2data,
+        preSigSize,
+        bytearray_getByte(extractedL2data, preSigSize+64) + 35 + 2 * chainParams_chainId(),
         bytearray_get256(extractedL2data, preSigSize),
         bytearray_get256(extractedL2data, preSigSize+32),
     );
@@ -83,29 +79,13 @@ public impure func translateSignedTx(req: MessageFromL1) -> option<MessageFromL1
         } with {
             msgData: bytearray_marshalFull(newL2message)
         } with {
-            inboxSeqNum: uint(keccak256(rlpEncoded, 0, bytearray_size(rlpEncoded)))
+            inboxSeqNum: uint(rlpHash)
         }
     );
 }
 
 impure func recoverSigner(msgData: ByteArray, preSigSize: uint) -> option<address> {
-    let maxGas = bytearray_get256(msgData, 1);
-    let gasPriceBid = bytearray_get256(msgData, 32+1);
-    let sequenceNum = bytearray_get256(msgData, 2*32+1);
-    let destAddress = address(bytearray_get256(msgData, 3*32+1));
-    let payment = bytearray_get256(msgData, 4*32+1);
-    let rlpEncoded = rlp_encodeMessageInfo(
-        sequenceNum,
-        gasPriceBid,
-        maxGas,
-        destAddress,
-        payment,
-        bytearray_extract(msgData, 5*32+1, preSigSize-(5*32+1)),
-        chainParams_chainId(),
-        0,
-        0,
-    );
-    let rlpHash = keccak256(rlpEncoded, 0, bytearray_size(rlpEncoded));
+    let rlpHash = rlpAndHash(msgData, preSigSize, chainParams_chainId(), 0, 0);
 
     let signer = asm(
         bytearray_get256(msgData, preSigSize),
@@ -119,4 +99,24 @@ impure func recoverSigner(msgData: ByteArray, preSigSize: uint) -> option<addres
     } else {
         return Some(signer);
     }
+}
+
+func rlpAndHash(msgData: ByteArray, preSigSize: uint, v: uint, r: uint, s: uint) -> bytes32 {
+    let maxGas = bytearray_get256(msgData, 1);
+    let gasPriceBid = bytearray_get256(msgData, 32+1);
+    let sequenceNum = bytearray_get256(msgData, 2*32+1);
+    let destAddress = address(bytearray_get256(msgData, 3*32+1));
+    let payment = bytearray_get256(msgData, 4*32+1);
+    let rlpEncoded = rlp_encodeMessageInfo(
+        sequenceNum,
+        gasPriceBid,
+        maxGas,
+        destAddress,
+        payment,
+        bytearray_extract(msgData, 5*32+1, preSigSize-(5*32+1)),
+        v,
+        r,
+        s
+    );
+    return keccak256(rlpEncoded, 0, bytearray_size(rlpEncoded));
 }

--- a/arb_os/signedTx.mini
+++ b/arb_os/signedTx.mini
@@ -120,3 +120,13 @@ func rlpAndHash(msgData: ByteArray, preSigSize: uint, v: uint, r: uint, s: uint)
     );
     return keccak256(rlpEncoded, 0, bytearray_size(rlpEncoded));
 }
+
+public func hashL2messageInfo(l2msgData: ByteArray, chainId: uint, sender: address) -> bytes32 {
+    return hash(
+        bytes32(sender),
+        hash(
+            bytes32(chainId),
+            keccak256(l2msgData, 1, bytearray_size(l2msgData)-1)
+        )
+    );
+}

--- a/arb_os/signedTx.mini
+++ b/arb_os/signedTx.mini
@@ -24,6 +24,8 @@ import func bytearray_setByte(ba: ByteArray, offset: uint, val: uint) -> ByteArr
 import func bytearray_extract(ba: ByteArray, offset: uint, nbytes: uint) -> ByteArray;
 import func bytearray_unmarshalBytes(mb: MarshalledBytes) -> ByteArray;
 import func bytearray_marshalFull(ba: ByteArray) -> MarshalledBytes;
+import func marshalledBytes_hash(mb: MarshalledBytes) -> bytes32;
+
 
 import func rlp_encodeMessageInfo(
     seqNum: uint,
@@ -121,12 +123,13 @@ func rlpAndHash(msgData: ByteArray, preSigSize: uint, v: uint, r: uint, s: uint)
     return keccak256(rlpEncoded, 0, bytearray_size(rlpEncoded));
 }
 
-public func hashL2messageInfo(l2msgData: ByteArray, chainId: uint, sender: address) -> bytes32 {
+public func hashL2messageInfo(l2msg: MarshalledBytes, chainId: uint, sender: address) -> bytes32 {
+    asm(300,) { debugprint };
     return hash(
         bytes32(sender),
         hash(
             bytes32(chainId),
-            keccak256(l2msgData, 1, bytearray_size(l2msgData)-1)
+            marshalledBytes_hash(l2msg),
         )
     );
 }

--- a/arb_os/signedTx.mini
+++ b/arb_os/signedTx.mini
@@ -65,11 +65,25 @@ public impure func translateSignedTx(req: MessageFromL1) -> option<MessageFromL1
         0
     );
 
+   let rlpEncoded = rlp_encodeMessageInfo(
+        bytearray_get256(extractedL2data, 2*32),             // sequenceNum,
+        bytearray_get256(extractedL2data, 1*32),             // gasPriceBid
+        bytearray_get256(extractedL2data, 0),                // maxGas
+        address(bytearray_get256(extractedL2data, 3*32)),    // destAddress
+        bytearray_get256(extractedL2data, 4*32),             // payment
+        bytearray_extract(extractedL2data, 5*32+1, preSigSize-(5*32+1)),  // calldata
+        bytearray_getByte(extractedL2data, preSigSize+64),
+        bytearray_get256(extractedL2data, preSigSize),
+        bytearray_get256(extractedL2data, preSigSize+32),
+    );
+
     return Some(
         req with {
             sender: signer
         } with {
             msgData: bytearray_marshalFull(newL2message)
+        } with {
+            inboxSeqNum: uint(keccak256(rlpEncoded, 0, bytearray_size(rlpEncoded)))
         }
     );
 }

--- a/arb_os/signedTx.mini
+++ b/arb_os/signedTx.mini
@@ -68,7 +68,7 @@ public impure func translateSignedTx(req: MessageFromL1) -> option<MessageFromL1
     let rlpHash = rlpAndHash(
         extractedL2data,
         preSigSize,
-        bytearray_getByte(extractedL2data, preSigSize+64) + 35 + 2 * chainParams_chainId(),
+        bytearray_getByte(extractedL2data, preSigSize+64) % 2 + 35 + 2 * chainParams_chainId(),
         bytearray_get256(extractedL2data, preSigSize),
         bytearray_get256(extractedL2data, preSigSize+32),
     );
@@ -90,7 +90,7 @@ impure func recoverSigner(msgData: ByteArray, preSigSize: uint) -> option<addres
     let signer = asm(
         bytearray_get256(msgData, preSigSize),
         bytearray_get256(msgData, preSigSize+32),
-        1-(bytearray_getByte(msgData, preSigSize+64) % 2),
+        bytearray_getByte(msgData, preSigSize+64) % 2,
         rlpHash,
     ) address { ecrecover };
 

--- a/src/evm/abi.rs
+++ b/src/evm/abi.rs
@@ -371,11 +371,11 @@ impl AbiForContract {
         machine: &mut Machine,
         payment: Uint256,
         wallet: &Wallet,
-    ) -> Result<(), ethabi::Error> {
+    ) -> Result<Uint256, ethabi::Error> {
         let this_function = self.contract.function(func_name)?;
         let calldata = this_function.encode_input(args).unwrap();
 
-        machine.runtime_env.append_signed_tx_message_to_batch(
+        let tx_id_bytes = machine.runtime_env.append_signed_tx_message_to_batch(
             batch,
             sender_addr,
             Uint256::from_usize(1_000_000_000_000),
@@ -386,6 +386,6 @@ impl AbiForContract {
             &wallet,
         );
 
-        Ok(())
+        Ok((Uint256::from_bytes(&tx_id_bytes)))
     }
 }

--- a/src/evm/abi.rs
+++ b/src/evm/abi.rs
@@ -289,7 +289,7 @@ impl AbiForContract {
         };
 
         let sender_addr = Uint256::from_usize(1025);
-        machine.runtime_env.insert_tx_message(
+        let request_id = machine.runtime_env.insert_tx_message(
             sender_addr,
             Uint256::from_usize(1_000_000_000_000),
             Uint256::zero(),
@@ -314,6 +314,12 @@ impl AbiForContract {
 
         if let Value::Tuple(tup) = &logs[logs.len() - 1] {
             assert_eq!(tup[1], Value::Int(Uint256::zero()));
+            if let Value::Tuple(tup2) = &tup[0] {
+                assert_eq!(tup2[4], Value::Int(request_id));
+            } else {
+                println!("Malformed ArbOS log item");
+                return None;
+            }
             let buf = bytes_from_bytestack(tup[2].clone())?;
             self.address = Uint256::from_bytes(&buf);
             Some(self.address.clone())

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -217,7 +217,7 @@ pub fn evm_xcontract_call_using_batch(
     }
 
     let mut batch = machine.runtime_env.new_batch();
-    pc_contract.add_function_call_to_batch(
+    let tx_id_1 = pc_contract.add_function_call_to_batch(
         &mut batch,
         my_addr.clone(),
         "deposit",
@@ -226,7 +226,7 @@ pub fn evm_xcontract_call_using_batch(
         Uint256::from_usize(10000),
         &wallet,
     )?;
-    pc_contract.add_function_call_to_batch(
+    let tx_id_2 = pc_contract.add_function_call_to_batch(
         &mut batch,
         my_addr.clone(),
         "transferFib",
@@ -262,9 +262,19 @@ pub fn evm_xcontract_call_using_batch(
     assert_eq!(sends.len(), 0);
     if let Value::Tuple(tup) = &logs[0] {
         assert_eq!(tup[1], Value::Int(Uint256::zero()));
+        if let Value::Tuple(subtup) = &tup[0] {
+            assert_eq!(subtup[4], Value::Int(tx_id_1));
+        } else {
+            panic!("malformed log entry");
+        }
     }
     if let Value::Tuple(tup) = &logs[1] {
         assert_eq!(tup[1], Value::Int(Uint256::zero()));
+        if let Value::Tuple(subtup) = &tup[0] {
+            assert_eq!(subtup[4], Value::Int(tx_id_2));
+        } else {
+            panic!("malformed log entry");
+        }
     }
 
     if let Some(path) = log_to {

--- a/src/run/runtime_env.rs
+++ b/src/run/runtime_env.rs
@@ -90,9 +90,9 @@ impl RuntimeEnvironment {
         to_addr: Uint256,
         value: Uint256,
         data: &[u8],
-    ) {
+    ) -> Uint256 {
         let mut buf = vec![0u8];
-        let seq_num = self.get_and_incr_seq_num(&sender_addr);
+        let seq_num = self.get_and_incr_seq_num(&sender_addr.clone());
         buf.extend(max_gas.to_bytes_be());
         buf.extend(gas_price_bid.to_bytes_be());
         buf.extend(seq_num.to_bytes_be());
@@ -100,7 +100,15 @@ impl RuntimeEnvironment {
         buf.extend(value.to_bytes_be());
         buf.extend_from_slice(data);
 
-        self.insert_l2_message(sender_addr, &buf);
+        self.insert_l2_message(sender_addr.clone(), &buf);
+
+        Uint256::avm_hash2(
+            &sender_addr,
+            &Uint256::avm_hash2(
+                &Uint256::from_u64(self.chain_id),
+                &hash_bytestack(bytestack_from_bytes(&buf)).unwrap()
+            )
+        )
     }
 
     pub fn new_batch(&self) -> Vec<u8> {
@@ -300,6 +308,39 @@ fn bytestack_build_uint(b: &[u8]) -> Value {
         }
     }
     Value::Int(ui)
+}
+
+pub fn hash_bytestack(bs: Value) -> Option<Uint256> {
+    if let Value::Tuple(tup) = bs {
+        if let Value::Int(ui) = &tup[0] {
+            let mut acc: Uint256 = ui.clone();
+            let mut pair = &tup[1];
+            while ( ! (*pair == Value::none())) {
+                if let Value::Tuple(tup2) = pair {
+                    if let Value::Int(ui2) = &tup2[0] {
+                        acc = Uint256::avm_hash2(&acc, &ui2);
+                        pair = &tup2[1];
+                    } else {
+                        return None;
+                    }
+                } else {
+                    return None;
+                }
+            }
+            Some(acc)
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+#[test]
+fn test_hash_bytestack() {
+    let buf = hex::decode("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142").unwrap();
+    let h = hash_bytestack(bytestack_from_bytes(&buf)).unwrap();
+    assert_eq!(h, Uint256::from_string_hex("4fc384a19926e9ff7ec8f2376a0d146dc273031df1db4d133236d209700e4780").unwrap());
 }
 
 pub fn bytes_from_bytestack(bs: Value) -> Option<Vec<u8>> {

--- a/src/run/runtime_env.rs
+++ b/src/run/runtime_env.rs
@@ -106,8 +106,8 @@ impl RuntimeEnvironment {
             &sender_addr,
             &Uint256::avm_hash2(
                 &Uint256::from_u64(self.chain_id),
-                &hash_bytestack(bytestack_from_bytes(&buf)).unwrap()
-            )
+                &hash_bytestack(bytestack_from_bytes(&buf)).unwrap(),
+            ),
         )
     }
 
@@ -315,7 +315,7 @@ pub fn hash_bytestack(bs: Value) -> Option<Uint256> {
         if let Value::Int(ui) = &tup[0] {
             let mut acc: Uint256 = ui.clone();
             let mut pair = &tup[1];
-            while ( ! (*pair == Value::none())) {
+            while (!(*pair == Value::none())) {
                 if let Value::Tuple(tup2) = pair {
                     if let Value::Int(ui2) = &tup2[0] {
                         acc = Uint256::avm_hash2(&acc, &ui2);
@@ -340,7 +340,13 @@ pub fn hash_bytestack(bs: Value) -> Option<Uint256> {
 fn test_hash_bytestack() {
     let buf = hex::decode("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142").unwrap();
     let h = hash_bytestack(bytestack_from_bytes(&buf)).unwrap();
-    assert_eq!(h, Uint256::from_string_hex("4fc384a19926e9ff7ec8f2376a0d146dc273031df1db4d133236d209700e4780").unwrap());
+    assert_eq!(
+        h,
+        Uint256::from_string_hex(
+            "4fc384a19926e9ff7ec8f2376a0d146dc273031df1db4d133236d209700e4780"
+        )
+        .unwrap()
+    );
 }
 
 pub fn bytes_from_bytestack(bs: Value) -> Option<Vec<u8>> {

--- a/src/run/runtime_env.rs
+++ b/src/run/runtime_env.rs
@@ -18,11 +18,11 @@ use crate::mavm::Value;
 use crate::uint256::Uint256;
 use ethers_core::rand::thread_rng;
 use ethers_core::types::{Transaction, TransactionRequest};
+use ethers_core::utils::keccak256;
 use ethers_signers::{Signer, Wallet};
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use std::{collections::HashMap, fs::File, io, path::Path};
-use ethers_core::utils::keccak256;
 
 #[derive(Debug, Clone)]
 pub struct RuntimeEnvironment {
@@ -151,7 +151,15 @@ impl RuntimeEnvironment {
         calldata: Vec<u8>,
         wallet: &Wallet,
     ) -> Vec<u8> {
-        let (msg, tx_id_bytes) = self.make_signed_l2_message(sender_addr, max_gas, gas_price_bid, to_addr, value, calldata, wallet);
+        let (msg, tx_id_bytes) = self.make_signed_l2_message(
+            sender_addr,
+            max_gas,
+            gas_price_bid,
+            to_addr,
+            value,
+            calldata,
+            wallet,
+        );
         let msg_size: u64 = msg.len().try_into().unwrap();
         batch.extend(&msg_size.to_be_bytes());
         batch.extend(msg);


### PR DESCRIPTION
ArbOS now calculates a requestId for non-signed txs (aka L2 messages of subtype 0). This is put into the requestId field of the log item reporting the tx result.

Formula:
hash2(
    uint32(sender), 
    hash2(
        uint32(chainId), 
        hashBytestack(L2 message as bytestack)
    )
)