### PR TITLE
Trim reads past end of bytearray slice

### DIFF
--- a/stdlib/bytearray.mini
+++ b/stdlib/bytearray.mini
@@ -169,6 +169,10 @@ public func bytearray_get64(ba: ByteArray, offset: uint) -> uint {
     if (offset >= ba.size) {
         return 0;
     }
+    let bytesToTrim = 0;
+    if (offset+8 > ba.size) {
+        bytesToTrim = offset+8 - ba.size;
+    }
     // the access might extend beyond size, but access to the underlying array will be in-bounds
     // on the true side of the if, any overage is within an existing word of the underlying array
     // on the false side of the if, bytearray_get256 will avoid out-of-bounds accesses
@@ -176,10 +180,18 @@ public func bytearray_get64(ba: ByteArray, offset: uint) -> uint {
     let alignment = offset % 32;
     if (alignment <= 24) {
         let res = ba.contents[offset/32];
-        return (res / asm(2, 192-8*alignment) uint { exp }) & 0xffffffffffffffff;
+        let ret = (res / asm(2, 192-8*alignment) uint { exp }) & 0xffffffffffffffff;
+        if (bytesToTrim > 0) {
+            ret = ret & ~((asm(256, bytesToTrim) uint { exp }) - 1);
+        }
+        return ret;
     } else {
         let res = bytearray_get256(ba, offset);
-        return res / 0x1000000000000000000000000000000000000000000000000;
+        let ret = res / 0x1000000000000000000000000000000000000000000000000;
+        if (bytesToTrim > 0) {
+            ret = ret & ~((asm(256, bytesToTrim) uint { exp }) - 1);
+        }
+        return ret;
     }
 }
 
@@ -211,6 +223,10 @@ public func bytearray_set64(ba: ByteArray, offset: uint, value: uint) -> ByteArr
 
 // bytearray_get256 reads a chunk of 32 bytes from a ByteArray
 public func bytearray_get256(ba: ByteArray, offset: uint) -> uint {
+    let bytesToTrim = 0;
+    if (offset+32 > ba.size) {
+        bytesToTrim = offset+32 - ba.size;
+    }
     offset = offset + ba.sliceOffset;
     let lowWordIndex = offset / 32;
     let alignment = offset % 32;
@@ -218,8 +234,12 @@ public func bytearray_get256(ba: ByteArray, offset: uint) -> uint {
         if (offset+32 > ba.arrayCapacityBytes) {
             // because arrayCapacityBytes is a multiple of 32 in this case, access is entirely beyond size
             return 0;
-        } 
-        return ba.contents[lowWordIndex];
+        }
+        let ret = ba.contents[lowWordIndex];
+        if (bytesToTrim > 0) {
+            ret = ret & ~((asm(256, bytesToTrim) uint { exp }) - 1);
+        }
+        return ret;
     } else {
         let lowWord = 0;  // word from lower-numbered array slot
         let hiWord = 0;   // word from higher-numbered array slot
@@ -242,7 +262,11 @@ public func bytearray_get256(ba: ByteArray, offset: uint) -> uint {
 
         let shiftFactor = asm(2, 8*alignment) uint { exp };
         let invShiftFactor = asm(2, 256-8*alignment) uint { exp };
-        return (hiWord/invShiftFactor) | (lowWord*shiftFactor);
+        let ret = (hiWord/invShiftFactor) | (lowWord*shiftFactor);
+        if (bytesToTrim > 0) {
+            ret = ret & ~((asm(256, bytesToTrim) uint { exp }) - 1);
+        }
+        return ret;
     }
 }
 

--- a/stdlib/bytearraytest.mini
+++ b/stdlib/bytearraytest.mini
@@ -27,6 +27,8 @@ import func bytearray_set64(ba: ByteArray, idx: uint, val: uint) -> ByteArray;
 import func bytearray_get256(ba: ByteArray, offset: uint) -> uint;
 import func bytearray_set256(ba: ByteArray, offset: uint, value: uint) -> ByteArray;
 import func bytearray_marshalFull(ba: ByteArray) -> MarshalledBytes;
+import func bytearray_extract(ba: ByteArray, offset: uint, nbytes: uint) -> ByteArray;
+import func bytearray_copy(from: ByteArray, fromOffset: uint, to: ByteArray, toOffset: uint, nbytes: uint) -> ByteArray;
 
 import func marshalledBytes_hash(mb: MarshalledBytes) -> bytes32;
 
@@ -150,6 +152,13 @@ func tests() -> uint {
             != marshalledBytes_hash(bytearray_marshalFull(bytearray_set256(bytearray_new(0), 0, 0x6203cb97ced4e35e64eeaddf64d03b68bcb81b5ee3cb0205f7edb755a8a4198)))
     ) {
         return 15;
+    }
+
+    let ba = setupFromUnmarshal();
+    let ba2 = bytearray_extract(ba, 0, 41);
+    let ba3 = bytearray_copy(ba, 0, bytearray_new(0), 0, 41);
+    if (bytearray_marshalFull(ba2) != bytearray_marshalFull(ba3)) {
+        return 16;
     }
 
 	return 0;


### PR DESCRIPTION
Reads that extend past the end of a bytearray are supposed to return zeroes for the bytes that extend past the end of the slice. When slices share an underlying array, we need to explicitly zero-fill these bytes, because we can no longer count on them being already zero.

This was causing marshaling of bytearrays to give wrong results sometimes.

Includes a regression test for this bug.