### PR TITLE
Switch to new tx receipt format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ $(BUILTINDIR)/kvs.mao: $(BUILTINDIR)/kvs.mini
 	$(CARGORUN) compile $(BUILTINDIR)/kvs.mini -c -o $(BUILTINDIR)/kvs.mao
 
 ARBOSDIR = arb_os
-ARBOSAOS = $(ARBOSDIR)/main.mao $(ARBOSDIR)/accounts.mao $(ARBOSDIR)/messages.mao $(ARBOSDIR)/inbox.mao $(ARBOSDIR)/evmCallStack.mao $(ARBOSDIR)/evmOps.mao $(ARBOSDIR)/codeSegment.mao $(ARBOSDIR)/evmlogs.mao $(ARBOSDIR)/errorHandler.mao $(ARBOSDIR)/gasAccounting.mao $(ARBOSDIR)/contractTemplates.mao $(ARBOSDIR)/tokens.mao $(ARBOSDIR)/arbsys.mao $(ARBOSDIR)/messageBatch.mao $(ARBOSDIR)/chainParameters.mao $(ARBOSDIR)/precompiles.mao $(ARBOSDIR)/signedTx.mao
+ARBOSAOS = $(ARBOSDIR)/main.mao $(ARBOSDIR)/accounts.mao $(ARBOSDIR)/messages.mao $(ARBOSDIR)/inbox.mao $(ARBOSDIR)/evmCallStack.mao $(ARBOSDIR)/evmOps.mao $(ARBOSDIR)/codeSegment.mao $(ARBOSDIR)/evmlogs.mao $(ARBOSDIR)/errorHandler.mao $(ARBOSDIR)/gasAccounting.mao $(ARBOSDIR)/contractTemplates.mao $(ARBOSDIR)/tokens.mao $(ARBOSDIR)/arbsys.mao $(ARBOSDIR)/messageBatch.mao $(ARBOSDIR)/chainParameters.mao $(ARBOSDIR)/precompiles.mao $(ARBOSDIR)/signedTx.mao $(ARBOSDIR)/txReceipt.mao
 ARBOS = $(ARBOSDIR)/arbos.mexe
 
 arbos: $(ARBOS)
@@ -140,6 +140,9 @@ $(ARBOSDIR)/precompiles.mao: $(ARBOSDIR)/precompiles.mini
 
 $(ARBOSDIR)/signedTx.mao: $(ARBOSDIR)/signedTx.mini
 	$(CARGORUN) compile $(ARBOSDIR)/signedTx.mini -c -o $(ARBOSDIR)/signedTx.mao
+
+$(ARBOSDIR)/txReceipt.mao: $(ARBOSDIR)/txReceipt.mini
+	$(CARGORUN) compile $(ARBOSDIR)/txReceipt.mini -c -o $(ARBOSDIR)/txReceipt.mao
 
 $(ARBOS): $(ARBOSAOS) $(STDLIB) $(BUILTINMAOS)
 	$(CARGORUN) compile $(ARBOSAOS) $(STDLIB) -o $(ARBOS)

--- a/arb_os/evmCallStack.mini
+++ b/arb_os/evmCallStack.mini
@@ -95,8 +95,17 @@ import impure func translateEvmCodeSegment(
     bs: ByteStream
 ) -> option<(impure func(), map<uint, impure func()>)>;
 
+import impure func emitLog(
+    l1message: IncomingRequest,
+    resultCode: uint,
+    maybeReturnData: option<ByteArray>,
+    maybeEvmLogs: option<EvmLogs>,
+    gasUsage: option<GasUsage>,
+);
+
 import impure func mainRunLoop();
 
+// This is declared identially in gasAccounting.mini
 type GasUsage = struct {
     gasUsed: uint,
     gasPriceWei: uint,
@@ -541,47 +550,6 @@ public impure func evmCallStack_returnFromCall(
         errorHandler();
         panic;
     }
-}
-
-// result codes:
-//    0    return (success)
-//    1    tx reverted
-//    2    rejected due to congestion
-//    3    insufficient funds to pay for gas
-//    4    insufficient funds for tx payment
-//    5    bad sequence number
-//    6    message format error
-//    255  unknown error
-public impure func emitLog(
-    l1message: IncomingRequest,
-    resultCode: uint,
-    maybeReturnData: option<ByteArray>,
-    maybeEvmLogs: option<EvmLogs>,
-    gasUsage: option<GasUsage>,
-) {
-    let returnData = bytearray_new(0);
-    if let Some(rd) = maybeReturnData {
-        returnData = rd;
-    }
-    let evmLogs = evmlogs_empty();
-    if let Some(el) = maybeEvmLogs {
-        evmLogs = el;
-    }
-    let realGasUsage = struct {
-        gasUsed: 0,
-        gasPriceWei: 0,
-    };
-    if let Some(gu) = gasUsage {
-        realGasUsage = gu;
-    }
-
-    asm((
-        l1message,
-        resultCode,
-        bytearray_marshalFull(returnData),
-        evmLogs,
-        realGasUsage
-    ),) { log };
 }
 
 func saveAvmStack() -> Stack {

--- a/arb_os/main.mini
+++ b/arb_os/main.mini
@@ -30,6 +30,7 @@ import impure func evmCallStack_init();
 import impure func inbox_init();
 import impure func accountStore_init();
 import impure func precompiles_init(acctStore: AccountStore) -> option<AccountStore>;
+import impure func txReceipts_init();
 
 import impure func getGlobalAccountStore() -> AccountStore;
 import impure func setGlobalAccountStore(acctStore: AccountStore);
@@ -91,6 +92,7 @@ impure func main() {
     evmCallStack_init();
     inbox_init();
     accountStore_init();
+    txReceipts_init();
     if (initializeContractTemplates() == None<()>) {
         panic;   // don't try to run without contract templates
     }

--- a/arb_os/txReceipt.mini
+++ b/arb_os/txReceipt.mini
@@ -38,6 +38,12 @@ type GasUsage = struct {
     gasPriceWei: uint,
 }
 
+type TxResultInfo = struct {
+    returnCode: uint,
+    returnData: MarshalledBytes,
+    evmLogs: EvmLogs,
+}
+
 // result codes:
 //    0    return (success)
 //    1    tx reverted
@@ -70,11 +76,14 @@ public impure func emitLog(
         realGasUsage = gu;
     }
 
+    let txResultInfo = struct {
+        returnCode: resultCode,
+        returnData: bytearray_marshalFull(returnData),
+        evmLogs: evmLogs,
+    };
     asm((
         l1message,
-        resultCode,
-        bytearray_marshalFull(returnData),
-        evmLogs,
+        txResultInfo,
         realGasUsage
     ),) { log };
 }

--- a/arb_os/txReceipt.mini
+++ b/arb_os/txReceipt.mini
@@ -39,13 +39,6 @@ type GasUsage = struct {
     gasPriceWei: uint,
 }
 
-type TxResultInfo = struct {
-    returnCode: uint,
-    returnData: MarshalledBytes,
-    evmLogs: EvmLogs,
-    perBlockData: PerBlockReceiptData,
-}
-
 type PerBlockReceiptData = struct {
     totalGasUsed: uint,
     numTx: uint,

--- a/arb_os/txReceipt.mini
+++ b/arb_os/txReceipt.mini
@@ -21,6 +21,7 @@ import type EvmLogs;
 import func bytearray_new(capacity: uint) -> ByteArray;
 import func bytearray_marshalFull(ba: ByteArray) -> MarshalledBytes;
 import func evmlogs_empty() -> EvmLogs;
+import func evmlogs_numLogs(logs: EvmLogs) -> uint;
 
 // This is declared identically in messages.mini
 type IncomingRequest = struct {
@@ -42,6 +43,59 @@ type TxResultInfo = struct {
     returnCode: uint,
     returnData: MarshalledBytes,
     evmLogs: EvmLogs,
+    perBlockData: PerBlockReceiptData,
+}
+
+type PerBlockReceiptData = struct {
+    totalGasUsed: uint,
+    numTx: uint,
+    numEvmLogs: uint,
+}
+
+var globalBlockReceiptData: struct {
+    blockNum: uint,
+    data: PerBlockReceiptData
+};
+
+public impure func txReceipts_init() {  // will be called at beginning of main()
+    init_txReceiptsForBlock(0);
+}
+
+impure func init_txReceiptsForBlock(blockNum: uint) {
+    globalBlockReceiptData = struct {
+        blockNum: blockNum,
+        data: struct {
+            totalGasUsed: 0,
+            numTx: 0,
+            numEvmLogs: 0
+        }
+    };
+}
+
+impure func update_txReceiptsForBlock(
+    blockNum: uint,
+    gasUsed: uint,
+    numEvmLogs: uint
+) -> PerBlockReceiptData {
+    if (blockNum > globalBlockReceiptData.blockNum) {
+        init_txReceiptsForBlock(blockNum);
+    }
+
+    // first add in the gas, because returned value is supposed to include it
+    let ret = globalBlockReceiptData.data with {
+        totalGasUsed: gasUsed + globalBlockReceiptData.data.totalGasUsed
+    };
+
+    // now update the accumulated data and write it back
+    globalBlockReceiptData = globalBlockReceiptData with {
+        data: ret with {
+            numTx: ret.numTx + 1
+        } with {
+            numEvmLogs: ret.numEvmLogs + numEvmLogs
+        }
+    };
+
+    return ret;
 }
 
 // result codes:
@@ -84,6 +138,11 @@ public impure func emitLog(
     asm((
         l1message,
         txResultInfo,
-        realGasUsage
+        realGasUsage,
+        update_txReceiptsForBlock(
+            l1message.blockNumber,
+            realGasUsage.gasUsed,
+            evmlogs_numLogs(evmLogs)
+        )
     ),) { log };
 }

--- a/arb_os/txReceipt.mini
+++ b/arb_os/txReceipt.mini
@@ -1,0 +1,80 @@
+//
+// Copyright 2020, Offchain Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import type ByteArray;
+import type MarshalledBytes;
+import type EvmLogs;
+
+import func bytearray_new(capacity: uint) -> ByteArray;
+import func bytearray_marshalFull(ba: ByteArray) -> MarshalledBytes;
+import func evmlogs_empty() -> EvmLogs;
+
+// This is declared identically in messages.mini
+type IncomingRequest = struct {
+    kind: uint,               // type of message
+    blockNumber: uint,        // block number of the L1 block
+    timestamp: uint,          // timestamp of the L1 block
+    sender: address,          // address of the sender
+    requestId: uint,          // sequence number in L1 inbox
+    msgData: MarshalledBytes  // contents of the message, as a marshalled bytearray
+}
+
+// This is declared identially in gasAccounting.mini
+type GasUsage = struct {
+    gasUsed: uint,
+    gasPriceWei: uint,
+}
+
+// result codes:
+//    0    return (success)
+//    1    tx reverted
+//    2    rejected due to congestion
+//    3    insufficient funds to pay for gas
+//    4    insufficient funds for tx payment
+//    5    bad sequence number
+//    6    message format error
+//    255  unknown error
+public impure func emitLog(
+    l1message: IncomingRequest,
+    resultCode: uint,
+    maybeReturnData: option<ByteArray>,
+    maybeEvmLogs: option<EvmLogs>,
+    gasUsage: option<GasUsage>,
+) {
+    let returnData = bytearray_new(0);
+    if let Some(rd) = maybeReturnData {
+        returnData = rd;
+    }
+    let evmLogs = evmlogs_empty();
+    if let Some(el) = maybeEvmLogs {
+        evmLogs = el;
+    }
+    let realGasUsage = struct {
+        gasUsed: 0,
+        gasPriceWei: 0,
+    };
+    if let Some(gu) = gasUsage {
+        realGasUsage = gu;
+    }
+
+    asm((
+        l1message,
+        resultCode,
+        bytearray_marshalFull(returnData),
+        evmLogs,
+        realGasUsage
+    ),) { log };
+}

--- a/src/evm/abi.rs
+++ b/src/evm/abi.rs
@@ -15,7 +15,7 @@
  */
 
 use crate::mavm::Value;
-use crate::run::{Machine, ArbosReceipt};
+use crate::run::{ArbosReceipt, Machine};
 use crate::uint256::Uint256;
 use ethers_signers::Wallet;
 use std::{fs::File, io::Read, path::Path};
@@ -312,7 +312,7 @@ impl AbiForContract {
             return None;
         }
 
-        let log_item = &logs[logs.len()-1];
+        let log_item = &logs[logs.len() - 1];
         assert!(log_item.succeeded());
         if let Value::Tuple(tup2) = log_item.get_request() {
             assert_eq!(tup2[4], Value::Int(request_id));

--- a/src/evm/abi.rs
+++ b/src/evm/abi.rs
@@ -15,7 +15,7 @@
  */
 
 use crate::mavm::Value;
-use crate::run::{bytes_from_bytestack, Machine};
+use crate::run::{Machine, ArbosReceipt};
 use crate::uint256::Uint256;
 use ethers_signers::Wallet;
 use std::{fs::File, io::Read, path::Path};
@@ -312,20 +312,17 @@ impl AbiForContract {
             return None;
         }
 
-        if let Value::Tuple(tup) = &logs[logs.len() - 1] {
-            assert_eq!(tup[1], Value::Int(Uint256::zero()));
-            if let Value::Tuple(tup2) = &tup[0] {
-                assert_eq!(tup2[4], Value::Int(request_id));
-            } else {
-                println!("Malformed ArbOS log item");
-                return None;
-            }
-            let buf = bytes_from_bytestack(tup[2].clone())?;
-            self.address = Uint256::from_bytes(&buf);
-            Some(self.address.clone())
+        let log_item = &logs[logs.len()-1];
+        assert!(log_item.succeeded());
+        if let Value::Tuple(tup2) = log_item.get_request() {
+            assert_eq!(tup2[4], Value::Int(request_id));
         } else {
-            None
+            println!("Malformed ArbOS log item");
+            return None;
         }
+        let buf = log_item.get_return_data();
+        self.address = Uint256::from_bytes(&buf);
+        Some(self.address.clone())
     }
 
     pub fn get_function(&self, name: &str) -> Result<&ethabi::Function, ethabi::Error> {
@@ -340,7 +337,7 @@ impl AbiForContract {
         machine: &mut Machine,
         payment: Uint256,
         debug: bool,
-    ) -> Result<(Vec<Value>, Vec<Value>), ethabi::Error> {
+    ) -> Result<(Vec<ArbosReceipt>, Vec<Value>), ethabi::Error> {
         let this_function = self.contract.function(func_name)?;
         let calldata = this_function.encode_input(args).unwrap();
 

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -261,7 +261,10 @@ pub fn evm_xcontract_call_using_batch(
 
     assert!(logs[1].succeeded());
     assert_eq!(logs[1].get_request_id(), tx_id_2);
-    assert_eq!(gas_used_so_far_1.add(&logs[1].get_gas_used()), logs[1].get_gas_used_so_far());
+    assert_eq!(
+        gas_used_so_far_1.add(&logs[1].get_gas_used()),
+        logs[1].get_gas_used_so_far()
+    );
 
     if let Some(path) = log_to {
         machine.runtime_env.recorder.to_file(path).unwrap();

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -256,18 +256,10 @@ pub fn evm_xcontract_call_using_batch(
     assert_eq!(sends.len(), 0);
 
     assert!(logs[0].succeeded());
-    if let Value::Tuple(subtup) = logs[0].get_request() {
-        assert_eq!(subtup[4], Value::Int(tx_id_1));
-    } else {
-        panic!("malformed log entry");
-    }
+    assert_eq!(logs[0].get_request_id(), tx_id_1);
 
     assert!(logs[1].succeeded());
-    if let Value::Tuple(subtup) = logs[1].get_request() {
-        assert_eq!(subtup[4], Value::Int(tx_id_2));
-    } else {
-        panic!("malformed log entry");
-    }
+    assert_eq!(logs[1].get_request_id(), tx_id_2);
 
     if let Some(path) = log_to {
         machine.runtime_env.recorder.to_file(path).unwrap();
@@ -482,8 +474,8 @@ pub fn mint_erc20_and_get_balance(log_to: Option<&Path>, debug: bool) {
     };
     let logs = machine.runtime_env.get_all_logs();
     assert_eq!(logs.len(), num_logs_before + 2);
-    assert!(logs[logs.len()-2].succeeded());
-    assert!(logs[logs.len()-1].succeeded());
+    assert!(logs[logs.len() - 2].succeeded());
+    assert!(logs[logs.len() - 1].succeeded());
 
     if let Some(path) = log_to {
         machine.runtime_env.recorder.to_file(path).unwrap();
@@ -519,8 +511,8 @@ pub fn mint_erc721_and_get_balance(log_to: Option<&Path>, debug: bool) {
     };
     let logs = machine.runtime_env.get_all_logs();
     assert_eq!(logs.len(), num_logs_before + 2);
-    assert!(logs[logs.len()-2].succeeded());
-    assert!(logs[logs.len()-1].succeeded());
+    assert!(logs[logs.len() - 2].succeeded());
+    assert!(logs[logs.len() - 1].succeeded());
 
     if let Some(path) = log_to {
         machine.runtime_env.recorder.to_file(path).unwrap();

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -257,9 +257,11 @@ pub fn evm_xcontract_call_using_batch(
 
     assert!(logs[0].succeeded());
     assert_eq!(logs[0].get_request_id(), tx_id_1);
+    let gas_used_so_far_1 = logs[0].get_gas_used_so_far();
 
     assert!(logs[1].succeeded());
     assert_eq!(logs[1].get_request_id(), tx_id_2);
+    assert_eq!(gas_used_so_far_1.add(&logs[1].get_gas_used()), logs[1].get_gas_used_so_far());
 
     if let Some(path) = log_to {
         machine.runtime_env.recorder.to_file(path).unwrap();

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -22,7 +22,7 @@ use emulator::{ExecutionError, StackTrace};
 use std::{fs::File, io::Read, path::Path};
 
 pub use emulator::Machine;
-pub use runtime_env::{bytes_from_bytestack, bytestack_from_bytes, RuntimeEnvironment};
+pub use runtime_env::{bytes_from_bytestack, bytestack_from_bytes, RuntimeEnvironment, ArbosReceipt};
 
 mod emulator;
 mod runtime_env;
@@ -93,7 +93,7 @@ pub fn run(
 ) -> Result<Vec<Value>, (ExecutionError, StackTrace)> {
     // We use PC 1 here because PC pushes an unwanted value--designed for a different entry ABI
     match machine.test_call(CodePt::new_internal(1), args, debug) {
-        Ok(_stack) => Ok(machine.runtime_env.get_all_logs()),
+        Ok(_stack) => Ok(machine.runtime_env.get_all_raw_logs()),
         Err(e) => Err((e, machine.get_stack_trace())),
     }
 }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -22,7 +22,9 @@ use emulator::{ExecutionError, StackTrace};
 use std::{fs::File, io::Read, path::Path};
 
 pub use emulator::Machine;
-pub use runtime_env::{bytes_from_bytestack, bytestack_from_bytes, RuntimeEnvironment, ArbosReceipt};
+pub use runtime_env::{
+    bytes_from_bytestack, bytestack_from_bytes, ArbosReceipt, RuntimeEnvironment,
+};
 
 mod emulator;
 mod runtime_env;

--- a/src/run/runtime_env.rs
+++ b/src/run/runtime_env.rs
@@ -256,11 +256,15 @@ impl RuntimeEnvironment {
     }
 
     pub fn get_all_raw_logs(&self) -> Vec<Value> {
-       self.logs.clone()
+        self.logs.clone()
     }
 
     pub fn get_all_logs(&self) -> Vec<ArbosReceipt> {
-        self.logs.clone().into_iter().map(|log| ArbosReceipt::new(log)).collect()
+        self.logs
+            .clone()
+            .into_iter()
+            .map(|log| ArbosReceipt::new(log))
+            .collect()
     }
 
     pub fn push_send(&mut self, send_item: Value) {
@@ -276,6 +280,7 @@ impl RuntimeEnvironment {
 #[derive(Clone, Debug)]
 pub struct ArbosReceipt {
     request: Value,
+    request_id: Uint256,
     return_code: Uint256,
     return_data: Vec<u8>,
     evm_logs: Value,
@@ -289,11 +294,36 @@ impl ArbosReceipt {
             if let Value::Tuple(usage_info) = &tup[4] {
                 ArbosReceipt {
                     request: tup[0].clone(),
-                    return_code: if let Value::Int(ui) = &tup[1] { ui.clone() } else { panic!(); },
-                    return_data: if let Some(d) = bytes_from_bytestack(tup[2].clone()) { d } else { vec![] },
+                    request_id: if let Value::Tuple(subtup) = &tup[0] {
+                        if let Value::Int(ui) = &subtup[4] {
+                            ui.clone()
+                        } else {
+                            panic!()
+                        }
+                    } else {
+                        panic!();
+                    },
+                    return_code: if let Value::Int(ui) = &tup[1] {
+                        ui.clone()
+                    } else {
+                        panic!();
+                    },
+                    return_data: if let Some(d) = bytes_from_bytestack(tup[2].clone()) {
+                        d
+                    } else {
+                        vec![]
+                    },
                     evm_logs: tup[3].clone(),
-                    gas_used: if let Value::Int(ui) = &usage_info[0] { ui.clone() } else { Uint256::zero() },
-                    gas_price_wei: if let Value::Int(ui) = &usage_info[1] { ui.clone() } else { Uint256::zero() },
+                    gas_used: if let Value::Int(ui) = &usage_info[0] {
+                        ui.clone()
+                    } else {
+                        Uint256::zero()
+                    },
+                    gas_price_wei: if let Value::Int(ui) = &usage_info[1] {
+                        ui.clone()
+                    } else {
+                        Uint256::zero()
+                    },
                 }
             } else {
                 panic!("Arbog log gas usage field was not a Tuple");
@@ -305,6 +335,10 @@ impl ArbosReceipt {
 
     pub fn get_request(&self) -> Value {
         self.request.clone()
+    }
+
+    pub fn get_request_id(&self) -> Uint256 {
+        self.request_id.clone()
     }
 
     pub fn get_return_code(&self) -> Uint256 {

--- a/src/run/runtime_env.rs
+++ b/src/run/runtime_env.rs
@@ -286,17 +286,19 @@ pub struct ArbosReceipt {
     evm_logs: Value,
     gas_used: Uint256,
     gas_price_wei: Uint256,
-    gas_so_far: Uint256,       // gas used so far in L1 block, including this tx
-    index_in_block: Uint256,   // index of this tx in L1 block
-    logs_so_far: Uint256,      // EVM logs emitted so far in L1 block, NOT including this tx
+    gas_so_far: Uint256,     // gas used so far in L1 block, including this tx
+    index_in_block: Uint256, // index of this tx in L1 block
+    logs_so_far: Uint256,    // EVM logs emitted so far in L1 block, NOT including this tx
 }
 
 impl ArbosReceipt {
     pub fn new(arbos_log: Value) -> Self {
         if let Value::Tuple(tup) = arbos_log {
-            let (return_code, return_data, evm_logs) = ArbosReceipt::unpack_return_info(&tup[1]).unwrap();
+            let (return_code, return_data, evm_logs) =
+                ArbosReceipt::unpack_return_info(&tup[1]).unwrap();
             let (gas_used, gas_price_wei) = ArbosReceipt::unpack_gas_info(&tup[2]).unwrap();
-            let (gas_so_far, index_in_block, logs_so_far) = ArbosReceipt::unpack_cumulative_info(&tup[3]).unwrap();
+            let (gas_so_far, index_in_block, logs_so_far) =
+                ArbosReceipt::unpack_cumulative_info(&tup[3]).unwrap();
             ArbosReceipt {
                 request: tup[0].clone(),
                 request_id: if let Value::Tuple(subtup) = &tup[0] {
@@ -339,8 +341,16 @@ impl ArbosReceipt {
     fn unpack_gas_info(val: &Value) -> Option<(Uint256, Uint256)> {
         if let Value::Tuple(tup) = val {
             Some((
-                if let Value::Int(ui) = &tup[0] { ui.clone() } else { return None; },
-                if let Value::Int(ui) = &tup[1] { ui.clone() } else { return None; },
+                if let Value::Int(ui) = &tup[0] {
+                    ui.clone()
+                } else {
+                    return None;
+                },
+                if let Value::Int(ui) = &tup[1] {
+                    ui.clone()
+                } else {
+                    return None;
+                },
             ))
         } else {
             None
@@ -350,9 +360,21 @@ impl ArbosReceipt {
     fn unpack_cumulative_info(val: &Value) -> Option<(Uint256, Uint256, Uint256)> {
         if let Value::Tuple(tup) = val {
             Some((
-                if let Value::Int(ui) = &tup[0] { ui.clone() } else { return None; },
-                if let Value::Int(ui) = &tup[1] { ui.clone() } else { return None; },
-                if let Value::Int(ui) = &tup[2] { ui.clone() } else { return None; },
+                if let Value::Int(ui) = &tup[0] {
+                    ui.clone()
+                } else {
+                    return None;
+                },
+                if let Value::Int(ui) = &tup[1] {
+                    ui.clone()
+                } else {
+                    return None;
+                },
+                if let Value::Int(ui) = &tup[2] {
+                    ui.clone()
+                } else {
+                    return None;
+                },
             ))
         } else {
             None

--- a/src/run/runtime_env.rs
+++ b/src/run/runtime_env.rs
@@ -291,45 +291,49 @@ pub struct ArbosReceipt {
 impl ArbosReceipt {
     pub fn new(arbos_log: Value) -> Self {
         if let Value::Tuple(tup) = arbos_log {
-            if let Value::Tuple(usage_info) = &tup[4] {
-                ArbosReceipt {
-                    request: tup[0].clone(),
-                    request_id: if let Value::Tuple(subtup) = &tup[0] {
-                        if let Value::Int(ui) = &subtup[4] {
+            if let Value::Tuple(return_info) = &tup[1] {
+                if let Value::Tuple(usage_info) = &tup[2] {
+                    ArbosReceipt {
+                        request: tup[0].clone(),
+                        request_id: if let Value::Tuple(subtup) = &tup[0] {
+                            if let Value::Int(ui) = &subtup[4] {
+                                ui.clone()
+                            } else {
+                                panic!()
+                            }
+                        } else {
+                            panic!();
+                        },
+                        return_code: if let Value::Int(ui) = &return_info[0] {
                             ui.clone()
                         } else {
-                            panic!()
-                        }
-                    } else {
-                        panic!();
-                    },
-                    return_code: if let Value::Int(ui) = &tup[1] {
-                        ui.clone()
-                    } else {
-                        panic!();
-                    },
-                    return_data: if let Some(d) = bytes_from_bytestack(tup[2].clone()) {
-                        d
-                    } else {
-                        vec![]
-                    },
-                    evm_logs: tup[3].clone(),
-                    gas_used: if let Value::Int(ui) = &usage_info[0] {
-                        ui.clone()
-                    } else {
-                        Uint256::zero()
-                    },
-                    gas_price_wei: if let Value::Int(ui) = &usage_info[1] {
-                        ui.clone()
-                    } else {
-                        Uint256::zero()
-                    },
+                            panic!();
+                        },
+                        return_data: if let Some(d) = bytes_from_bytestack(return_info[1].clone()) {
+                            d
+                        } else {
+                            vec![]
+                        },
+                        evm_logs: return_info[2].clone(),
+                        gas_used: if let Value::Int(ui) = &usage_info[0] {
+                            ui.clone()
+                        } else {
+                            Uint256::zero()
+                        },
+                        gas_price_wei: if let Value::Int(ui) = &usage_info[1] {
+                            ui.clone()
+                        } else {
+                            Uint256::zero()
+                        },
+                    }
+                } else {
+                    panic!("ArbOS log gas usage field was not a Tuple");
                 }
             } else {
-                panic!("Arbog log gas usage field was not a Tuple");
+                panic!("ArbOS return info field was not a Tuple");
             }
         } else {
-            panic!("Arbos log item was not a Tuple");
+            panic!("ArbOS log item was not a Tuple");
         }
     }
 


### PR DESCRIPTION
Add support for the new tx receipt (== AVM log item) format, which restructures the receipt data structure and adds information on: total gas used in L1 block including this tx; index of this tx in L1 block; number of EVM logs so far in this L1 block excluding this tx.

Also refactor the receipt handling code in ArbOS, and in the Rust test harnesses.

Fixes #148 