### PR TITLE
Add returndata to tx receipt when tx reverts

### DIFF
--- a/arb_os/evmCallStack.mini
+++ b/arb_os/evmCallStack.mini
@@ -584,7 +584,7 @@ public impure func evmCallStack_returnFromCall(
             emitLog(
                 globalCurrentEthMessage,
                 1,
-                None<ByteArray>,
+                Some(returnData),
                 None<EvmLogs>,
                 Some(gasUsage)
             );


### PR DESCRIPTION
Cause revert operations to report return data in their tx receipt when the operation reverts with data.