### PR TITLE
Fix AVM byte instruction in Rust emulator

### DIFF
--- a/builtin/globaltest.mini
+++ b/builtin/globaltest.mini
@@ -82,6 +82,17 @@ impure func tests() -> uint {
         return 8;
     }
 
+    // regression tests for issue #156
+    if (asm(16, 31) uint { byte } != 16) {
+        return 9;
+    }
+    if (asm(16, 0) uint { byte } != 0) {
+        return 10;
+    }
+    if (asm(65534, 30) uint { byte } != 255) {
+        return 11;
+    }
+
     return struct9test();
 }
 

--- a/src/run/emulator.rs
+++ b/src/run/emulator.rs
@@ -1249,9 +1249,9 @@ impl Machine {
 						let r1 = self.stack.pop_uint(&self.state)?;
 						let r2 = self.stack.pop_uint(&self.state)?;
 						self.stack.push_uint(
-							if r1 < Uint256::from_usize(32) {
-								let shift_factor = Uint256::one().exp(&Uint256::from_usize(8*(31-r1.to_usize().unwrap())));
-								r2.div(&shift_factor).unwrap().bitwise_and(&Uint256::from_usize(255))
+							if r2 < Uint256::from_usize(32) {
+								let shift_factor = Uint256::from_u64(256).exp(&Uint256::from_usize(31-r2.to_usize().unwrap()));
+								r1.div(&shift_factor).unwrap().bitwise_and(&Uint256::from_usize(255))
 							} else {
 								Uint256::zero()
 							}


### PR DESCRIPTION
Correct implementation of `byte` instruction in the Rust emulator, and regression tests.

Fixes #156 