### PR TITLE
Faster bytearrays

### DIFF
--- a/builtin/kvs.mini
+++ b/builtin/kvs.mini
@@ -25,219 +25,220 @@
 // damage to the internals of a map, leading to erroneous results or even a panic.
 
 
-type TreeKvsTriple = struct {  // This struct stores one item in the KVS.
-    reducedKey: uint,   // hash of the item's key, divided by 8 for each level we descend in the tree
-    key: any,           // item's key
-    value: any          // item's value
+// This is an efficient implementation of a key-value store,
+//       with an implied "default value" of None<any> for uninitialized keys.
+//
+// It's built as an 8-ary trie, using hash(key) as the index for trie-ing.
+// Each "slot" in the trie is either:
+// *  0, which means an empty subtree
+// *  a 2-tuple (key, value), which means that pair is the only item in the subtree
+// *  an 8-tuple, with each entry referencing a subtree
+// To find a key's path down the tree, compute hash(key). Then the low-order 3 bits
+//     gives the branch to take at top-level, the next 3 bits give the branch to take at
+//     the second level, and so on.
+
+// There's a lot of unsafecast and assembly code in here, because of the decision to
+//     have multiple node types that can live in the same slots. This was done because
+//     it's more space-efficient than alternative approaches, which is important when the
+//     structure gets large.
+
+type Kvs = struct {
+    tree: KvsNode,
+    size: uint,
 }
 
-type TreeKvsCell = struct {   // The KVS is represented as a tree of these.
-    triple: option<TreeKvsTriple>,
-    children: [8]any,    // actually [8]TreeKvs but compiler doesn't support recursive types
-    size: uint
+type KvsNode = [8]any
+
+type KvsCell = struct {
+    key: any,
+    value: option<any>,
 }
 
-type TreeKvs = option<TreeKvsCell>   // will be None if tree is empty
 
-
-public func builtin_kvsNew() -> TreeKvs {
-    return None<TreeKvsCell>;
+public func builtin_kvsNew() -> Kvs {
+    return struct {
+        tree: unsafecast<KvsNode>(0),
+        size: 0,
+    };
 }
 
-public func builtin_kvsGet(kvs: TreeKvs, key: any) -> option<any> {
-    let reducedKey = uint(hash(key));
+public func builtin_kvsSize(kvs: Kvs) -> uint {
+    return kvs.size;
+}
+
+public func builtin_kvsGet(kvs: Kvs, key: any) -> option<any> {
+    let hashedKey = uint(hash(key));
+    let s = kvs.tree;
+    let reductionFactor = 1;
     loop {
-        let cell = kvs?;
-        if let Some(triple) = cell.triple {
-            if (reducedKey == triple.reducedKey) {
-                return Some(triple.value);
+        if (s == unsafecast<KvsNode>(0)) {
+            // empty subtree
+            return None;
+        } elseif (asm(s,) uint { length } == 2) {
+            // singleton item
+            if (key == unsafecast<KvsCell>(s).key) {
+                return unsafecast<KvsCell>(s).value;
+            } else {
+                return None;
             }
+        } else {
+            // still at an internal node of the tree; walk downward and try again
+            s = unsafecast<KvsNode>(s[(hashedKey/reductionFactor) & 0x7]);
+            reductionFactor = reductionFactor * 8;
         }
-        kvs = unsafecast<TreeKvs>(cell.children[reducedKey % 8]);
-        reducedKey = reducedKey / 8;
     }
 }
 
-public func builtin_kvsHasKey(kvs: TreeKvs, key: any) -> bool {
+public func builtin_kvsHasKey(kvs: Kvs, key: any) -> bool {
     return builtin_kvsGet(kvs, key) != None<any>;
 }
 
-public func builtin_kvsSet(kvs: TreeKvs, key: any, value: any) -> TreeKvs {
-    if let Some(res) = builtin_kvsSet2(
-        kvs,
-        uint(hash(key)),
-        key,
-        value
-    ) {
-        let (newKvs, _) = res;
-        return newKvs;
-    } else {
-        return kvs;
+// An Unwinder remembers how to reassemble the tree as we traverse back up it.
+// During a set operation, we walk down the tree to the leaf, building an Unwinder as we go.
+// Then we use the Unwinder to guide our traversal back up the tree and the remind us of the
+//      writes we need to do on that upward traversal.
+type Unwinder = struct {
+    kvs: [8]any,
+    index: uint,
+    next: option<any>,   // really option<Unwinder>, but compiler doesn't do recursive types
+}
+
+public func builtin_kvsSet(s: Kvs, key: any, value: any) -> Kvs {
+    let (utree, maybeUnwinder, delta) = kvs_set2(s.tree, key, Some(value));
+    loop {
+        if let Some(unwinder) = maybeUnwinder {
+            utree = unwinder.kvs with {
+                [unwinder.index] = utree
+            };
+            maybeUnwinder = unsafecast<option<Unwinder>>(unwinder.next);
+        } else {
+            if (delta != int(0)) {
+                s = s with { size: uint(int(s.size) + delta) };
+            }
+            return s with { tree: utree };
+        }
     }
 }
 
-func builtin_kvsSet2(
-    kvs: TreeKvs,
-    reducedKey: uint,
-    key: any,
-    value: any
-) -> option<(TreeKvs, int)> {
-    // Update a KVS by setting a key/value pair.
-    // This returns Some((updatedKvs, sizeDiff)) if the structure changed, None if it didn't.
-    if let Some(cell) = kvs {
-        if let Some(triple) = cell.triple {
-            if (triple.reducedKey == reducedKey) {
-                // Found a cell containing the same key. Update the value.
-                return Some((Some(
-                    cell with {
-                        triple: Some(triple with { value: value })
-                    }
-                ), 0s));
+func kvs_set2(s: KvsNode, key: any, value: option<any>) -> (KvsNode, option<Unwinder>, int) {
+    let hashedKey = uint(hash(key));
+    let reductionFactor = 1;
+    let unwinder = None<Unwinder>;
+    loop {
+        if (s == unsafecast<KvsNode>(0)) {
+            if (value == None<any>) {
+                // writing None to an empty slot; do nothing
+                return (s, unwinder, int(0));
             } else {
-                // Didn't find a match here, descend on level in the tree, recursively.
-                let slot = reducedKey % 8;
-                let oldKid = unsafecast<TreeKvs>(cell.children[slot]);
-                let (newKid, sizeDiff) = builtin_kvsSet2(
-                    oldKid,
-                    reducedKey / 8,
-                    key,
-                    value
-                )?;
-                return Some((Some(
-                    cell with {
-                        children: cell.children with {
-                            [slot] = newKid
+                // writing non-zero to empty slot; create a singleton item
+                return (
+                    unsafecast<KvsNode>(
+                        struct {
+                            key: key,
+                            value: value
                         }
-                    } with {
-                        size: uint(int(cell.size) + sizeDiff)
-                    }
-                ), sizeDiff));
+                    ),
+                    unwinder,
+                    int(1)
+                );
             }
-        } else {
-            // This cell doesn't have a triple, so insert our new item here.
-            // But there might already be an item with the same key lower in the tree,
-            //     so we have to make sure to delete that one first.
-
-            // If there is an item with the same key lower in the tree, delete it.
-            let slot = reducedKey % 8;
-            let sizeDiff = 1s;
-            if let Some(res) = builtin_kvsDelete2(
-                unsafecast<TreeKvs>(cell.children[slot]),
-                reducedKey / 8
-            ) {
-                let (newChild, subSizeDiff) = res;
-                sizeDiff = sizeDiff + subSizeDiff;
-                cell = cell with {
-                    children: cell.children with {
-                        [slot] = newChild
-                    }
+        } elseif (asm(s,) uint { length } == 2) {
+            let kid = unsafecast<KvsCell>(s);
+            if (kid.key == key) {
+                // overwriting an existing item with same key
+                if (value == None<any>) {
+                    // delete existing item
+                    return (
+                        unsafecast<KvsNode>(0),
+                        unwinder,
+                        -1s,
+                    );
+                } else {
+                    // update existing item with new value
+                    return (
+                        unsafecast<KvsNode>(kid with { value: value }),
+                        unwinder,
+                        int(0)
+                    );
+                }
+            } else {
+                // already found a singleton here
+                // create new internal node and push singleton into it
+                // then loop back and try again
+                s = unsafecast<KvsNode>(newfixedarray(8, 0)) with {
+                    [(uint(hash(kid.key))/reductionFactor) & 0x7] = kid
                 };
             }
-
-            // Now add the new item
-            return Some((Some(
-                cell with {
-                    triple: Some(struct {
-                        reducedKey: reducedKey,
-                        key: key,
-                        value: value
-                    })
-                } with {
-                    size: uint(int(cell.size) + sizeDiff)
-                }
-            ), sizeDiff));
+        } else {
+            // traversing an internal node
+            // update the unwinder so we know what to do on the way back up
+            // then move one level down the tree
+            let slot = (hashedKey / reductionFactor) & 0x7;
+            unwinder = Some(struct {
+                kvs: s,
+                index: slot,
+                next: unwinder,
+            });
+            s = unsafecast<KvsNode>(s[slot]);
+            reductionFactor = reductionFactor * 8;
         }
-    } else {
-        // There was nothing here, so allocate an empty cell and add this item to it.
-        return Some((Some(
-            struct {
-                triple: Some(struct {
-                    reducedKey: reducedKey,
-                    key: key,
-                    value: value
-                }),
-                children: newfixedarray(8, None<TreeKvsCell>),
-                size: 1
+    }
+}
+
+public func builtin_kvsDelete(s: Kvs, key: uint) -> Kvs {
+    let (utree, maybeUnwinder, delta) = kvs_set2(s.tree, key, None<any>);
+    loop {
+        if let Some(unwinder) = maybeUnwinder {
+            utree = unwinder.kvs with {
+                [unwinder.index] = utree
+            };
+            maybeUnwinder = unsafecast<option<Unwinder>>(unwinder.next);
+        } else {
+            if (delta != int(0)) {
+                s = s with { size: uint(int(s.size) + delta) };
             }
-        ), 1s));
-    }
-}
-
-public func builtin_kvsDelete(kvs: TreeKvs, key: any) -> TreeKvs {
-    if let Some(res) = builtin_kvsDelete2(kvs, uint(hash(key))) {
-        let (newKvs, _) = res;
-        return newKvs;
-    } else {
-        return kvs;
-    }
-}
-
-func builtin_kvsDelete2(kvs: TreeKvs, reducedKey: uint) -> option<(TreeKvs, int)> {
-    // Delete a key.
-    // Returns Some((updatedKvs, sizeDiff)) is anything changed, None otherwise.
-    let cell = kvs?;
-    if let Some(triple) = cell.triple {
-        if (triple.reducedKey == reducedKey) {
-            // Found a matching item. Delete it and return.
-            return Some(
-                (
-                    Some(
-                        cell with { triple: None<TreeKvsTriple> }
-                             with { size: uint(int(cell.size) - 1s) }
-                    ),
-                    -1s
-                )
-            );
+            return s with { tree: utree };
         }
     }
-
-    // Didn't find a match here, descend the tree recursively.
-    let slot = reducedKey % 8;
-    let (newKid, sizeDiff) = builtin_kvsDelete2(
-        unsafecast<TreeKvs>(cell.children[slot]),
-        reducedKey / 8,
-    )?;
-    return Some((Some(
-        cell with {
-            children: cell.children with {
-                [slot] = newKid
-            }
-        } with {
-            size: uint(int(cell.size) + sizeDiff)
-        }
-    ), sizeDiff));
 }
 
+// apply a closure to all items in the storageMap, in sequence
+// for each item (k,v) we'll do:  state <- closure(k, v, state)
+// this will return the state at the end
+// order of traversal is deterministic but weird and subject to change,
+//       so callers are advised not to rely on the ordering
 public func builtin_kvsForall(
-    kvs: TreeKvs,
-    callback: func(any, any, any) -> any,
-    state: any  // initial value for state
+    s: Kvs,
+    closure: func(any, any, any) -> any,
+    state: any
 ) -> any {
-    // Visit every item in the KVS, calling callback on each one.
-    // newState = callback(thisItem.key, thisItem.value, oldState)
-    // Return the final state after visiting all items.
-    if let Some(cell) = kvs {
-        if let Some(triple) = cell.triple {
-            state = callback(triple.key, triple.value, state);
-        }
-        let i = 0;
-        while (i < 8) {
-            state = builtin_kvsForall(
-                unsafecast<TreeKvs>(cell.children[i]),
-                callback,
+    return kvs_forall_tree(s.tree, closure, state);
+}
+
+func kvs_forall_tree(
+    t: KvsNode,
+    closure: func(any, any, any) -> any,
+    state: any
+) -> any {
+    if (t == unsafecast<KvsNode>(0)) {
+        return state;
+    } elseif (asm(t,) uint { length } == 2) {
+        if let Some(val) = unsafecast<KvsCell>(t).value {
+            return closure(
+                unsafecast<KvsCell>(t).key,
+                val,
                 state
             );
+        } else {
+            // structure was corrupted, best to just ignore this cell
+            return state;
+        }
+   } else {
+        let i = 0;
+        while (i < 8) {
+            state = kvs_forall_tree(unsafecast<KvsNode>(t[i]), closure, state);
             i = i+1;
         }
-    }
-
-    return state;
-}
-
-public func builtin_kvsSize(kvs: TreeKvs) -> uint {
-    if let Some(cell) = kvs {
-        return cell.size;
-    } else {
-        return 0;
-    }
+        return state;
+   }
 }

--- a/oot
+++ b/oot
@@ -1,0 +1,6239 @@
+exported: [ExportedFuncPoint { name: "bytearray_new", codept: Internal(442), tipe: Func(false, [Uint], Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }])) }, ExportedFuncPoint { name: "marshalledBytes_firstByte", codept: Internal(486), tipe: Func(false, [Struct([StructField { name: 9, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Any }]) }])], Uint) }, ExportedFuncPoint { name: "marshalledBytes_hash", codept: Internal(526), tipe: Func(false, [Struct([StructField { name: 9, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Any }]) }])], Bytes32) }, ExportedFuncPoint { name: "bytearray_unmarshalBytes", codept: Internal(559), tipe: Func(false, [Struct([StructField { name: 9, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Any }]) }])], Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }])) }, ExportedFuncPoint { name: "bytearray_marshalFull", codept: Internal(692), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }])], Struct([StructField { name: 9, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Any }]) }])) }, ExportedFuncPoint { name: "bytearray_size", codept: Internal(783), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }])], Uint) }, ExportedFuncPoint { name: "bytearray_getByte", codept: Internal(792), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }]), Uint], Uint) }, ExportedFuncPoint { name: "bytearray_get64", codept: Internal(830), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }]), Uint], Uint) }, ExportedFuncPoint { name: "bytearray_get256", codept: Internal(932), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }]), Uint], Uint) }, ExportedFuncPoint { name: "bytearray_setByte", codept: Internal(1071), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }]), Uint, Uint], Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }])) }, ExportedFuncPoint { name: "bytearray_set64", codept: Internal(1201), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }]), Uint, Uint], Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }])) }, ExportedFuncPoint { name: "bytearray_set256", codept: Internal(607), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }]), Uint, Uint], Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }])) }, ExportedFuncPoint { name: "bytearray_copy", codept: Internal(1544), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }]), Uint, Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }]), Uint, Uint], Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }])) }, ExportedFuncPoint { name: "bytearray_extract", codept: Internal(1627), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }]), Uint, Uint], Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Struct([StructField { name: 1, tipe: Uint }, StructField { name: 78, tipe: Uint }, StructField { name: 3, tipe: FixedArray(Any, 8) }]) }])) }, ExportedFuncPoint { name: "priorityq_new", codept: Internal(1826), tipe: Func(false, [], Struct([StructField { name: 8, tipe: Uint }, StructField { name: 9, tipe: Uint }, StructField { name: 10, tipe: Array(Struct([StructField { name: 5, tipe: Uint }, StructField { name: 6, tipe: Any }])) }])) }, ExportedFuncPoint { name: "priorityq_isEmpty", codept: Internal(1842), tipe: Func(false, [Struct([StructField { name: 8, tipe: Uint }, StructField { name: 9, tipe: Uint }, StructField { name: 10, tipe: Array(Struct([StructField { name: 5, tipe: Uint }, StructField { name: 6, tipe: Any }])) }])], Bool) }, ExportedFuncPoint { name: "priorityq_size", codept: Internal(1852), tipe: Func(false, [Struct([StructField { name: 8, tipe: Uint }, StructField { name: 9, tipe: Uint }, StructField { name: 10, tipe: Array(Struct([StructField { name: 5, tipe: Uint }, StructField { name: 6, tipe: Any }])) }])], Uint) }, ExportedFuncPoint { name: "priorityq_get", codept: Internal(1861), tipe: Func(false, [Struct([StructField { name: 8, tipe: Uint }, StructField { name: 9, tipe: Uint }, StructField { name: 10, tipe: Array(Struct([StructField { name: 5, tipe: Uint }, StructField { name: 6, tipe: Any }])) }])], Option(Tuple([Any, Struct([StructField { name: 8, tipe: Uint }, StructField { name: 9, tipe: Uint }, StructField { name: 10, tipe: Array(Struct([StructField { name: 5, tipe: Uint }, StructField { name: 6, tipe: Any }])) }])]))) }, ExportedFuncPoint { name: "priorityq_insert", codept: Internal(2132), tipe: Func(false, [Struct([StructField { name: 8, tipe: Uint }, StructField { name: 9, tipe: Uint }, StructField { name: 10, tipe: Array(Struct([StructField { name: 5, tipe: Uint }, StructField { name: 6, tipe: Any }])) }]), Any, Uint], Struct([StructField { name: 8, tipe: Uint }, StructField { name: 9, tipe: Uint }, StructField { name: 10, tipe: Array(Struct([StructField { name: 5, tipe: Uint }, StructField { name: 6, tipe: Any }])) }])) }, ExportedFuncPoint { name: "priorityq_printAsArray", codept: Internal(2189), tipe: Func(false, [Struct([StructField { name: 8, tipe: Uint }, StructField { name: 9, tipe: Uint }, StructField { name: 10, tipe: Array(Struct([StructField { name: 5, tipe: Uint }, StructField { name: 6, tipe: Any }])) }])], Uint) }, ExportedFuncPoint { name: "random_new", codept: Internal(2221), tipe: Func(false, [Bytes32], Bytes32) }, ExportedFuncPoint { name: "random_refresh_seed", codept: Internal(2229), tipe: Func(false, [Bytes32, Bytes32], Bytes32) }, ExportedFuncPoint { name: "random_next", codept: Internal(2240), tipe: Func(false, [Bytes32], Tuple([Bytes32, Bytes32])) }, ExportedFuncPoint { name: "randomly_permute_array", codept: Internal(2254), tipe: Func(false, [Bytes32, Array(Any), Uint, Uint], Tuple([Array(Any), Bytes32])) }, ExportedFuncPoint { name: "boundedQueue_new", codept: Internal(2324), tipe: Func(false, [Uint], Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }])) }, ExportedFuncPoint { name: "boundedQueue_isEmpty", codept: Internal(2343), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }])], Bool) }, ExportedFuncPoint { name: "boundedQueue_isFull", codept: Internal(2355), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }])], Bool) }, ExportedFuncPoint { name: "boundedQueue_size", codept: Internal(2371), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }])], Uint) }, ExportedFuncPoint { name: "boundedQueue_put", codept: Internal(2389), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }]), Any], Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }])) }, ExportedFuncPoint { name: "boundedQueue_get", codept: Internal(2426), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }])], Option(Tuple([Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }]), Any]))) }, ExportedFuncPoint { name: "boundedQueue_expand", codept: Internal(2463), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }]), Uint], Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }])) }, ExportedFuncPoint { name: "queue_new", codept: Internal(2520), tipe: Func(false, [], Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }])) }, ExportedFuncPoint { name: "queue_isEmpty", codept: Internal(2531), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }])], Bool) }, ExportedFuncPoint { name: "queue_size", codept: Internal(2543), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }])], Uint) }, ExportedFuncPoint { name: "queue_put", codept: Internal(2555), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }]), Any], Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }])) }, ExportedFuncPoint { name: "queue_get", codept: Internal(2586), tipe: Func(false, [Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }])], Option(Tuple([Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: Array(Any) }]), Any]))) }, ExportedFuncPoint { name: "keccak256", codept: Internal(2598), tipe: Func(false, [Imported(0), Uint, Uint], Bytes32) }, ExportedFuncPoint { name: "keccak_permutation", codept: Internal(2922), tipe: Func(false, [FixedArray(Uint, 7)], FixedArray(Uint, 7)) }, ExportedFuncPoint { name: "bytestream_new", codept: Internal(2931), tipe: Func(false, [Imported(0)], Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }])) }, ExportedFuncPoint { name: "bytestream_atEof", codept: Internal(2951), tipe: Func(false, [Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }])], Bool) }, ExportedFuncPoint { name: "bytestream_bytesReadSoFar", codept: Internal(2964), tipe: Func(false, [Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }])], Uint) }, ExportedFuncPoint { name: "bytestream_bytesRemaining", codept: Internal(2973), tipe: Func(false, [Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }])], Uint) }, ExportedFuncPoint { name: "bytestream_skipBytes", codept: Internal(2985), tipe: Func(false, [Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }]), Uint], Option(Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }]))) }, ExportedFuncPoint { name: "bytestream_truncate", codept: Internal(3014), tipe: Func(false, [Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }]), Uint], Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }])) }, ExportedFuncPoint { name: "bytestream_getByte", codept: Internal(3050), tipe: Func(false, [Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }])], Option(Tuple([Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }]), Uint]))) }, ExportedFuncPoint { name: "bytestream_get64", codept: Internal(3139), tipe: Func(false, [Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }])], Option(Tuple([Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }]), Uint]))) }, ExportedFuncPoint { name: "bytestream_get256", codept: Internal(3178), tipe: Func(false, [Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }])], Option(Tuple([Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }]), Uint]))) }, ExportedFuncPoint { name: "bytestream_getN", codept: Internal(3217), tipe: Func(false, [Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }]), Uint], Option(Tuple([Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }]), Imported(0)]))) }, ExportedFuncPoint { name: "bytestream_getRemainingBytes", codept: Internal(3258), tipe: Func(false, [Struct([StructField { name: 10, tipe: Imported(0) }, StructField { name: 11, tipe: Uint }, StructField { name: 12, tipe: Uint }, StructField { name: 13, tipe: Option(Uint) }])], Imported(0)) }, ExportedFuncPoint { name: "stack_new", codept: Internal(3278), tipe: Func(false, [], Option(Struct([StructField { name: 2, tipe: Any }, StructField { name: 3, tipe: Option(Any) }]))) }, ExportedFuncPoint { name: "stack_push", codept: Internal(3284), tipe: Func(false, [Option(Struct([StructField { name: 2, tipe: Any }, StructField { name: 3, tipe: Option(Any) }])), Any], Option(Struct([StructField { name: 2, tipe: Any }, StructField { name: 3, tipe: Option(Any) }]))) }, ExportedFuncPoint { name: "stack_isEmpty", codept: Internal(3299), tipe: Func(false, [Option(Struct([StructField { name: 2, tipe: Any }, StructField { name: 3, tipe: Option(Any) }]))], Bool) }, ExportedFuncPoint { name: "stack_pop", codept: Internal(3309), tipe: Func(false, [Option(Struct([StructField { name: 2, tipe: Any }, StructField { name: 3, tipe: Option(Any) }]))], Option(Tuple([Option(Struct([StructField { name: 2, tipe: Any }, StructField { name: 3, tipe: Option(Any) }])), Any]))) }, ExportedFuncPoint { name: "rlp_encodeUint", codept: Internal(3335), tipe: Func(false, [Uint, Imported(0), Uint], Tuple([Imported(0), Uint])) }, ExportedFuncPoint { name: "rlp_encodeAddress", codept: Internal(3480), tipe: Func(false, [EthAddress, Imported(0), Uint], Tuple([Imported(0), Uint])) }, ExportedFuncPoint { name: "rlp_encodeBytes", codept: Internal(3496), tipe: Func(false, [Imported(0), Uint, Uint, Imported(0), Uint], Tuple([Imported(0), Uint])) }, ExportedFuncPoint { name: "rlp_decodeBytes", codept: Internal(3664), tipe: Func(false, [Imported(1)], Option(Tuple([Imported(1), Imported(0)]))) }, ExportedFuncPoint { name: "rlp_encodeList", codept: Internal(3906), tipe: Func(false, [Array(Imported(0)), Uint, Uint, Imported(0), Uint], Option(Tuple([Imported(0), Uint]))) }, ExportedFuncPoint { name: "rlp_encodeMessageInfo", codept: Internal(4132), tipe: Func(false, [Uint, Uint, Uint, EthAddress, Uint, Imported(0), Uint, Uint, Uint], Imported(0)) }, ExportedFuncPoint { name: "rlp_encodeAddrUintPair", codept: Internal(4324), tipe: Func(false, [EthAddress, Uint, Imported(0), Uint], Tuple([Imported(0), Uint])) }, ExportedFuncPoint { name: "keccakOfRlpEncodedAddrUintPair", codept: Internal(4385), tipe: Func(true, [EthAddress, Uint], Bytes32) }, ExportedFuncPoint { name: "rlp_decodeUint", codept: Internal(4418), tipe: Func(false, [Imported(1)], Option(Tuple([Imported(1), Uint]))) }, ExportedFuncPoint { name: "rlp_decodeAddress", codept: Internal(4516), tipe: Func(false, [Imported(1)], Option(Tuple([Imported(1), EthAddress]))) }, ExportedFuncPoint { name: "bytesNeededToRepresentUint", codept: Internal(3431), tipe: Func(false, [Uint], Uint) }, ExportedFuncPoint { name: "storageMap_new", codept: Internal(4560), tipe: Func(false, [], Struct([StructField { name: 1, tipe: FixedArray(Any, 8) }, StructField { name: 3, tipe: Uint }])) }, ExportedFuncPoint { name: "storageMap_size", codept: Internal(4571), tipe: Func(false, [Struct([StructField { name: 1, tipe: FixedArray(Any, 8) }, StructField { name: 3, tipe: Uint }])], Uint) }, ExportedFuncPoint { name: "storageMap_get", codept: Internal(4580), tipe: Func(false, [Struct([StructField { name: 1, tipe: FixedArray(Any, 8) }, StructField { name: 3, tipe: Uint }]), Uint], Uint) }, ExportedFuncPoint { name: "storageMap_set", codept: Internal(4633), tipe: Func(false, [Struct([StructField { name: 1, tipe: FixedArray(Any, 8) }, StructField { name: 3, tipe: Uint }]), Uint, Uint], Struct([StructField { name: 1, tipe: FixedArray(Any, 8) }, StructField { name: 3, tipe: Uint }])) }, ExportedFuncPoint { name: "storageMap_set2", codept: Internal(4693), tipe: Func(false, [FixedArray(Any, 8), Uint, Uint], Tuple([FixedArray(Any, 8), Option(Struct([StructField { name: 9, tipe: FixedArray(Any, 8) }, StructField { name: 14, tipe: Uint }, StructField { name: 15, tipe: Option(Any) }])), Int])) }, ExportedFuncPoint { name: "storageMap_delete", codept: Internal(4829), tipe: Func(false, [Struct([StructField { name: 1, tipe: FixedArray(Any, 8) }, StructField { name: 3, tipe: Uint }]), Uint], Struct([StructField { name: 1, tipe: FixedArray(Any, 8) }, StructField { name: 3, tipe: Uint }])) }, ExportedFuncPoint { name: "storageMap_forall", codept: Internal(4844), tipe: Func(false, [Struct([StructField { name: 1, tipe: FixedArray(Any, 8) }, StructField { name: 3, tipe: Uint }]), Func(false, [Uint, Uint, Any], Any), Any], Any) }, ExportedFuncPoint { name: "storageMap_forall_tree", codept: Internal(4859), tipe: Func(false, [FixedArray(Any, 8), Func(false, [Uint, Uint, Any], Any), Any], Any) }, ExportedFuncPoint { name: "builtin_arrayNew", codept: Internal(4918), tipe: Func(false, [Uint, Any], Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }])) }, ExportedFuncPoint { name: "builtin_arrayGet", codept: Internal(4981), tipe: Func(false, [Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Uint], Any) }, ExportedFuncPoint { name: "builtin_arrayGetSafe", codept: Internal(5024), tipe: Func(false, [Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Uint], Option(Any)) }, ExportedFuncPoint { name: "builtin_arrayGetConsecutive", codept: Internal(5049), tipe: Func(false, [Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Uint], Tuple([Any, Any])) }, ExportedFuncPoint { name: "builtin_arrayGetConsecutiveSafe", codept: Internal(5128), tipe: Func(false, [Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Uint], Option(Tuple([Any, Any]))) }, ExportedFuncPoint { name: "builtin_arraySet", codept: Internal(5154), tipe: Func(false, [Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Uint, Any], Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }])) }, ExportedFuncPoint { name: "builtin_arraySetSafe", codept: Internal(5222), tipe: Func(false, [Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Uint, Any], Option(Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]))) }, ExportedFuncPoint { name: "builtin_arraySwap", codept: Internal(5249), tipe: Func(false, [Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Uint, Any], Tuple([Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Any])) }, ExportedFuncPoint { name: "builtin_arraySwapSafe", codept: Internal(5336), tipe: Func(false, [Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Uint, Any], Option(Tuple([Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Any]))) }, ExportedFuncPoint { name: "builtin_arrayOp", codept: Internal(5373), tipe: Func(false, [Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Uint, Struct([StructField { name: 34, tipe: Func(false, [Any, Any], Tuple([Any, Any])) }, StructField { name: 27, tipe: Any }])], Tuple([Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Any])) }, ExportedFuncPoint { name: "builtin_arrayOpSafe", codept: Internal(5472), tipe: Func(false, [Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Uint, Struct([StructField { name: 34, tipe: Func(false, [Any, Any], Tuple([Any, Any])) }, StructField { name: 27, tipe: Any }])], Option(Tuple([Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Any]))) }, ExportedFuncPoint { name: "builtin_arrayOpConsecutive", codept: Internal(5509), tipe: Func(false, [Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Uint, Struct([StructField { name: 34, tipe: Func(false, [Any, Any], Tuple([Any, Any])) }, StructField { name: 27, tipe: Any }]), Struct([StructField { name: 34, tipe: Func(false, [Any, Any], Tuple([Any, Any])) }, StructField { name: 27, tipe: Any }])], Tuple([Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Any, Any])) }, ExportedFuncPoint { name: "builtin_arrayOpConsecutiveSafe", codept: Internal(5551), tipe: Func(false, [Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Uint, Struct([StructField { name: 34, tipe: Func(false, [Any, Any], Tuple([Any, Any])) }, StructField { name: 27, tipe: Any }]), Struct([StructField { name: 34, tipe: Func(false, [Any, Any], Tuple([Any, Any])) }, StructField { name: 27, tipe: Any }])], Option(Tuple([Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Any, Any]))) }, ExportedFuncPoint { name: "array_resize", codept: Internal(5611), tipe: Func(false, [Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }]), Uint, Any], Struct([StructField { name: 2, tipe: Uint }, StructField { name: 3, tipe: Uint }, StructField { name: 4, tipe: FixedArray(Any, 8) }])) }, ExportedFuncPoint { name: "builtin_kvsNew", codept: Internal(5665), tipe: Func(false, [], Option(Struct([StructField { name: 5, tipe: Option(Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Any }, StructField { name: 3, tipe: Any }])) }, StructField { name: 6, tipe: FixedArray(Any, 8) }, StructField { name: 7, tipe: Uint }]))) }, ExportedFuncPoint { name: "builtin_kvsGet", codept: Internal(5671), tipe: Func(false, [Option(Struct([StructField { name: 5, tipe: Option(Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Any }, StructField { name: 3, tipe: Any }])) }, StructField { name: 6, tipe: FixedArray(Any, 8) }, StructField { name: 7, tipe: Uint }])), Any], Option(Any)) }, ExportedFuncPoint { name: "builtin_kvsHasKey", codept: Internal(5727), tipe: Func(false, [Option(Struct([StructField { name: 5, tipe: Option(Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Any }, StructField { name: 3, tipe: Any }])) }, StructField { name: 6, tipe: FixedArray(Any, 8) }, StructField { name: 7, tipe: Uint }])), Any], Bool) }, ExportedFuncPoint { name: "builtin_kvsSet", codept: Internal(5744), tipe: Func(false, [Option(Struct([StructField { name: 5, tipe: Option(Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Any }, StructField { name: 3, tipe: Any }])) }, StructField { name: 6, tipe: FixedArray(Any, 8) }, StructField { name: 7, tipe: Uint }])), Any, Any], Option(Struct([StructField { name: 5, tipe: Option(Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Any }, StructField { name: 3, tipe: Any }])) }, StructField { name: 6, tipe: FixedArray(Any, 8) }, StructField { name: 7, tipe: Uint }]))) }, ExportedFuncPoint { name: "builtin_kvsDelete", codept: Internal(6118), tipe: Func(false, [Option(Struct([StructField { name: 5, tipe: Option(Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Any }, StructField { name: 3, tipe: Any }])) }, StructField { name: 6, tipe: FixedArray(Any, 8) }, StructField { name: 7, tipe: Uint }])), Any], Option(Struct([StructField { name: 5, tipe: Option(Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Any }, StructField { name: 3, tipe: Any }])) }, StructField { name: 6, tipe: FixedArray(Any, 8) }, StructField { name: 7, tipe: Uint }]))) }, ExportedFuncPoint { name: "builtin_kvsForall", codept: Internal(6153), tipe: Func(false, [Option(Struct([StructField { name: 5, tipe: Option(Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Any }, StructField { name: 3, tipe: Any }])) }, StructField { name: 6, tipe: FixedArray(Any, 8) }, StructField { name: 7, tipe: Uint }])), Func(false, [Any, Any, Any], Any), Any], Any) }, ExportedFuncPoint { name: "builtin_kvsSize", codept: Internal(6214), tipe: Func(false, [Option(Struct([StructField { name: 5, tipe: Option(Struct([StructField { name: 1, tipe: Uint }, StructField { name: 2, tipe: Any }, StructField { name: 3, tipe: Any }])) }, StructField { name: 6, tipe: FixedArray(Any, 8) }, StructField { name: 7, tipe: Uint }]))], Uint) }]
+imported: [ImportedFunc(0, builtin_arrayNew), ImportedFunc(1, builtin_arrayGet), ImportedFunc(2, builtin_arraySet), ImportedFunc(3, builtin_kvsNew), ImportedFunc(4, builtin_kvsHasKey), ImportedFunc(5, builtin_kvsGet), ImportedFunc(6, builtin_kvsSet), ImportedFunc(7, builtin_kvsDelete), ImportedFunc(8, bytearray_new), ImportedFunc(9, bytearray_unmarshalBytes), ImportedFunc(10, bytearray_size), ImportedFunc(11, bytearray_getByte), ImportedFunc(12, bytearray_setByte), ImportedFunc(13, bytearray_get64), ImportedFunc(14, bytearray_set64), ImportedFunc(15, bytearray_get256), ImportedFunc(16, bytearray_set256), ImportedFunc(17, bytearray_marshalFull), ImportedFunc(18, bytearray_extract), ImportedFunc(19, bytearray_copy), ImportedFunc(20, marshalledBytes_hash), ImportedFunc(21, builtin_arrayNew), ImportedFunc(22, builtin_arrayGet), ImportedFunc(23, builtin_arraySet), ImportedFunc(24, builtin_kvsNew), ImportedFunc(25, builtin_kvsHasKey), ImportedFunc(26, builtin_kvsGet), ImportedFunc(27, builtin_kvsSet), ImportedFunc(28, builtin_kvsDelete), ImportedFunc(29, builtin_arrayNew), ImportedFunc(30, builtin_arrayGet), ImportedFunc(31, builtin_arraySet), ImportedFunc(32, builtin_kvsNew), ImportedFunc(33, builtin_kvsHasKey), ImportedFunc(34, builtin_kvsGet), ImportedFunc(35, builtin_kvsSet), ImportedFunc(36, builtin_kvsDelete), ImportedFunc(37, array_resize), ImportedFunc(38, builtin_arrayNew), ImportedFunc(39, builtin_arrayGet), ImportedFunc(40, builtin_arraySet), ImportedFunc(41, builtin_kvsNew), ImportedFunc(42, builtin_kvsHasKey), ImportedFunc(43, builtin_kvsGet), ImportedFunc(44, builtin_kvsSet), ImportedFunc(45, builtin_kvsDelete), ImportedFunc(46, builtin_arrayNew), ImportedFunc(47, builtin_arrayGet), ImportedFunc(48, builtin_arraySet), ImportedFunc(49, builtin_kvsNew), ImportedFunc(50, builtin_kvsHasKey), ImportedFunc(51, builtin_kvsGet), ImportedFunc(52, builtin_kvsSet), ImportedFunc(53, builtin_kvsDelete), ImportedFunc(54, builtin_arrayNew), ImportedFunc(55, builtin_arrayGet), ImportedFunc(56, builtin_arraySet), ImportedFunc(57, builtin_kvsNew), ImportedFunc(58, builtin_kvsHasKey), ImportedFunc(59, builtin_kvsGet), ImportedFunc(60, builtin_kvsSet), ImportedFunc(61, builtin_kvsDelete), ImportedFunc(62, bytearray_new), ImportedFunc(63, bytearray_get256), ImportedFunc(64, bytearray_set256), ImportedFunc(65, bytearray_get64), ImportedFunc(66, bytearray_set64), ImportedFunc(67, bytearray_getByte), ImportedFunc(68, bytearray_setByte), ImportedFunc(69, bytearray_copy), ImportedFunc(70, builtin_arrayNew), ImportedFunc(71, builtin_arrayGet), ImportedFunc(72, builtin_arraySet), ImportedFunc(73, builtin_kvsNew), ImportedFunc(74, builtin_kvsHasKey), ImportedFunc(75, builtin_kvsGet), ImportedFunc(76, builtin_kvsSet), ImportedFunc(77, builtin_kvsDelete), ImportedFunc(78, bytearray_size), ImportedFunc(79, bytearray_getByte), ImportedFunc(80, bytearray_get64), ImportedFunc(81, bytearray_get256), ImportedFunc(82, bytearray_extract), ImportedFunc(83, builtin_arrayNew), ImportedFunc(84, builtin_arrayGet), ImportedFunc(85, builtin_arraySet), ImportedFunc(86, builtin_kvsNew), ImportedFunc(87, builtin_kvsHasKey), ImportedFunc(88, builtin_kvsGet), ImportedFunc(89, builtin_kvsSet), ImportedFunc(90, builtin_kvsDelete), ImportedFunc(91, builtin_arrayNew), ImportedFunc(92, builtin_arrayGet), ImportedFunc(93, builtin_arraySet), ImportedFunc(94, builtin_kvsNew), ImportedFunc(95, builtin_kvsHasKey), ImportedFunc(96, builtin_kvsGet), ImportedFunc(97, builtin_kvsSet), ImportedFunc(98, builtin_kvsDelete), ImportedFunc(99, builtin_arrayGetSafe), ImportedFunc(100, bytearray_new), ImportedFunc(101, bytearray_size), ImportedFunc(102, bytearray_getByte), ImportedFunc(103, bytearray_get256), ImportedFunc(104, bytearray_setByte), ImportedFunc(105, bytearray_set256), ImportedFunc(106, bytearray_copy), ImportedFunc(107, bytestream_getByte), ImportedFunc(108, bytestream_get256), ImportedFunc(109, keccak256), ImportedFunc(110, builtin_arrayNew), ImportedFunc(111, builtin_arrayGet), ImportedFunc(112, builtin_arraySet), ImportedFunc(113, builtin_kvsNew), ImportedFunc(114, builtin_kvsHasKey), ImportedFunc(115, builtin_kvsGet), ImportedFunc(116, builtin_kvsSet), ImportedFunc(117, builtin_kvsDelete), ImportedFunc(118, builtin_arrayNew), ImportedFunc(119, builtin_arrayGet), ImportedFunc(120, builtin_arraySet), ImportedFunc(121, builtin_kvsNew), ImportedFunc(122, builtin_kvsHasKey), ImportedFunc(123, builtin_kvsGet), ImportedFunc(124, builtin_kvsSet), ImportedFunc(125, builtin_kvsDelete), ImportedFunc(126, builtin_arrayNew), ImportedFunc(127, builtin_arrayGet), ImportedFunc(128, builtin_arraySet), ImportedFunc(129, builtin_kvsNew), ImportedFunc(130, builtin_kvsHasKey), ImportedFunc(131, builtin_kvsGet), ImportedFunc(132, builtin_kvsSet), ImportedFunc(133, builtin_kvsDelete)]
+static: Tuple(CodePoint(Internal(442)), CodePoint(Internal(737)), Tuple(CodePoint(Internal(1123)), CodePoint(Internal(932)), CodePoint(Internal(607)), CodePoint(Internal(792)), CodePoint(Internal(1071)), CodePoint(Internal(1712)), CodePoint(Internal(1755)), CodePoint(Internal(1842))), Tuple(CodePoint(Internal(2071)), CodePoint(Internal(2240)), CodePoint(Internal(2355)), CodePoint(Internal(2343)), CodePoint(Internal(2324)), CodePoint(Internal(2426)), CodePoint(Internal(2389)), CodePoint(Internal(2371))), Tuple(CodePoint(Internal(2463)), CodePoint(Internal(1544)), CodePoint(Internal(830)), CodePoint(Internal(783)), CodePoint(Internal(1627)), CodePoint(Internal(3335)), CodePoint(Internal(3431)), CodePoint(Internal(3050))), Tuple(CodePoint(Internal(3178)), CodePoint(Internal(3496)), CodePoint(Internal(3480)), CodePoint(Internal(3906)), CodePoint(Internal(4324)), CodePoint(Internal(2598)), CodePoint(Internal(4418)), CodePoint(Internal(4633))), Tuple(CodePoint(Internal(4859)), CodePoint(Internal(4981)), CodePoint(Internal(5049)), CodePoint(Internal(5179)), CodePoint(Internal(5154)), CodePoint(Internal(5282)), CodePoint(Internal(5249)), CodePoint(Internal(5406))), Tuple(CodePoint(Internal(5373)), CodePoint(Internal(5472)), CodePoint(Internal(4918)), CodePoint(Internal(5671)), CodePoint(Internal(5780)), CodePoint(Internal(6016)), CodePoint(Internal(6153))))
+0000:  [_] AVMOpcode(Noop)		[no location]
+0001:  [_] AVMOpcode(Rset)		[no location]
+0002:  AVMOpcode(AuxPush)		Line: 36, Column: 1
+0003:  [_] AVMOpcode(AuxPush)		Line: 36, Column: 1
+0004:  [CodePoint(Internal(6))] AVMOpcode(Noop)		Line: 37, Column: 6
+0005:  [CodePoint(Internal(11))] AVMOpcode(Jump)		Line: 37, Column: 6
+0006:  AVMOpcode(Log)		Line: 37, Column: 18
+0007:  AVMOpcode(AuxPop)		Line: 36, Column: 1
+0008:  AVMOpcode(Pop)		Line: 36, Column: 1
+0009:  AVMOpcode(AuxPop)		Line: 36, Column: 1
+0010:  AVMOpcode(Jump)		Line: 36, Column: 1
+0011:  AVMOpcode(AuxPush)		Line: 40, Column: 1
+0012:  [Tuple(_, _, _, _, _, _, _, Tuple(_, _, _, _, _))] AVMOpcode(AuxPush)		Line: 40, Column: 1
+0013:  [33] AVMOpcode(Noop)		Line: 41, Column: 25
+0014:  [CodePoint(Internal(16))] AVMOpcode(Noop)		Line: 41, Column: 11
+0015:  [CodePoint(Internal(442))] AVMOpcode(Jump)		Line: 41, Column: 11
+0016:  [0] AVMOpcode(Xset)		Line: 41, Column: 2
+0017:  [0] AVMOpcode(Xget)		Line: 42, Column: 21
+0018:  [CodePoint(Internal(20))] AVMOpcode(Noop)		Line: 42, Column: 6
+0019:  [CodePoint(Internal(783))] AVMOpcode(Jump)		Line: 42, Column: 6
+0020:  [0] AVMOpcode(Equal)		Line: 42, Column: 6
+0021:  [CodePoint(Internal(26))] AVMOpcode(Cjump)		Line: 42, Column: 2
+0022:  [1] AVMOpcode(AuxPop)		Line: 43, Column: 3
+0023:  AVMOpcode(Pop)		Line: 43, Column: 3
+0024:  AVMOpcode(AuxPop)		Line: 43, Column: 3
+0025:  AVMOpcode(Jump)		Line: 43, Column: 3
+0026:  [117] AVMOpcode(Noop)		Line: 46, Column: 21
+0027:  [CodePoint(Internal(29))] AVMOpcode(Noop)		Line: 46, Column: 7
+0028:  [CodePoint(Internal(442))] AVMOpcode(Jump)		Line: 46, Column: 7
+0029:  [0] AVMOpcode(Xset)		Line: 46, Column: 2
+0030:  [42] AVMOpcode(Noop)		Line: 47, Column: 33
+0031:  [33] AVMOpcode(Noop)		Line: 47, Column: 29
+0032:  [0] AVMOpcode(Xget)		Line: 47, Column: 25
+0033:  [CodePoint(Internal(35))] AVMOpcode(Noop)		Line: 47, Column: 7
+0034:  [CodePoint(Internal(1071))] AVMOpcode(Jump)		Line: 47, Column: 7
+0035:  [0] AVMOpcode(Xset)		Line: 47, Column: 2
+0036:  [33] AVMOpcode(Noop)		Line: 48, Column: 31
+0037:  [0] AVMOpcode(Xget)		Line: 48, Column: 27
+0038:  [CodePoint(Internal(40))] AVMOpcode(Noop)		Line: 48, Column: 9
+0039:  [CodePoint(Internal(792))] AVMOpcode(Jump)		Line: 48, Column: 9
+0040:  [42] AVMOpcode(Equal)		Line: 48, Column: 9
+0041:  [CodePoint(Internal(46))] AVMOpcode(Cjump)		Line: 48, Column: 5
+0042:  [2] AVMOpcode(AuxPop)		Line: 49, Column: 6
+0043:  AVMOpcode(Pop)		Line: 49, Column: 6
+0044:  AVMOpcode(AuxPop)		Line: 49, Column: 6
+0045:  AVMOpcode(Jump)		Line: 49, Column: 6
+0046:  [117] AVMOpcode(Noop)		Line: 52, Column: 21
+0047:  [CodePoint(Internal(49))] AVMOpcode(Noop)		Line: 52, Column: 7
+0048:  [CodePoint(Internal(442))] AVMOpcode(Jump)		Line: 52, Column: 7
+0049:  [0] AVMOpcode(Xset)		Line: 52, Column: 2
+0050:  [42] AVMOpcode(Noop)		Line: 53, Column: 33
+0051:  [33] AVMOpcode(Noop)		Line: 53, Column: 29
+0052:  [0] AVMOpcode(Xget)		Line: 53, Column: 25
+0053:  [CodePoint(Internal(55))] AVMOpcode(Noop)		Line: 53, Column: 7
+0054:  [CodePoint(Internal(1071))] AVMOpcode(Jump)		Line: 53, Column: 7
+0055:  [0] AVMOpcode(Xset)		Line: 53, Column: 2
+0056:  [99] AVMOpcode(Noop)		Line: 54, Column: 36
+0057:  [37] AVMOpcode(Noop)		Line: 54, Column: 32
+0058:  [0] AVMOpcode(Xget)		Line: 54, Column: 28
+0059:  [CodePoint(Internal(61))] AVMOpcode(Noop)		Line: 54, Column: 10
+0060:  [CodePoint(Internal(1071))] AVMOpcode(Jump)		Line: 54, Column: 10
+0061:  [0] AVMOpcode(Xset)		Line: 54, Column: 5
+0062:  [33] AVMOpcode(Noop)		Line: 55, Column: 31
+0063:  [0] AVMOpcode(Xget)		Line: 55, Column: 27
+0064:  [CodePoint(Internal(66))] AVMOpcode(Noop)		Line: 55, Column: 9
+0065:  [CodePoint(Internal(792))] AVMOpcode(Jump)		Line: 55, Column: 9
+0066:  [42] AVMOpcode(Equal)		Line: 55, Column: 9
+0067:  [CodePoint(Internal(72))] AVMOpcode(Cjump)		Line: 55, Column: 5
+0068:  [3] AVMOpcode(AuxPop)		Line: 56, Column: 3
+0069:  AVMOpcode(Pop)		Line: 56, Column: 3
+0070:  AVMOpcode(AuxPop)		Line: 56, Column: 3
+0071:  AVMOpcode(Jump)		Line: 56, Column: 3
+0072:  [117] AVMOpcode(Noop)		Line: 59, Column: 21
+0073:  [CodePoint(Internal(75))] AVMOpcode(Noop)		Line: 59, Column: 7
+0074:  [CodePoint(Internal(442))] AVMOpcode(Jump)		Line: 59, Column: 7
+0075:  [0] AVMOpcode(Xset)		Line: 59, Column: 2
+0076:  [25386] AVMOpcode(Noop)		Line: 60, Column: 33
+0077:  [37] AVMOpcode(Noop)		Line: 60, Column: 29
+0078:  [0] AVMOpcode(Xget)		Line: 60, Column: 25
+0079:  [CodePoint(Internal(81))] AVMOpcode(Noop)		Line: 60, Column: 7
+0080:  [CodePoint(Internal(1071))] AVMOpcode(Jump)		Line: 60, Column: 7
+0081:  [0] AVMOpcode(Xset)		Line: 60, Column: 2
+0082:  [0xde0b6b3a763ffff] AVMOpcode(Noop)		Line: 61, Column: 33
+0083:  [36] AVMOpcode(Noop)		Line: 61, Column: 29
+0084:  [0] AVMOpcode(Xget)		Line: 61, Column: 25
+0085:  [CodePoint(Internal(87))] AVMOpcode(Noop)		Line: 61, Column: 7
+0086:  [CodePoint(Internal(1071))] AVMOpcode(Jump)		Line: 61, Column: 7
+0087:  [0] AVMOpcode(Xset)		Line: 61, Column: 2
+0088:  [37] AVMOpcode(Noop)		Line: 62, Column: 31
+0089:  [0] AVMOpcode(Xget)		Line: 62, Column: 27
+0090:  [CodePoint(Internal(92))] AVMOpcode(Noop)		Line: 62, Column: 9
+0091:  [CodePoint(Internal(792))] AVMOpcode(Jump)		Line: 62, Column: 9
+0092:  [42] AVMOpcode(Equal)		Line: 62, Column: 9
+0093:  [CodePoint(Internal(98))] AVMOpcode(Cjump)		Line: 62, Column: 5
+0094:  [4] AVMOpcode(AuxPop)		Line: 63, Column: 3
+0095:  AVMOpcode(Pop)		Line: 63, Column: 3
+0096:  AVMOpcode(AuxPop)		Line: 63, Column: 3
+0097:  AVMOpcode(Jump)		Line: 63, Column: 3
+0098:  [117] AVMOpcode(Noop)		Line: 66, Column: 21
+0099:  [CodePoint(Internal(101))] AVMOpcode(Noop)		Line: 66, Column: 7
+0100:  [CodePoint(Internal(442))] AVMOpcode(Jump)		Line: 66, Column: 7
+0101:  [0] AVMOpcode(Xset)		Line: 66, Column: 2
+0102:  [7373] AVMOpcode(Noop)		Line: 67, Column: 32
+0103:  [64] AVMOpcode(Noop)		Line: 67, Column: 28
+0104:  [0] AVMOpcode(Xget)		Line: 67, Column: 24
+0105:  [CodePoint(Internal(107))] AVMOpcode(Noop)		Line: 67, Column: 7
+0106:  [CodePoint(Internal(607))] AVMOpcode(Jump)		Line: 67, Column: 7
+0107:  [0] AVMOpcode(Xset)		Line: 67, Column: 2
+0108:  [64] AVMOpcode(Noop)		Line: 68, Column: 27
+0109:  [0] AVMOpcode(Xget)		Line: 68, Column: 23
+0110:  [CodePoint(Internal(112))] AVMOpcode(Noop)		Line: 68, Column: 6
+0111:  [CodePoint(Internal(932))] AVMOpcode(Jump)		Line: 68, Column: 6
+0112:  [7373] AVMOpcode(Equal)		Line: 68, Column: 6
+0113:  [CodePoint(Internal(118))] AVMOpcode(Cjump)		Line: 68, Column: 2
+0114:  [5] AVMOpcode(AuxPop)		Line: 69, Column: 3
+0115:  AVMOpcode(Pop)		Line: 69, Column: 3
+0116:  AVMOpcode(AuxPop)		Line: 69, Column: 3
+0117:  AVMOpcode(Jump)		Line: 69, Column: 3
+0118:  [117] AVMOpcode(Noop)		Line: 72, Column: 21
+0119:  [CodePoint(Internal(121))] AVMOpcode(Noop)		Line: 72, Column: 7
+0120:  [CodePoint(Internal(442))] AVMOpcode(Jump)		Line: 72, Column: 7
+0121:  [0] AVMOpcode(Xset)		Line: 72, Column: 2
+0122:  [7373] AVMOpcode(Noop)		Line: 73, Column: 32
+0123:  [64] AVMOpcode(Noop)		Line: 73, Column: 28
+0124:  [0] AVMOpcode(Xget)		Line: 73, Column: 24
+0125:  [CodePoint(Internal(127))] AVMOpcode(Noop)		Line: 73, Column: 7
+0126:  [CodePoint(Internal(607))] AVMOpcode(Jump)		Line: 73, Column: 7
+0127:  [0] AVMOpcode(Xset)		Line: 73, Column: 2
+0128:  [63] AVMOpcode(Noop)		Line: 74, Column: 33
+0129:  [0] AVMOpcode(Xget)		Line: 74, Column: 29
+0130:  [CodePoint(Internal(132))] AVMOpcode(Noop)		Line: 74, Column: 12
+0131:  [CodePoint(Internal(932))] AVMOpcode(Jump)		Line: 74, Column: 12
+0132:  [1] AVMOpcode(Xset)		Line: 74, Column: 2
+0133:  [1] AVMOpcode(Xget)		Line: 75, Column: 6
+0134:  [28] AVMOpcode(Equal)		Line: 75, Column: 6
+0135:  [CodePoint(Internal(142))] AVMOpcode(Cjump)		Line: 75, Column: 2
+0136:  [1] AVMOpcode(Xget)		Line: 76, Column: 19
+0137:  [60000] AVMOpcode(Plus)		Line: 76, Column: 13
+0138:  AVMOpcode(AuxPop)		Line: 76, Column: 6
+0139:  AVMOpcode(Pop)		Line: 76, Column: 6
+0140:  AVMOpcode(AuxPop)		Line: 76, Column: 6
+0141:  AVMOpcode(Jump)		Line: 76, Column: 6
+0142:  [117] AVMOpcode(Noop)		Line: 79, Column: 21
+0143:  [CodePoint(Internal(145))] AVMOpcode(Noop)		Line: 79, Column: 7
+0144:  [CodePoint(Internal(442))] AVMOpcode(Jump)		Line: 79, Column: 7
+0145:  [0] AVMOpcode(Xset)		Line: 79, Column: 2
+0146:  [0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff] AVMOpcode(Noop)		Line: 80, Column: 33
+0147:  [13] AVMOpcode(Noop)		Line: 80, Column: 28
+0148:  [0] AVMOpcode(Xget)		Line: 80, Column: 24
+0149:  [CodePoint(Internal(151))] AVMOpcode(Noop)		Line: 80, Column: 7
+0150:  [CodePoint(Internal(607))] AVMOpcode(Jump)		Line: 80, Column: 7
+0151:  [0] AVMOpcode(Xset)		Line: 80, Column: 2
+0152:  [0] AVMOpcode(Noop)		Line: 81, Column: 35
+0153:  [45] AVMOpcode(Noop)		Line: 81, Column: 28
+0154:  [0] AVMOpcode(Xget)		Line: 81, Column: 24
+0155:  [CodePoint(Internal(157))] AVMOpcode(Noop)		Line: 81, Column: 7
+0156:  [CodePoint(Internal(607))] AVMOpcode(Jump)		Line: 81, Column: 7
+0157:  [0] AVMOpcode(Xset)		Line: 81, Column: 2
+0158:  [0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff] AVMOpcode(Noop)		Line: 82, Column: 36
+0159:  [77] AVMOpcode(Noop)		Line: 82, Column: 28
+0160:  [0] AVMOpcode(Xget)		Line: 82, Column: 24
+0161:  [CodePoint(Internal(163))] AVMOpcode(Noop)		Line: 82, Column: 7
+0162:  [CodePoint(Internal(607))] AVMOpcode(Jump)		Line: 82, Column: 7
+0163:  [0] AVMOpcode(Xset)		Line: 82, Column: 2
+0164:  [13] AVMOpcode(Noop)		Line: 83, Column: 29
+0165:  [0] AVMOpcode(Xget)		Line: 83, Column: 25
+0166:  [CodePoint(Internal(168))] AVMOpcode(Noop)		Line: 83, Column: 8
+0167:  [CodePoint(Internal(932))] AVMOpcode(Jump)		Line: 83, Column: 8
+0168:  [0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff] AVMOpcode(Equal)		Line: 83, Column: 8
+0169:  AVMOpcode(IsZero)		Line: 83, Column: 8
+0170:  AVMOpcode(Dup0)		Line: 83, Column: 7
+0171:  [CodePoint(Internal(179))] AVMOpcode(Cjump)		Line: 83, Column: 7
+0172:  AVMOpcode(Pop)		Line: 83, Column: 7
+0173:  [45] AVMOpcode(Noop)		Line: 84, Column: 28
+0174:  [0] AVMOpcode(Xget)		Line: 84, Column: 24
+0175:  [CodePoint(Internal(177))] AVMOpcode(Noop)		Line: 84, Column: 7
+0176:  [CodePoint(Internal(932))] AVMOpcode(Jump)		Line: 84, Column: 7
+0177:  [0] AVMOpcode(Equal)		Line: 84, Column: 7
+0178:  AVMOpcode(IsZero)		Line: 84, Column: 7
+0179:  AVMOpcode(Dup0)		Line: 83, Column: 7
+0180:  [CodePoint(Internal(188))] AVMOpcode(Cjump)		Line: 83, Column: 7
+0181:  AVMOpcode(Pop)		Line: 83, Column: 7
+0182:  [77] AVMOpcode(Noop)		Line: 85, Column: 28
+0183:  [0] AVMOpcode(Xget)		Line: 85, Column: 24
+0184:  [CodePoint(Internal(186))] AVMOpcode(Noop)		Line: 85, Column: 7
+0185:  [CodePoint(Internal(932))] AVMOpcode(Jump)		Line: 85, Column: 7
+0186:  [0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff] AVMOpcode(Equal)		Line: 85, Column: 7
+0187:  AVMOpcode(IsZero)		Line: 85, Column: 7
+0188:  AVMOpcode(IsZero)		Line: 83, Column: 2
+0189:  [CodePoint(Internal(194))] AVMOpcode(Cjump)		Line: 83, Column: 2
+0190:  [7] AVMOpcode(AuxPop)		Line: 86, Column: 3
+0191:  AVMOpcode(Pop)		Line: 86, Column: 3
+0192:  AVMOpcode(AuxPop)		Line: 86, Column: 3
+0193:  AVMOpcode(Jump)		Line: 86, Column: 3
+0194:  [_] AVMOpcode(Noop)		Line: 97, Column: 6
+0195:  [0x102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f] AVMOpcode(Noop)		Line: 96, Column: 6
+0196:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 95, Column: 5
+0197:  [0] AVMOpcode(Tset)		Line: 95, Column: 5
+0198:  [1] AVMOpcode(Tset)		Line: 95, Column: 5
+0199:  [0x202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f] AVMOpcode(Noop)		Line: 94, Column: 5
+0200:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 93, Column: 4
+0201:  [0] AVMOpcode(Tset)		Line: 93, Column: 4
+0202:  [1] AVMOpcode(Tset)		Line: 93, Column: 4
+0203:  [0x4041420000000000000000000000000000000000000000000000000000000000] AVMOpcode(Noop)		Line: 92, Column: 4
+0204:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 91, Column: 3
+0205:  [0] AVMOpcode(Tset)		Line: 91, Column: 3
+0206:  [1] AVMOpcode(Tset)		Line: 91, Column: 3
+0207:  [67] AVMOpcode(Noop)		Line: 90, Column: 3
+0208:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 89, Column: 53
+0209:  [0] AVMOpcode(Tset)		Line: 89, Column: 53
+0210:  [1] AVMOpcode(Tset)		Line: 89, Column: 53
+0211:  [2] AVMOpcode(Xset)		Line: 89, Column: 2
+0212:  [67] AVMOpcode(Noop)		Line: 103, Column: 21
+0213:  [CodePoint(Internal(215))] AVMOpcode(Noop)		Line: 103, Column: 7
+0214:  [CodePoint(Internal(442))] AVMOpcode(Jump)		Line: 103, Column: 7
+0215:  [0] AVMOpcode(Xset)		Line: 103, Column: 2
+0216:  [2] AVMOpcode(Xget)		Line: 104, Column: 32
+0217:  [CodePoint(Internal(219))] AVMOpcode(Noop)		Line: 104, Column: 7
+0218:  [CodePoint(Internal(559))] AVMOpcode(Jump)		Line: 104, Column: 7
+0219:  [0] AVMOpcode(Xset)		Line: 104, Column: 2
+0220:  [0] AVMOpcode(Noop)		Line: 105, Column: 10
+0221:  [3] AVMOpcode(Xset)		Line: 105, Column: 2
+0222:  [CodePoint(Internal(225))] AVMOpcode(Noop)		Line: 106, Column: 2
+0223:  [4] AVMOpcode(Xset)		Line: 106, Column: 2
+0224:  [CodePoint(Internal(243))] AVMOpcode(Jump)		Line: 106, Column: 2
+0225:  [3] AVMOpcode(Xget)		Line: 107, Column: 33
+0226:  [0] AVMOpcode(Xget)		Line: 107, Column: 29
+0227:  [CodePoint(Internal(229))] AVMOpcode(Noop)		Line: 107, Column: 11
+0228:  [CodePoint(Internal(792))] AVMOpcode(Jump)		Line: 107, Column: 11
+0229:  [5] AVMOpcode(Xset)		Line: 107, Column: 3
+0230:  [3] AVMOpcode(Xget)		Line: 108, Column: 12
+0231:  [5] AVMOpcode(Xget)		Line: 108, Column: 7
+0232:  AVMOpcode(Equal)		Line: 108, Column: 7
+0233:  [CodePoint(Internal(240))] AVMOpcode(Cjump)		Line: 108, Column: 3
+0234:  [3] AVMOpcode(Xget)		Line: 109, Column: 15
+0235:  [100] AVMOpcode(Plus)		Line: 109, Column: 11
+0236:  AVMOpcode(AuxPop)		Line: 109, Column: 4
+0237:  AVMOpcode(Pop)		Line: 109, Column: 4
+0238:  AVMOpcode(AuxPop)		Line: 109, Column: 4
+0239:  AVMOpcode(Jump)		Line: 109, Column: 4
+0240:  [3] AVMOpcode(Xget)		Line: 111, Column: 7
+0241:  [1] AVMOpcode(Plus)		Line: 111, Column: 7
+0242:  [3] AVMOpcode(Xset)		Line: 111, Column: 3
+0243:  [3] AVMOpcode(Xget)		Line: 106, Column: 9
+0244:  [67] AVMOpcode(GreaterThan)		Line: 106, Column: 9
+0245:  [4] AVMOpcode(Xget)		Line: 106, Column: 2
+0246:  AVMOpcode(Cjump)		Line: 106, Column: 2
+0247:  [CodePoint(Internal(249))] AVMOpcode(Noop)		Line: 114, Column: 7
+0248:  [CodePoint(Internal(415))] AVMOpcode(Jump)		Line: 114, Column: 7
+0249:  [0] AVMOpcode(Xset)		Line: 114, Column: 2
+0250:  [3] AVMOpcode(Noop)		Line: 115, Column: 32
+0251:  [0] AVMOpcode(Xget)		Line: 115, Column: 28
+0252:  [CodePoint(Internal(254))] AVMOpcode(Noop)		Line: 115, Column: 12
+0253:  [CodePoint(Internal(830))] AVMOpcode(Jump)		Line: 115, Column: 12
+0254:  [6] AVMOpcode(Xset)		Line: 115, Column: 2
+0255:  [6] AVMOpcode(Xget)		Line: 116, Column: 6
+0256:  [0x30405060708090a] AVMOpcode(Equal)		Line: 116, Column: 6
+0257:  [CodePoint(Internal(262))] AVMOpcode(Cjump)		Line: 116, Column: 2
+0258:  [9] AVMOpcode(AuxPop)		Line: 117, Column: 3
+0259:  AVMOpcode(Pop)		Line: 117, Column: 3
+0260:  AVMOpcode(AuxPop)		Line: 117, Column: 3
+0261:  AVMOpcode(Jump)		Line: 117, Column: 3
+0262:  [CodePoint(Internal(264))] AVMOpcode(Noop)		Line: 120, Column: 7
+0263:  [CodePoint(Internal(415))] AVMOpcode(Jump)		Line: 120, Column: 7
+0264:  [0] AVMOpcode(Xset)		Line: 120, Column: 2
+0265:  [29] AVMOpcode(Noop)		Line: 121, Column: 26
+0266:  [0] AVMOpcode(Xget)		Line: 121, Column: 22
+0267:  [CodePoint(Internal(269))] AVMOpcode(Noop)		Line: 121, Column: 6
+0268:  [CodePoint(Internal(830))] AVMOpcode(Jump)		Line: 121, Column: 6
+0269:  [0x1d1e1f2021222324] AVMOpcode(Equal)		Line: 121, Column: 6
+0270:  [CodePoint(Internal(275))] AVMOpcode(Cjump)		Line: 121, Column: 2
+0271:  [10] AVMOpcode(AuxPop)		Line: 122, Column: 3
+0272:  AVMOpcode(Pop)		Line: 122, Column: 3
+0273:  AVMOpcode(AuxPop)		Line: 122, Column: 3
+0274:  AVMOpcode(Jump)		Line: 122, Column: 3
+0275:  [CodePoint(Internal(277))] AVMOpcode(Noop)		Line: 125, Column: 7
+0276:  [CodePoint(Internal(415))] AVMOpcode(Jump)		Line: 125, Column: 7
+0277:  [0] AVMOpcode(Xset)		Line: 125, Column: 2
+0278:  [32] AVMOpcode(Noop)		Line: 126, Column: 36
+0279:  [0] AVMOpcode(Xget)		Line: 126, Column: 32
+0280:  [CodePoint(Internal(282))] AVMOpcode(Noop)		Line: 126, Column: 15
+0281:  [CodePoint(Internal(932))] AVMOpcode(Jump)		Line: 126, Column: 15
+0282:  [7] AVMOpcode(Xget)		Line: 126, Column: 2
+0283:  [0] AVMOpcode(Tset)		Line: 126, Column: 2
+0284:  [7] AVMOpcode(Xset)		Line: 126, Column: 2
+0285:  [29] AVMOpcode(Noop)		Line: 127, Column: 30
+0286:  [0] AVMOpcode(Xget)		Line: 127, Column: 26
+0287:  [CodePoint(Internal(289))] AVMOpcode(Noop)		Line: 127, Column: 10
+0288:  [CodePoint(Internal(830))] AVMOpcode(Jump)		Line: 127, Column: 10
+0289:  [7] AVMOpcode(Xget)		Line: 127, Column: 2
+0290:  [1] AVMOpcode(Tset)		Line: 127, Column: 2
+0291:  [7] AVMOpcode(Xset)		Line: 127, Column: 2
+0292:  [7] AVMOpcode(Xget)		Line: 128, Column: 34
+0293:  [0] AVMOpcode(Tget)		Line: 128, Column: 34
+0294:  [32] AVMOpcode(Noop)		Line: 128, Column: 27
+0295:  [0] AVMOpcode(Xget)		Line: 128, Column: 23
+0296:  [CodePoint(Internal(298))] AVMOpcode(Noop)		Line: 128, Column: 6
+0297:  [CodePoint(Internal(932))] AVMOpcode(Jump)		Line: 128, Column: 6
+0298:  AVMOpcode(Equal)		Line: 128, Column: 6
+0299:  [CodePoint(Internal(304))] AVMOpcode(Cjump)		Line: 128, Column: 2
+0300:  [11] AVMOpcode(AuxPop)		Line: 129, Column: 3
+0301:  AVMOpcode(Pop)		Line: 129, Column: 3
+0302:  AVMOpcode(AuxPop)		Line: 129, Column: 3
+0303:  AVMOpcode(Jump)		Line: 129, Column: 3
+0304:  [32] AVMOpcode(Noop)		Line: 133, Column: 21
+0305:  [CodePoint(Internal(307))] AVMOpcode(Noop)		Line: 133, Column: 7
+0306:  [CodePoint(Internal(442))] AVMOpcode(Jump)		Line: 133, Column: 7
+0307:  [0] AVMOpcode(Xset)		Line: 133, Column: 2
+0308:  [1] AVMOpcode(Noop)		Line: 134, Column: 33
+0309:  [31] AVMOpcode(Noop)		Line: 134, Column: 29
+0310:  [0] AVMOpcode(Xget)		Line: 134, Column: 25
+0311:  [CodePoint(Internal(313))] AVMOpcode(Noop)		Line: 134, Column: 7
+0312:  [CodePoint(Internal(1071))] AVMOpcode(Jump)		Line: 134, Column: 7
+0313:  [0] AVMOpcode(Xset)		Line: 134, Column: 2
+0314:  [0] AVMOpcode(Noop)		Line: 135, Column: 27
+0315:  [0] AVMOpcode(Xget)		Line: 135, Column: 23
+0316:  [CodePoint(Internal(318))] AVMOpcode(Noop)		Line: 135, Column: 6
+0317:  [CodePoint(Internal(932))] AVMOpcode(Jump)		Line: 135, Column: 6
+0318:  [1] AVMOpcode(Equal)		Line: 135, Column: 6
+0319:  [CodePoint(Internal(324))] AVMOpcode(Cjump)		Line: 135, Column: 2
+0320:  [12] AVMOpcode(AuxPop)		Line: 136, Column: 6
+0321:  AVMOpcode(Pop)		Line: 136, Column: 6
+0322:  AVMOpcode(AuxPop)		Line: 136, Column: 6
+0323:  AVMOpcode(Jump)		Line: 136, Column: 6
+0324:  [CodePoint(Internal(326))] AVMOpcode(Noop)		Line: 140, Column: 55
+0325:  [CodePoint(Internal(415))] AVMOpcode(Jump)		Line: 140, Column: 55
+0326:  [CodePoint(Internal(328))] AVMOpcode(Noop)		Line: 140, Column: 33
+0327:  [CodePoint(Internal(692))] AVMOpcode(Jump)		Line: 140, Column: 33
+0328:  [CodePoint(Internal(330))] AVMOpcode(Noop)		Line: 140, Column: 12
+0329:  [CodePoint(Internal(526))] AVMOpcode(Jump)		Line: 140, Column: 12
+0330:  [0x4fc384a19926e9ff7ec8f2376a0d146dc273031df1db4d133236d209700e4780] AVMOpcode(Equal)		Line: 139, Column: 9
+0331:  [CodePoint(Internal(336))] AVMOpcode(Cjump)		Line: 139, Column: 5
+0332:  [13] AVMOpcode(AuxPop)		Line: 142, Column: 9
+0333:  AVMOpcode(Pop)		Line: 142, Column: 9
+0334:  AVMOpcode(AuxPop)		Line: 142, Column: 9
+0335:  AVMOpcode(Jump)		Line: 142, Column: 9
+0336:  [13] AVMOpcode(Noop)		Line: 146, Column: 98
+0337:  [0] AVMOpcode(Noop)		Line: 146, Column: 95
+0338:  [0] AVMOpcode(Noop)		Line: 146, Column: 91
+0339:  [CodePoint(Internal(341))] AVMOpcode(Noop)		Line: 146, Column: 77
+0340:  [CodePoint(Internal(442))] AVMOpcode(Jump)		Line: 146, Column: 77
+0341:  [CodePoint(Internal(343))] AVMOpcode(Noop)		Line: 146, Column: 59
+0342:  [CodePoint(Internal(1071))] AVMOpcode(Jump)		Line: 146, Column: 59
+0343:  [CodePoint(Internal(345))] AVMOpcode(Noop)		Line: 146, Column: 37
+0344:  [CodePoint(Internal(692))] AVMOpcode(Jump)		Line: 146, Column: 37
+0345:  [CodePoint(Internal(347))] AVMOpcode(Noop)		Line: 146, Column: 16
+0346:  [CodePoint(Internal(526))] AVMOpcode(Jump)		Line: 146, Column: 16
+0347:  [0x6203cb97ced4e35e64eeaddf64d03b68bcb81b5ee3cb0205f7edb755a8a4198] AVMOpcode(Equal)		Line: 145, Column: 9
+0348:  [CodePoint(Internal(353))] AVMOpcode(Cjump)		Line: 145, Column: 5
+0349:  [14] AVMOpcode(AuxPop)		Line: 148, Column: 9
+0350:  AVMOpcode(Pop)		Line: 148, Column: 9
+0351:  AVMOpcode(AuxPop)		Line: 148, Column: 9
+0352:  AVMOpcode(Jump)		Line: 148, Column: 9
+0353:  [0x6203cb97ced4e35e64eeaddf64d03b68bcb81b5ee3cb0205f7edb755a8a4198] AVMOpcode(Noop)		Line: 152, Column: 97
+0354:  [0] AVMOpcode(Noop)		Line: 152, Column: 94
+0355:  [0] AVMOpcode(Noop)		Line: 152, Column: 90
+0356:  [CodePoint(Internal(358))] AVMOpcode(Noop)		Line: 152, Column: 76
+0357:  [CodePoint(Internal(442))] AVMOpcode(Jump)		Line: 152, Column: 76
+0358:  [CodePoint(Internal(360))] AVMOpcode(Noop)		Line: 152, Column: 59
+0359:  [CodePoint(Internal(607))] AVMOpcode(Jump)		Line: 152, Column: 59
+0360:  [CodePoint(Internal(362))] AVMOpcode(Noop)		Line: 152, Column: 37
+0361:  [CodePoint(Internal(692))] AVMOpcode(Jump)		Line: 152, Column: 37
+0362:  [CodePoint(Internal(364))] AVMOpcode(Noop)		Line: 152, Column: 16
+0363:  [CodePoint(Internal(526))] AVMOpcode(Jump)		Line: 152, Column: 16
+0364:  [0x2286697a7baf78c99024b26bd236a05975a57714bf44a9b7400fe583b31fa274] AVMOpcode(Equal)		Line: 151, Column: 9
+0365:  [CodePoint(Internal(370))] AVMOpcode(Cjump)		Line: 151, Column: 5
+0366:  [15] AVMOpcode(AuxPop)		Line: 154, Column: 9
+0367:  AVMOpcode(Pop)		Line: 154, Column: 9
+0368:  AVMOpcode(AuxPop)		Line: 154, Column: 9
+0369:  AVMOpcode(Jump)		Line: 154, Column: 9
+0370:  [CodePoint(Internal(372))] AVMOpcode(Noop)		Line: 157, Column: 14
+0371:  [CodePoint(Internal(415))] AVMOpcode(Jump)		Line: 157, Column: 14
+0372:  [7] AVMOpcode(Xget)		Line: 157, Column: 5
+0373:  [2] AVMOpcode(Tset)		Line: 157, Column: 5
+0374:  [7] AVMOpcode(Xset)		Line: 157, Column: 5
+0375:  [41] AVMOpcode(Noop)		Line: 158, Column: 40
+0376:  [0] AVMOpcode(Noop)		Line: 158, Column: 37
+0377:  [7] AVMOpcode(Xget)		Line: 158, Column: 33
+0378:  [2] AVMOpcode(Tget)		Line: 158, Column: 33
+0379:  [CodePoint(Internal(381))] AVMOpcode(Noop)		Line: 158, Column: 15
+0380:  [CodePoint(Internal(1627))] AVMOpcode(Jump)		Line: 158, Column: 15
+0381:  [7] AVMOpcode(Xget)		Line: 158, Column: 5
+0382:  [3] AVMOpcode(Tset)		Line: 158, Column: 5
+0383:  [7] AVMOpcode(Xset)		Line: 158, Column: 5
+0384:  [41] AVMOpcode(Noop)		Line: 159, Column: 58
+0385:  [0] AVMOpcode(Noop)		Line: 159, Column: 55
+0386:  [0] AVMOpcode(Noop)		Line: 159, Column: 51
+0387:  [CodePoint(Internal(389))] AVMOpcode(Noop)		Line: 159, Column: 37
+0388:  [CodePoint(Internal(442))] AVMOpcode(Jump)		Line: 159, Column: 37
+0389:  [0] AVMOpcode(Noop)		Line: 159, Column: 34
+0390:  [7] AVMOpcode(Xget)		Line: 159, Column: 30
+0391:  [2] AVMOpcode(Tget)		Line: 159, Column: 30
+0392:  [CodePoint(Internal(394))] AVMOpcode(Noop)		Line: 159, Column: 15
+0393:  [CodePoint(Internal(1544))] AVMOpcode(Jump)		Line: 159, Column: 15
+0394:  [7] AVMOpcode(Xget)		Line: 159, Column: 5
+0395:  [4] AVMOpcode(Tset)		Line: 159, Column: 5
+0396:  [7] AVMOpcode(Xset)		Line: 159, Column: 5
+0397:  [7] AVMOpcode(Xget)		Line: 160, Column: 61
+0398:  [4] AVMOpcode(Tget)		Line: 160, Column: 61
+0399:  [CodePoint(Internal(401))] AVMOpcode(Noop)		Line: 160, Column: 39
+0400:  [CodePoint(Internal(692))] AVMOpcode(Jump)		Line: 160, Column: 39
+0401:  [7] AVMOpcode(Xget)		Line: 160, Column: 31
+0402:  [3] AVMOpcode(Tget)		Line: 160, Column: 31
+0403:  [CodePoint(Internal(405))] AVMOpcode(Noop)		Line: 160, Column: 9
+0404:  [CodePoint(Internal(692))] AVMOpcode(Jump)		Line: 160, Column: 9
+0405:  AVMOpcode(Equal)		Line: 160, Column: 9
+0406:  [CodePoint(Internal(411))] AVMOpcode(Cjump)		Line: 160, Column: 5
+0407:  [16] AVMOpcode(AuxPop)		Line: 161, Column: 9
+0408:  AVMOpcode(Pop)		Line: 161, Column: 9
+0409:  AVMOpcode(AuxPop)		Line: 161, Column: 9
+0410:  AVMOpcode(Jump)		Line: 161, Column: 9
+0411:  [0] AVMOpcode(AuxPop)		Line: 164, Column: 2
+0412:  AVMOpcode(Pop)		Line: 164, Column: 2
+0413:  AVMOpcode(AuxPop)		Line: 164, Column: 2
+0414:  AVMOpcode(Jump)		Line: 164, Column: 2
+0415:  AVMOpcode(AuxPush)		Line: 167, Column: 1
+0416:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 167, Column: 1
+0417:  [_] AVMOpcode(Noop)		Line: 176, Column: 6
+0418:  [0x102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f] AVMOpcode(Noop)		Line: 175, Column: 9
+0419:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 174, Column: 5
+0420:  [0] AVMOpcode(Tset)		Line: 174, Column: 5
+0421:  [1] AVMOpcode(Tset)		Line: 174, Column: 5
+0422:  [0x202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f] AVMOpcode(Noop)		Line: 173, Column: 5
+0423:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 172, Column: 4
+0424:  [0] AVMOpcode(Tset)		Line: 172, Column: 4
+0425:  [1] AVMOpcode(Tset)		Line: 172, Column: 4
+0426:  [0x4041420000000000000000000000000000000000000000000000000000000000] AVMOpcode(Noop)		Line: 171, Column: 4
+0427:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 170, Column: 3
+0428:  [0] AVMOpcode(Tset)		Line: 170, Column: 3
+0429:  [1] AVMOpcode(Tset)		Line: 170, Column: 3
+0430:  [67] AVMOpcode(Noop)		Line: 169, Column: 3
+0431:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 168, Column: 53
+0432:  [0] AVMOpcode(Tset)		Line: 168, Column: 53
+0433:  [1] AVMOpcode(Tset)		Line: 168, Column: 53
+0434:  [0] AVMOpcode(Xset)		Line: 168, Column: 2
+0435:  [0] AVMOpcode(Xget)		Line: 181, Column: 34
+0436:  [CodePoint(Internal(438))] AVMOpcode(Noop)		Line: 181, Column: 9
+0437:  [CodePoint(Internal(559))] AVMOpcode(Jump)		Line: 181, Column: 9
+0438:  AVMOpcode(AuxPop)		Line: 181, Column: 2
+0439:  AVMOpcode(Pop)		Line: 181, Column: 2
+0440:  AVMOpcode(AuxPop)		Line: 181, Column: 2
+0441:  AVMOpcode(Jump)		Line: 181, Column: 2
+0442:  AVMOpcode(AuxPush)		Line: 29, Column: 1
+0443:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 29, Column: 1
+0444:  [0] AVMOpcode(Xset)		Line: 29, Column: 1
+0445:  [CodePoint(Internal(447))] AVMOpcode(Noop)		Line: 33, Column: 19
+0446:  [CodePoint(Internal(457))] AVMOpcode(Jump)		Line: 33, Column: 19
+0447:  [0] AVMOpcode(Noop)		Line: 32, Column: 22
+0448:  [0] AVMOpcode(Noop)		Line: 31, Column: 15
+0449:  [Tuple(_, _, _)] AVMOpcode(Noop)		Line: 30, Column: 12
+0450:  [0] AVMOpcode(Tset)		Line: 30, Column: 12
+0451:  [1] AVMOpcode(Tset)		Line: 30, Column: 12
+0452:  [2] AVMOpcode(Tset)		Line: 30, Column: 12
+0453:  AVMOpcode(AuxPop)		Line: 30, Column: 5
+0454:  AVMOpcode(Pop)		Line: 30, Column: 5
+0455:  AVMOpcode(AuxPop)		Line: 30, Column: 5
+0456:  AVMOpcode(Jump)		Line: 30, Column: 5
+0457:  AVMOpcode(AuxPush)		Line: 352, Column: 1
+0458:  [_] AVMOpcode(AuxPush)		Line: 352, Column: 1
+0459:  [0] AVMOpcode(Noop)		Line: 356, Column: 53
+0460:  [0] AVMOpcode(Noop)		Line: 356, Column: 51
+0461:  [0] AVMOpcode(Noop)		Line: 356, Column: 49
+0462:  [0] AVMOpcode(Noop)		Line: 356, Column: 47
+0463:  [0] AVMOpcode(Noop)		Line: 356, Column: 45
+0464:  [0] AVMOpcode(Noop)		Line: 356, Column: 43
+0465:  [0] AVMOpcode(Noop)		Line: 356, Column: 41
+0466:  [0] AVMOpcode(Noop)		Line: 356, Column: 39
+0467:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(Noop)		Line: 356, Column: 38
+0468:  [0] AVMOpcode(Tset)		Line: 356, Column: 38
+0469:  [1] AVMOpcode(Tset)		Line: 356, Column: 38
+0470:  [2] AVMOpcode(Tset)		Line: 356, Column: 38
+0471:  [3] AVMOpcode(Tset)		Line: 356, Column: 38
+0472:  [4] AVMOpcode(Tset)		Line: 356, Column: 38
+0473:  [5] AVMOpcode(Tset)		Line: 356, Column: 38
+0474:  [6] AVMOpcode(Tset)		Line: 356, Column: 38
+0475:  [7] AVMOpcode(Tset)		Line: 356, Column: 38
+0476:  [1] AVMOpcode(Noop)		Line: 355, Column: 16
+0477:  [8] AVMOpcode(Noop)		Line: 354, Column: 15
+0478:  [Tuple(_, _, _)] AVMOpcode(Noop)		Line: 353, Column: 12
+0479:  [0] AVMOpcode(Tset)		Line: 353, Column: 12
+0480:  [1] AVMOpcode(Tset)		Line: 353, Column: 12
+0481:  [2] AVMOpcode(Tset)		Line: 353, Column: 12
+0482:  AVMOpcode(AuxPop)		Line: 353, Column: 5
+0483:  AVMOpcode(Pop)		Line: 353, Column: 5
+0484:  AVMOpcode(AuxPop)		Line: 353, Column: 5
+0485:  AVMOpcode(Jump)		Line: 353, Column: 5
+0486:  AVMOpcode(AuxPush)		Line: 47, Column: 1
+0487:  [Tuple(_, _, _, _)] AVMOpcode(AuxPush)		Line: 47, Column: 1
+0488:  [0] AVMOpcode(Xset)		Line: 47, Column: 1
+0489:  [0] AVMOpcode(Xget)		Line: 48, Column: 18
+0490:  [0] AVMOpcode(Tget)		Line: 48, Column: 18
+0491:  [1] AVMOpcode(Xset)		Line: 48, Column: 5
+0492:  [0] AVMOpcode(Xget)		Line: 49, Column: 20
+0493:  [1] AVMOpcode(Tget)		Line: 49, Column: 20
+0494:  [2] AVMOpcode(Xset)		Line: 49, Column: 5
+0495:  [1] AVMOpcode(Xget)		Line: 50, Column: 9
+0496:  [1] AVMOpcode(GreaterThan)		Line: 50, Column: 9
+0497:  AVMOpcode(IsZero)		Line: 50, Column: 5
+0498:  [CodePoint(Internal(503))] AVMOpcode(Cjump)		Line: 50, Column: 5
+0499:  [0] AVMOpcode(AuxPop)		Line: 51, Column: 9
+0500:  AVMOpcode(Pop)		Line: 51, Column: 9
+0501:  AVMOpcode(AuxPop)		Line: 51, Column: 9
+0502:  AVMOpcode(Jump)		Line: 51, Column: 9
+0503:  [CodePoint(Internal(506))] AVMOpcode(Noop)		Line: 53, Column: 5
+0504:  [3] AVMOpcode(Xset)		Line: 53, Column: 5
+0505:  [CodePoint(Internal(513))] AVMOpcode(Jump)		Line: 53, Column: 5
+0506:  [2] AVMOpcode(Xget)		Line: 54, Column: 52
+0507:  [1] AVMOpcode(Tget)		Line: 54, Column: 52
+0508:  [2] AVMOpcode(Xset)		Line: 54, Column: 9
+0509:  [32] AVMOpcode(Noop)		Line: 55, Column: 25
+0510:  [1] AVMOpcode(Xget)		Line: 55, Column: 18
+0511:  AVMOpcode(Minus)		Line: 55, Column: 18
+0512:  [1] AVMOpcode(Xset)		Line: 55, Column: 9
+0513:  [1] AVMOpcode(Xget)		Line: 53, Column: 12
+0514:  [32] AVMOpcode(LessThan)		Line: 53, Column: 12
+0515:  [3] AVMOpcode(Xget)		Line: 53, Column: 5
+0516:  AVMOpcode(Cjump)		Line: 53, Column: 5
+0517:  [248] AVMOpcode(Noop)		Line: 57, Column: 36
+0518:  [2] AVMOpcode(Exp)		Line: 57, Column: 48
+0519:  [2] AVMOpcode(Xget)		Line: 57, Column: 12
+0520:  [0] AVMOpcode(Tget)		Line: 57, Column: 12
+0521:  AVMOpcode(Div)		Line: 57, Column: 12
+0522:  AVMOpcode(AuxPop)		Line: 57, Column: 5
+0523:  AVMOpcode(Pop)		Line: 57, Column: 5
+0524:  AVMOpcode(AuxPop)		Line: 57, Column: 5
+0525:  AVMOpcode(Jump)		Line: 57, Column: 5
+0526:  AVMOpcode(AuxPush)		Line: 60, Column: 1
+0527:  [Tuple(_, _, _, _, _)] AVMOpcode(AuxPush)		Line: 60, Column: 1
+0528:  [0] AVMOpcode(Xset)		Line: 60, Column: 1
+0529:  [0] AVMOpcode(Xget)		Line: 64, Column: 23
+0530:  [0] AVMOpcode(Tget)		Line: 64, Column: 23
+0531:  [1] AVMOpcode(Xset)		Line: 64, Column: 5
+0532:  [0] AVMOpcode(Xget)		Line: 65, Column: 29
+0533:  [1] AVMOpcode(Tget)		Line: 65, Column: 29
+0534:  [2] AVMOpcode(Xset)		Line: 65, Column: 5
+0535:  [CodePoint(Internal(538))] AVMOpcode(Noop)		Line: 66, Column: 5
+0536:  [3] AVMOpcode(Xset)		Line: 66, Column: 5
+0537:  [CodePoint(Internal(548))] AVMOpcode(Jump)		Line: 66, Column: 5
+0538:  [2] AVMOpcode(Xget)		Line: 67, Column: 52
+0539:  [4] AVMOpcode(Xset)		Line: 67, Column: 9
+0540:  [4] AVMOpcode(Xget)		Line: 68, Column: 33
+0541:  [0] AVMOpcode(Tget)		Line: 68, Column: 33
+0542:  [1] AVMOpcode(Xget)		Line: 68, Column: 20
+0543:  AVMOpcode(Hash2)		Line: 68, Column: 15
+0544:  [1] AVMOpcode(Xset)		Line: 68, Column: 9
+0545:  [4] AVMOpcode(Xget)		Line: 69, Column: 13
+0546:  [1] AVMOpcode(Tget)		Line: 69, Column: 13
+0547:  [2] AVMOpcode(Xset)		Line: 69, Column: 9
+0548:  [_] AVMOpcode(Noop)		Line: 66, Column: 16
+0549:  [2] AVMOpcode(Xget)		Line: 66, Column: 11
+0550:  AVMOpcode(Equal)		Line: 66, Column: 11
+0551:  AVMOpcode(IsZero)		Line: 66, Column: 11
+0552:  [3] AVMOpcode(Xget)		Line: 66, Column: 5
+0553:  AVMOpcode(Cjump)		Line: 66, Column: 5
+0554:  [1] AVMOpcode(Xget)		Line: 71, Column: 12
+0555:  AVMOpcode(AuxPop)		Line: 71, Column: 5
+0556:  AVMOpcode(Pop)		Line: 71, Column: 5
+0557:  AVMOpcode(AuxPop)		Line: 71, Column: 5
+0558:  AVMOpcode(Jump)		Line: 71, Column: 5
+0559:  AVMOpcode(AuxPush)		Line: 76, Column: 1
+0560:  [Tuple(_, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 76, Column: 1
+0561:  [0] AVMOpcode(Xset)		Line: 76, Column: 1
+0562:  [0] AVMOpcode(Xget)		Line: 78, Column: 18
+0563:  [0] AVMOpcode(Tget)		Line: 78, Column: 18
+0564:  [1] AVMOpcode(Xset)		Line: 78, Column: 5
+0565:  [1] AVMOpcode(Xget)		Line: 79, Column: 49
+0566:  [1] AVMOpcode(Xget)		Line: 79, Column: 28
+0567:  [CodePoint(Internal(570))] AVMOpcode(PushStatic)		Line: 79, Column: 14
+0568:  [0] AVMOpcode(Tget)		Line: 79, Column: 14
+0569:  AVMOpcode(Jump)		Line: 79, Column: 14
+0570:  [0] AVMOpcode(Tset)		Line: 79, Column: 14
+0571:  [2] AVMOpcode(Xset)		Line: 79, Column: 5
+0572:  [32] AVMOpcode(Noop)		Line: 80, Column: 30
+0573:  [1] AVMOpcode(Xget)		Line: 80, Column: 19
+0574:  [31] AVMOpcode(Plus)		Line: 80, Column: 19
+0575:  AVMOpcode(Div)		Line: 80, Column: 18
+0576:  [3] AVMOpcode(Xset)		Line: 80, Column: 5
+0577:  [0] AVMOpcode(Xget)		Line: 82, Column: 17
+0578:  [1] AVMOpcode(Tget)		Line: 82, Column: 17
+0579:  [4] AVMOpcode(Xset)		Line: 82, Column: 5
+0580:  [CodePoint(Internal(583))] AVMOpcode(Noop)		Line: 83, Column: 5
+0581:  [5] AVMOpcode(Xset)		Line: 83, Column: 5
+0582:  [CodePoint(Internal(598))] AVMOpcode(Jump)		Line: 83, Column: 5
+0583:  [1] AVMOpcode(Noop)		Line: 84, Column: 25
+0584:  [3] AVMOpcode(Xget)		Line: 84, Column: 18
+0585:  AVMOpcode(Minus)		Line: 84, Column: 18
+0586:  [3] AVMOpcode(Xset)		Line: 84, Column: 9
+0587:  [4] AVMOpcode(Xget)		Line: 85, Column: 46
+0588:  [0] AVMOpcode(Tget)		Line: 85, Column: 46
+0589:  [3] AVMOpcode(Xget)		Line: 85, Column: 38
+0590:  [32] AVMOpcode(Mul)		Line: 85, Column: 35
+0591:  [2] AVMOpcode(Xget)		Line: 85, Column: 31
+0592:  [CodePoint(Internal(594))] AVMOpcode(Noop)		Line: 85, Column: 14
+0593:  [CodePoint(Internal(607))] AVMOpcode(Jump)		Line: 85, Column: 14
+0594:  [2] AVMOpcode(Xset)		Line: 85, Column: 9
+0595:  [4] AVMOpcode(Xget)		Line: 86, Column: 49
+0596:  [1] AVMOpcode(Tget)		Line: 86, Column: 49
+0597:  [4] AVMOpcode(Xset)		Line: 86, Column: 9
+0598:  [3] AVMOpcode(Xget)		Line: 83, Column: 12
+0599:  [0] AVMOpcode(LessThan)		Line: 83, Column: 12
+0600:  [5] AVMOpcode(Xget)		Line: 83, Column: 5
+0601:  AVMOpcode(Cjump)		Line: 83, Column: 5
+0602:  [2] AVMOpcode(Xget)		Line: 88, Column: 12
+0603:  AVMOpcode(AuxPop)		Line: 88, Column: 5
+0604:  AVMOpcode(Pop)		Line: 88, Column: 5
+0605:  AVMOpcode(AuxPop)		Line: 88, Column: 5
+0606:  AVMOpcode(Jump)		Line: 88, Column: 5
+0607:  AVMOpcode(AuxPush)		Line: 235, Column: 1
+0608:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 235, Column: 1
+0609:  [0] AVMOpcode(Xset)		Line: 235, Column: 1
+0610:  [1] AVMOpcode(Xset)		Line: 235, Column: 1
+0611:  [2] AVMOpcode(Xset)		Line: 235, Column: 1
+0612:  [0] AVMOpcode(Xget)		Line: 236, Column: 21
+0613:  [0] AVMOpcode(Tget)		Line: 236, Column: 21
+0614:  [1] AVMOpcode(Xget)		Line: 236, Column: 9
+0615:  [32] AVMOpcode(Plus)		Line: 236, Column: 9
+0616:  AVMOpcode(GreaterThan)		Line: 236, Column: 9
+0617:  AVMOpcode(IsZero)		Line: 236, Column: 5
+0618:  [CodePoint(Internal(625))] AVMOpcode(Cjump)		Line: 236, Column: 5
+0619:  [1] AVMOpcode(Xget)		Line: 237, Column: 30
+0620:  [32] AVMOpcode(Plus)		Line: 237, Column: 30
+0621:  [0] AVMOpcode(Xget)		Line: 237, Column: 14
+0622:  [0] AVMOpcode(Tset)		Line: 237, Column: 14
+0623:  [0] AVMOpcode(Xset)		Line: 237, Column: 9
+0624:  [CodePoint(Internal(625))] AVMOpcode(Jump)		Line: 236, Column: 5
+0625:  [0] AVMOpcode(Xget)		Line: 239, Column: 23
+0626:  [1] AVMOpcode(Tget)		Line: 239, Column: 23
+0627:  [1] AVMOpcode(Xget)		Line: 239, Column: 14
+0628:  AVMOpcode(Plus)		Line: 239, Column: 14
+0629:  [1] AVMOpcode(Xset)		Line: 239, Column: 5
+0630:  [32] AVMOpcode(Noop)		Line: 240, Column: 33
+0631:  [1] AVMOpcode(Xget)		Line: 240, Column: 24
+0632:  AVMOpcode(Div)		Line: 240, Column: 24
+0633:  [3] AVMOpcode(Xset)		Line: 240, Column: 5
+0634:  [32] AVMOpcode(Noop)		Line: 241, Column: 30
+0635:  [1] AVMOpcode(Xget)		Line: 241, Column: 21
+0636:  AVMOpcode(Mod)		Line: 241, Column: 21
+0637:  [4] AVMOpcode(Xset)		Line: 241, Column: 5
+0638:  [4] AVMOpcode(Xget)		Line: 242, Column: 9
+0639:  [0] AVMOpcode(Equal)		Line: 242, Column: 9
+0640:  AVMOpcode(IsZero)		Line: 242, Column: 5
+0641:  [CodePoint(Internal(654))] AVMOpcode(Cjump)		Line: 242, Column: 5
+0642:  [2] AVMOpcode(Xget)		Line: 244, Column: 72
+0643:  [3] AVMOpcode(Xget)		Line: 244, Column: 58
+0644:  [0] AVMOpcode(Xget)		Line: 244, Column: 45
+0645:  [2] AVMOpcode(Tget)		Line: 244, Column: 45
+0646:  [CodePoint(Internal(648))] AVMOpcode(Noop)		Line: 244, Column: 23
+0647:  [CodePoint(Internal(1473))] AVMOpcode(Jump)		Line: 244, Column: 23
+0648:  [0] AVMOpcode(Xget)		Line: 243, Column: 16
+0649:  [2] AVMOpcode(Tset)		Line: 243, Column: 16
+0650:  AVMOpcode(AuxPop)		Line: 243, Column: 9
+0651:  AVMOpcode(Pop)		Line: 243, Column: 9
+0652:  AVMOpcode(AuxPop)		Line: 243, Column: 9
+0653:  AVMOpcode(Jump)		Line: 243, Column: 9
+0654:  [2] AVMOpcode(Xget)		Line: 256, Column: 34
+0655:  [4] AVMOpcode(Xget)		Line: 256, Column: 23
+0656:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 256, Column: 22
+0657:  [0] AVMOpcode(Tset)		Line: 256, Column: 22
+0658:  [1] AVMOpcode(Tset)		Line: 256, Column: 22
+0659:  [CodePoint(Internal(1437))] AVMOpcode(Noop)		Line: 255, Column: 46
+0660:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 254, Column: 13
+0661:  [0] AVMOpcode(Tset)		Line: 254, Column: 13
+0662:  [1] AVMOpcode(Tset)		Line: 254, Column: 13
+0663:  [2] AVMOpcode(Xget)		Line: 252, Column: 34
+0664:  [4] AVMOpcode(Xget)		Line: 252, Column: 23
+0665:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 252, Column: 22
+0666:  [0] AVMOpcode(Tset)		Line: 252, Column: 22
+0667:  [1] AVMOpcode(Tset)		Line: 252, Column: 22
+0668:  [CodePoint(Internal(1505))] AVMOpcode(Noop)		Line: 251, Column: 46
+0669:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 250, Column: 13
+0670:  [0] AVMOpcode(Tset)		Line: 250, Column: 13
+0671:  [1] AVMOpcode(Tset)		Line: 250, Column: 13
+0672:  [3] AVMOpcode(Xget)		Line: 249, Column: 13
+0673:  [0] AVMOpcode(Xget)		Line: 248, Column: 13
+0674:  [2] AVMOpcode(Tget)		Line: 248, Column: 13
+0675:  [CodePoint(Internal(677))] AVMOpcode(Noop)		Line: 247, Column: 37
+0676:  [CodePoint(Internal(1337))] AVMOpcode(Jump)		Line: 247, Column: 37
+0677:  AVMOpcode(Dup0)		Line: 247, Column: 9
+0678:  [0] AVMOpcode(Tget)		Line: 247, Column: 9
+0679:  [5] AVMOpcode(Xset)		Line: 247, Column: 9
+0680:  AVMOpcode(Dup0)		Line: 247, Column: 9
+0681:  [1] AVMOpcode(Tget)		Line: 247, Column: 9
+0682:  [6] AVMOpcode(Xset)		Line: 247, Column: 9
+0683:  [2] AVMOpcode(Tget)		Line: 247, Column: 9
+0684:  [7] AVMOpcode(Xset)		Line: 247, Column: 9
+0685:  [5] AVMOpcode(Xget)		Line: 259, Column: 36
+0686:  [0] AVMOpcode(Xget)		Line: 259, Column: 16
+0687:  [2] AVMOpcode(Tset)		Line: 259, Column: 16
+0688:  AVMOpcode(AuxPop)		Line: 259, Column: 9
+0689:  AVMOpcode(Pop)		Line: 259, Column: 9
+0690:  AVMOpcode(AuxPop)		Line: 259, Column: 9
+0691:  AVMOpcode(Jump)		Line: 259, Column: 9
+0692:  AVMOpcode(AuxPush)		Line: 91, Column: 1
+0693:  [Tuple(_, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 91, Column: 1
+0694:  [0] AVMOpcode(Xset)		Line: 91, Column: 1
+0695:  [0] AVMOpcode(Xget)		Line: 92, Column: 18
+0696:  [0] AVMOpcode(Tget)		Line: 92, Column: 18
+0697:  [1] AVMOpcode(Xset)		Line: 92, Column: 5
+0698:  [32] AVMOpcode(Noop)		Line: 93, Column: 30
+0699:  [1] AVMOpcode(Xget)		Line: 93, Column: 19
+0700:  [31] AVMOpcode(Plus)		Line: 93, Column: 19
+0701:  AVMOpcode(Div)		Line: 93, Column: 18
+0702:  [2] AVMOpcode(Xset)		Line: 93, Column: 5
+0703:  [_] AVMOpcode(Noop)		Line: 94, Column: 49
+0704:  [3] AVMOpcode(Xset)		Line: 94, Column: 5
+0705:  [0] AVMOpcode(Noop)		Line: 95, Column: 13
+0706:  [4] AVMOpcode(Xset)		Line: 95, Column: 5
+0707:  [CodePoint(Internal(710))] AVMOpcode(Noop)		Line: 96, Column: 5
+0708:  [5] AVMOpcode(Xset)		Line: 96, Column: 5
+0709:  [CodePoint(Internal(723))] AVMOpcode(Jump)		Line: 96, Column: 5
+0710:  [3] AVMOpcode(Xget)		Line: 99, Column: 19
+0711:  [4] AVMOpcode(Xget)		Line: 98, Column: 55
+0712:  [0] AVMOpcode(Xget)		Line: 98, Column: 42
+0713:  [2] AVMOpcode(Tget)		Line: 98, Column: 42
+0714:  [CodePoint(Internal(716))] AVMOpcode(Noop)		Line: 98, Column: 20
+0715:  [CodePoint(Internal(737))] AVMOpcode(Jump)		Line: 98, Column: 20
+0716:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 97, Column: 17
+0717:  [0] AVMOpcode(Tset)		Line: 97, Column: 17
+0718:  [1] AVMOpcode(Tset)		Line: 97, Column: 17
+0719:  [3] AVMOpcode(Xset)		Line: 97, Column: 9
+0720:  [4] AVMOpcode(Xget)		Line: 101, Column: 13
+0721:  [1] AVMOpcode(Plus)		Line: 101, Column: 13
+0722:  [4] AVMOpcode(Xset)		Line: 101, Column: 9
+0723:  [2] AVMOpcode(Xget)		Line: 96, Column: 16
+0724:  [4] AVMOpcode(Xget)		Line: 96, Column: 12
+0725:  AVMOpcode(LessThan)		Line: 96, Column: 12
+0726:  [5] AVMOpcode(Xget)		Line: 96, Column: 5
+0727:  AVMOpcode(Cjump)		Line: 96, Column: 5
+0728:  [3] AVMOpcode(Xget)		Line: 105, Column: 19
+0729:  [1] AVMOpcode(Xget)		Line: 104, Column: 17
+0730:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 103, Column: 12
+0731:  [0] AVMOpcode(Tset)		Line: 103, Column: 12
+0732:  [1] AVMOpcode(Tset)		Line: 103, Column: 12
+0733:  AVMOpcode(AuxPop)		Line: 103, Column: 5
+0734:  AVMOpcode(Pop)		Line: 103, Column: 5
+0735:  AVMOpcode(AuxPop)		Line: 103, Column: 5
+0736:  AVMOpcode(Jump)		Line: 103, Column: 5
+0737:  AVMOpcode(AuxPush)		Line: 360, Column: 1
+0738:  [Tuple(_, _, _, _, _)] AVMOpcode(AuxPush)		Line: 360, Column: 1
+0739:  [0] AVMOpcode(Xset)		Line: 360, Column: 1
+0740:  [1] AVMOpcode(Xset)		Line: 360, Column: 1
+0741:  [0] AVMOpcode(Xget)		Line: 361, Column: 17
+0742:  [0] AVMOpcode(Tget)		Line: 361, Column: 17
+0743:  [1] AVMOpcode(Xget)		Line: 361, Column: 9
+0744:  AVMOpcode(GreaterThan)		Line: 361, Column: 9
+0745:  AVMOpcode(IsZero)		Line: 361, Column: 5
+0746:  [CodePoint(Internal(751))] AVMOpcode(Cjump)		Line: 361, Column: 5
+0747:  [0] AVMOpcode(AuxPop)		Line: 362, Column: 9
+0748:  AVMOpcode(Pop)		Line: 362, Column: 9
+0749:  AVMOpcode(AuxPop)		Line: 362, Column: 9
+0750:  AVMOpcode(Jump)		Line: 362, Column: 9
+0751:  [0] AVMOpcode(Xget)		Line: 364, Column: 17
+0752:  [1] AVMOpcode(Tget)		Line: 364, Column: 17
+0753:  [2] AVMOpcode(Xset)		Line: 364, Column: 5
+0754:  [0] AVMOpcode(Xget)		Line: 365, Column: 16
+0755:  [2] AVMOpcode(Tget)		Line: 365, Column: 16
+0756:  [3] AVMOpcode(Xset)		Line: 365, Column: 5
+0757:  [CodePoint(Internal(760))] AVMOpcode(Noop)		Line: 366, Column: 5
+0758:  [4] AVMOpcode(Xset)		Line: 366, Column: 5
+0759:  [CodePoint(Internal(774))] AVMOpcode(Jump)		Line: 366, Column: 5
+0760:  [3] AVMOpcode(Xget)		Line: 367, Column: 35
+0761:  [2] AVMOpcode(Xget)		Line: 367, Column: 48
+0762:  [1] AVMOpcode(Xget)		Line: 367, Column: 40
+0763:  AVMOpcode(Div)		Line: 367, Column: 40
+0764:  AVMOpcode(Tget)		Line: 367, Column: 35
+0765:  [3] AVMOpcode(Xset)		Line: 367, Column: 9
+0766:  [2] AVMOpcode(Xget)		Line: 368, Column: 25
+0767:  [1] AVMOpcode(Xget)		Line: 368, Column: 17
+0768:  AVMOpcode(Mod)		Line: 368, Column: 17
+0769:  [1] AVMOpcode(Xset)		Line: 368, Column: 9
+0770:  [8] AVMOpcode(Noop)		Line: 369, Column: 25
+0771:  [2] AVMOpcode(Xget)		Line: 369, Column: 17
+0772:  AVMOpcode(Div)		Line: 369, Column: 17
+0773:  [2] AVMOpcode(Xset)		Line: 369, Column: 9
+0774:  [2] AVMOpcode(Xget)		Line: 366, Column: 12
+0775:  [1] AVMOpcode(LessThan)		Line: 366, Column: 12
+0776:  [4] AVMOpcode(Xget)		Line: 366, Column: 5
+0777:  AVMOpcode(Cjump)		Line: 366, Column: 5
+0778:  [3] AVMOpcode(Xget)		Line: 371, Column: 29
+0779:  AVMOpcode(AuxPop)		Line: 371, Column: 5
+0780:  AVMOpcode(Pop)		Line: 371, Column: 5
+0781:  AVMOpcode(AuxPop)		Line: 371, Column: 5
+0782:  AVMOpcode(Jump)		Line: 371, Column: 5
+0783:  AVMOpcode(AuxPush)		Line: 110, Column: 1
+0784:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 110, Column: 1
+0785:  [0] AVMOpcode(Xset)		Line: 110, Column: 1
+0786:  [0] AVMOpcode(Xget)		Line: 111, Column: 12
+0787:  [0] AVMOpcode(Tget)		Line: 111, Column: 12
+0788:  AVMOpcode(AuxPop)		Line: 111, Column: 5
+0789:  AVMOpcode(Pop)		Line: 111, Column: 5
+0790:  AVMOpcode(AuxPop)		Line: 111, Column: 5
+0791:  AVMOpcode(Jump)		Line: 111, Column: 5
+0792:  AVMOpcode(AuxPush)		Line: 115, Column: 1
+0793:  [Tuple(_, _, _)] AVMOpcode(AuxPush)		Line: 115, Column: 1
+0794:  [0] AVMOpcode(Xset)		Line: 115, Column: 1
+0795:  [1] AVMOpcode(Xset)		Line: 115, Column: 1
+0796:  [0] AVMOpcode(Xget)		Line: 116, Column: 19
+0797:  [0] AVMOpcode(Tget)		Line: 116, Column: 19
+0798:  [1] AVMOpcode(Xget)		Line: 116, Column: 9
+0799:  AVMOpcode(LessThan)		Line: 116, Column: 9
+0800:  [CodePoint(Internal(805))] AVMOpcode(Cjump)		Line: 116, Column: 5
+0801:  [0] AVMOpcode(AuxPop)		Line: 117, Column: 9
+0802:  AVMOpcode(Pop)		Line: 117, Column: 9
+0803:  AVMOpcode(AuxPop)		Line: 117, Column: 9
+0804:  AVMOpcode(Jump)		Line: 117, Column: 9
+0805:  [0] AVMOpcode(Xget)		Line: 119, Column: 23
+0806:  [1] AVMOpcode(Tget)		Line: 119, Column: 23
+0807:  [1] AVMOpcode(Xget)		Line: 119, Column: 14
+0808:  AVMOpcode(Plus)		Line: 119, Column: 14
+0809:  [1] AVMOpcode(Xset)		Line: 119, Column: 5
+0810:  [32] AVMOpcode(Noop)		Line: 120, Column: 58
+0811:  [1] AVMOpcode(Xget)		Line: 120, Column: 51
+0812:  AVMOpcode(Div)		Line: 120, Column: 51
+0813:  [0] AVMOpcode(Xget)		Line: 120, Column: 38
+0814:  [2] AVMOpcode(Tget)		Line: 120, Column: 38
+0815:  [CodePoint(Internal(818))] AVMOpcode(PushStatic)		Line: 120, Column: 16
+0816:  [1] AVMOpcode(Tget)		Line: 120, Column: 16
+0817:  AVMOpcode(Jump)		Line: 120, Column: 16
+0818:  [2] AVMOpcode(Xset)		Line: 120, Column: 5
+0819:  [1] AVMOpcode(Xget)		Line: 121, Column: 35
+0820:  [31] AVMOpcode(BitwiseAnd)		Line: 121, Column: 35
+0821:  [31] AVMOpcode(Minus)		Line: 121, Column: 31
+0822:  [256] AVMOpcode(Exp)		Line: 121, Column: 58
+0823:  [2] AVMOpcode(Xget)		Line: 121, Column: 13
+0824:  AVMOpcode(Div)		Line: 121, Column: 13
+0825:  [255] AVMOpcode(BitwiseAnd)		Line: 121, Column: 12
+0826:  AVMOpcode(AuxPop)		Line: 121, Column: 5
+0827:  AVMOpcode(Pop)		Line: 121, Column: 5
+0828:  AVMOpcode(AuxPop)		Line: 121, Column: 5
+0829:  AVMOpcode(Jump)		Line: 121, Column: 5
+0830:  AVMOpcode(AuxPush)		Line: 125, Column: 1
+0831:  [Tuple(_, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 125, Column: 1
+0832:  [0] AVMOpcode(Xset)		Line: 125, Column: 1
+0833:  [1] AVMOpcode(Xset)		Line: 125, Column: 1
+0834:  [0] AVMOpcode(Xget)		Line: 126, Column: 19
+0835:  [0] AVMOpcode(Tget)		Line: 126, Column: 19
+0836:  [1] AVMOpcode(Xget)		Line: 126, Column: 9
+0837:  AVMOpcode(LessThan)		Line: 126, Column: 9
+0838:  [CodePoint(Internal(843))] AVMOpcode(Cjump)		Line: 126, Column: 5
+0839:  [0] AVMOpcode(AuxPop)		Line: 127, Column: 9
+0840:  AVMOpcode(Pop)		Line: 127, Column: 9
+0841:  AVMOpcode(AuxPop)		Line: 127, Column: 9
+0842:  AVMOpcode(Jump)		Line: 127, Column: 9
+0843:  [0] AVMOpcode(Noop)		Line: 129, Column: 23
+0844:  [2] AVMOpcode(Xset)		Line: 129, Column: 5
+0845:  [0] AVMOpcode(Xget)		Line: 130, Column: 20
+0846:  [0] AVMOpcode(Tget)		Line: 130, Column: 20
+0847:  [1] AVMOpcode(Xget)		Line: 130, Column: 9
+0848:  [8] AVMOpcode(Plus)		Line: 130, Column: 9
+0849:  AVMOpcode(GreaterThan)		Line: 130, Column: 9
+0850:  AVMOpcode(IsZero)		Line: 130, Column: 5
+0851:  [CodePoint(Internal(859))] AVMOpcode(Cjump)		Line: 130, Column: 5
+0852:  [0] AVMOpcode(Xget)		Line: 131, Column: 34
+0853:  [0] AVMOpcode(Tget)		Line: 131, Column: 34
+0854:  [1] AVMOpcode(Xget)		Line: 131, Column: 23
+0855:  [8] AVMOpcode(Plus)		Line: 131, Column: 23
+0856:  AVMOpcode(Minus)		Line: 131, Column: 23
+0857:  [2] AVMOpcode(Xset)		Line: 131, Column: 9
+0858:  [CodePoint(Internal(859))] AVMOpcode(Jump)		Line: 130, Column: 5
+0859:  [0] AVMOpcode(Xget)		Line: 136, Column: 23
+0860:  [1] AVMOpcode(Tget)		Line: 136, Column: 23
+0861:  [1] AVMOpcode(Xget)		Line: 136, Column: 14
+0862:  AVMOpcode(Plus)		Line: 136, Column: 14
+0863:  [1] AVMOpcode(Xset)		Line: 136, Column: 5
+0864:  [32] AVMOpcode(Noop)		Line: 137, Column: 30
+0865:  [1] AVMOpcode(Xget)		Line: 137, Column: 21
+0866:  AVMOpcode(Mod)		Line: 137, Column: 21
+0867:  [3] AVMOpcode(Xset)		Line: 137, Column: 5
+0868:  [3] AVMOpcode(Xget)		Line: 138, Column: 9
+0869:  [24] AVMOpcode(LessThan)		Line: 138, Column: 9
+0870:  [CodePoint(Internal(905))] AVMOpcode(Cjump)		Line: 138, Column: 5
+0871:  [32] AVMOpcode(Noop)		Line: 139, Column: 62
+0872:  [1] AVMOpcode(Xget)		Line: 139, Column: 55
+0873:  AVMOpcode(Div)		Line: 139, Column: 55
+0874:  [0] AVMOpcode(Xget)		Line: 139, Column: 42
+0875:  [2] AVMOpcode(Tget)		Line: 139, Column: 42
+0876:  [CodePoint(Internal(879))] AVMOpcode(PushStatic)		Line: 139, Column: 20
+0877:  [1] AVMOpcode(Tget)		Line: 139, Column: 20
+0878:  AVMOpcode(Jump)		Line: 139, Column: 20
+0879:  [4] AVMOpcode(Xset)		Line: 139, Column: 9
+0880:  [3] AVMOpcode(Xget)		Line: 140, Column: 39
+0881:  [24] AVMOpcode(Minus)		Line: 140, Column: 36
+0882:  [256] AVMOpcode(Exp)		Line: 140, Column: 57
+0883:  [4] AVMOpcode(Xget)		Line: 140, Column: 20
+0884:  AVMOpcode(Div)		Line: 140, Column: 20
+0885:  [0xffffffffffffffff] AVMOpcode(BitwiseAnd)		Line: 140, Column: 19
+0886:  [5] AVMOpcode(Xset)		Line: 140, Column: 9
+0887:  [2] AVMOpcode(Xget)		Line: 141, Column: 13
+0888:  [0] AVMOpcode(LessThan)		Line: 141, Column: 13
+0889:  AVMOpcode(IsZero)		Line: 141, Column: 9
+0890:  [CodePoint(Internal(900))] AVMOpcode(Cjump)		Line: 141, Column: 9
+0891:  [1] AVMOpcode(Noop)		Line: 142, Column: 66
+0892:  [2] AVMOpcode(Xget)		Line: 142, Column: 37
+0893:  [256] AVMOpcode(Exp)		Line: 142, Column: 57
+0894:  AVMOpcode(Minus)		Line: 142, Column: 27
+0895:  AVMOpcode(BitwiseNeg)		Line: 142, Column: 25
+0896:  [5] AVMOpcode(Xget)		Line: 142, Column: 19
+0897:  AVMOpcode(BitwiseAnd)		Line: 142, Column: 19
+0898:  [5] AVMOpcode(Xset)		Line: 142, Column: 13
+0899:  [CodePoint(Internal(900))] AVMOpcode(Jump)		Line: 141, Column: 9
+0900:  [5] AVMOpcode(Xget)		Line: 144, Column: 16
+0901:  AVMOpcode(AuxPop)		Line: 144, Column: 9
+0902:  AVMOpcode(Pop)		Line: 144, Column: 9
+0903:  AVMOpcode(AuxPop)		Line: 144, Column: 9
+0904:  AVMOpcode(Jump)		Line: 144, Column: 9
+0905:  [1] AVMOpcode(Xget)		Line: 146, Column: 40
+0906:  [0] AVMOpcode(Xget)		Line: 146, Column: 36
+0907:  [CodePoint(Internal(909))] AVMOpcode(Noop)		Line: 146, Column: 19
+0908:  [CodePoint(Internal(932))] AVMOpcode(Jump)		Line: 146, Column: 19
+0909:  [4] AVMOpcode(Xset)		Line: 146, Column: 9
+0910:  [0x1000000000000000000000000000000000000000000000000] AVMOpcode(Noop)		Line: 147, Column: 25
+0911:  [4] AVMOpcode(Xget)		Line: 147, Column: 19
+0912:  AVMOpcode(Div)		Line: 147, Column: 19
+0913:  [5] AVMOpcode(Xset)		Line: 147, Column: 9
+0914:  [2] AVMOpcode(Xget)		Line: 148, Column: 13
+0915:  [0] AVMOpcode(LessThan)		Line: 148, Column: 13
+0916:  AVMOpcode(IsZero)		Line: 148, Column: 9
+0917:  [CodePoint(Internal(927))] AVMOpcode(Cjump)		Line: 148, Column: 9
+0918:  [1] AVMOpcode(Noop)		Line: 149, Column: 66
+0919:  [2] AVMOpcode(Xget)		Line: 149, Column: 37
+0920:  [256] AVMOpcode(Exp)		Line: 149, Column: 57
+0921:  AVMOpcode(Minus)		Line: 149, Column: 27
+0922:  AVMOpcode(BitwiseNeg)		Line: 149, Column: 25
+0923:  [5] AVMOpcode(Xget)		Line: 149, Column: 19
+0924:  AVMOpcode(BitwiseAnd)		Line: 149, Column: 19
+0925:  [5] AVMOpcode(Xset)		Line: 149, Column: 13
+0926:  [CodePoint(Internal(927))] AVMOpcode(Jump)		Line: 148, Column: 9
+0927:  [5] AVMOpcode(Xget)		Line: 151, Column: 16
+0928:  AVMOpcode(AuxPop)		Line: 151, Column: 9
+0929:  AVMOpcode(Pop)		Line: 151, Column: 9
+0930:  AVMOpcode(AuxPop)		Line: 151, Column: 9
+0931:  AVMOpcode(Jump)		Line: 151, Column: 9
+0932:  AVMOpcode(AuxPush)		Line: 156, Column: 1
+0933:  [Tuple(_, _, _, _, _, _, _, Tuple(_, _, _))] AVMOpcode(AuxPush)		Line: 156, Column: 1
+0934:  [0] AVMOpcode(Xset)		Line: 156, Column: 1
+0935:  [1] AVMOpcode(Xset)		Line: 156, Column: 1
+0936:  [0] AVMOpcode(Noop)		Line: 157, Column: 23
+0937:  [2] AVMOpcode(Xset)		Line: 157, Column: 5
+0938:  [0] AVMOpcode(Xget)		Line: 158, Column: 21
+0939:  [0] AVMOpcode(Tget)		Line: 158, Column: 21
+0940:  [1] AVMOpcode(Xget)		Line: 158, Column: 9
+0941:  [32] AVMOpcode(Plus)		Line: 158, Column: 9
+0942:  AVMOpcode(GreaterThan)		Line: 158, Column: 9
+0943:  AVMOpcode(IsZero)		Line: 158, Column: 5
+0944:  [CodePoint(Internal(952))] AVMOpcode(Cjump)		Line: 158, Column: 5
+0945:  [0] AVMOpcode(Xget)		Line: 159, Column: 35
+0946:  [0] AVMOpcode(Tget)		Line: 159, Column: 35
+0947:  [1] AVMOpcode(Xget)		Line: 159, Column: 23
+0948:  [32] AVMOpcode(Plus)		Line: 159, Column: 23
+0949:  AVMOpcode(Minus)		Line: 159, Column: 23
+0950:  [2] AVMOpcode(Xset)		Line: 159, Column: 9
+0951:  [CodePoint(Internal(952))] AVMOpcode(Jump)		Line: 158, Column: 5
+0952:  [0] AVMOpcode(Xget)		Line: 161, Column: 23
+0953:  [1] AVMOpcode(Tget)		Line: 161, Column: 23
+0954:  [1] AVMOpcode(Xget)		Line: 161, Column: 14
+0955:  AVMOpcode(Plus)		Line: 161, Column: 14
+0956:  [1] AVMOpcode(Xset)		Line: 161, Column: 5
+0957:  [32] AVMOpcode(Noop)		Line: 162, Column: 33
+0958:  [1] AVMOpcode(Xget)		Line: 162, Column: 24
+0959:  AVMOpcode(Div)		Line: 162, Column: 24
+0960:  [3] AVMOpcode(Xset)		Line: 162, Column: 5
+0961:  [32] AVMOpcode(Noop)		Line: 163, Column: 30
+0962:  [1] AVMOpcode(Xget)		Line: 163, Column: 21
+0963:  AVMOpcode(Mod)		Line: 163, Column: 21
+0964:  [4] AVMOpcode(Xset)		Line: 163, Column: 5
+0965:  [4] AVMOpcode(Xget)		Line: 164, Column: 9
+0966:  [0] AVMOpcode(Equal)		Line: 164, Column: 9
+0967:  AVMOpcode(IsZero)		Line: 164, Column: 5
+0968:  [CodePoint(Internal(994))] AVMOpcode(Cjump)		Line: 164, Column: 5
+0969:  [3] AVMOpcode(Xget)		Line: 165, Column: 54
+0970:  [0] AVMOpcode(Xget)		Line: 165, Column: 41
+0971:  [2] AVMOpcode(Tget)		Line: 165, Column: 41
+0972:  [CodePoint(Internal(975))] AVMOpcode(PushStatic)		Line: 165, Column: 19
+0973:  [1] AVMOpcode(Tget)		Line: 165, Column: 19
+0974:  AVMOpcode(Jump)		Line: 165, Column: 19
+0975:  [5] AVMOpcode(Xset)		Line: 165, Column: 9
+0976:  [2] AVMOpcode(Xget)		Line: 166, Column: 13
+0977:  [0] AVMOpcode(LessThan)		Line: 166, Column: 13
+0978:  AVMOpcode(IsZero)		Line: 166, Column: 9
+0979:  [CodePoint(Internal(989))] AVMOpcode(Cjump)		Line: 166, Column: 9
+0980:  [1] AVMOpcode(Noop)		Line: 167, Column: 66
+0981:  [2] AVMOpcode(Xget)		Line: 167, Column: 37
+0982:  [256] AVMOpcode(Exp)		Line: 167, Column: 57
+0983:  AVMOpcode(Minus)		Line: 167, Column: 27
+0984:  AVMOpcode(BitwiseNeg)		Line: 167, Column: 25
+0985:  [5] AVMOpcode(Xget)		Line: 167, Column: 19
+0986:  AVMOpcode(BitwiseAnd)		Line: 167, Column: 19
+0987:  [5] AVMOpcode(Xset)		Line: 167, Column: 13
+0988:  [CodePoint(Internal(989))] AVMOpcode(Jump)		Line: 166, Column: 9
+0989:  [5] AVMOpcode(Xget)		Line: 169, Column: 16
+0990:  AVMOpcode(AuxPop)		Line: 169, Column: 9
+0991:  AVMOpcode(Pop)		Line: 169, Column: 9
+0992:  AVMOpcode(AuxPop)		Line: 169, Column: 9
+0993:  AVMOpcode(Jump)		Line: 169, Column: 9
+0994:  [3] AVMOpcode(Xget)		Line: 171, Column: 79
+0995:  [0] AVMOpcode(Xget)		Line: 171, Column: 66
+0996:  [2] AVMOpcode(Tget)		Line: 171, Column: 66
+0997:  [CodePoint(Internal(999))] AVMOpcode(Noop)		Line: 171, Column: 33
+0998:  [CodePoint(Internal(1049))] AVMOpcode(Jump)		Line: 171, Column: 33
+0999:  AVMOpcode(Dup0)		Line: 171, Column: 9
+1000:  [0] AVMOpcode(Tget)		Line: 171, Column: 9
+1001:  [5] AVMOpcode(Xset)		Line: 171, Column: 9
+1002:  [1] AVMOpcode(Tget)		Line: 171, Column: 9
+1003:  [6] AVMOpcode(Xset)		Line: 171, Column: 9
+1004:  [4] AVMOpcode(Xget)		Line: 172, Column: 36
+1005:  [256] AVMOpcode(Exp)		Line: 172, Column: 54
+1006:  [7] AVMOpcode(Xget)		Line: 172, Column: 9
+1007:  [0] AVMOpcode(Tset)		Line: 172, Column: 9
+1008:  [7] AVMOpcode(Xset)		Line: 172, Column: 9
+1009:  [4] AVMOpcode(Xget)		Line: 173, Column: 42
+1010:  [32] AVMOpcode(Minus)		Line: 173, Column: 39
+1011:  [256] AVMOpcode(Exp)		Line: 173, Column: 60
+1012:  [7] AVMOpcode(Xget)		Line: 173, Column: 9
+1013:  [1] AVMOpcode(Tset)		Line: 173, Column: 9
+1014:  [7] AVMOpcode(Xset)		Line: 173, Column: 9
+1015:  [7] AVMOpcode(Xget)		Line: 174, Column: 54
+1016:  [0] AVMOpcode(Tget)		Line: 174, Column: 54
+1017:  [5] AVMOpcode(Xget)		Line: 174, Column: 46
+1018:  AVMOpcode(Mul)		Line: 174, Column: 46
+1019:  [7] AVMOpcode(Xget)		Line: 174, Column: 27
+1020:  [1] AVMOpcode(Tget)		Line: 174, Column: 27
+1021:  [6] AVMOpcode(Xget)		Line: 174, Column: 20
+1022:  AVMOpcode(Div)		Line: 174, Column: 20
+1023:  AVMOpcode(BitwiseOr)		Line: 174, Column: 19
+1024:  [7] AVMOpcode(Xget)		Line: 174, Column: 9
+1025:  [2] AVMOpcode(Tset)		Line: 174, Column: 9
+1026:  [7] AVMOpcode(Xset)		Line: 174, Column: 9
+1027:  [2] AVMOpcode(Xget)		Line: 175, Column: 13
+1028:  [0] AVMOpcode(LessThan)		Line: 175, Column: 13
+1029:  AVMOpcode(IsZero)		Line: 175, Column: 9
+1030:  [CodePoint(Internal(1043))] AVMOpcode(Cjump)		Line: 175, Column: 9
+1031:  [1] AVMOpcode(Noop)		Line: 176, Column: 66
+1032:  [2] AVMOpcode(Xget)		Line: 176, Column: 37
+1033:  [256] AVMOpcode(Exp)		Line: 176, Column: 57
+1034:  AVMOpcode(Minus)		Line: 176, Column: 27
+1035:  AVMOpcode(BitwiseNeg)		Line: 176, Column: 25
+1036:  [7] AVMOpcode(Xget)		Line: 176, Column: 19
+1037:  [2] AVMOpcode(Tget)		Line: 176, Column: 19
+1038:  AVMOpcode(BitwiseAnd)		Line: 176, Column: 19
+1039:  [7] AVMOpcode(Xget)		Line: 176, Column: 13
+1040:  [2] AVMOpcode(Tset)		Line: 176, Column: 13
+1041:  [7] AVMOpcode(Xset)		Line: 176, Column: 13
+1042:  [CodePoint(Internal(1043))] AVMOpcode(Jump)		Line: 175, Column: 9
+1043:  [7] AVMOpcode(Xget)		Line: 178, Column: 16
+1044:  [2] AVMOpcode(Tget)		Line: 178, Column: 16
+1045:  AVMOpcode(AuxPop)		Line: 178, Column: 9
+1046:  AVMOpcode(Pop)		Line: 178, Column: 9
+1047:  AVMOpcode(AuxPop)		Line: 178, Column: 9
+1048:  AVMOpcode(Jump)		Line: 178, Column: 9
+1049:  AVMOpcode(AuxPush)		Line: 374, Column: 1
+1050:  [Tuple(_, _)] AVMOpcode(AuxPush)		Line: 374, Column: 1
+1051:  [0] AVMOpcode(Xset)		Line: 374, Column: 1
+1052:  [1] AVMOpcode(Xset)		Line: 374, Column: 1
+1053:  [1] AVMOpcode(Xget)		Line: 378, Column: 36
+1054:  [1] AVMOpcode(Plus)		Line: 378, Column: 36
+1055:  [0] AVMOpcode(Xget)		Line: 378, Column: 31
+1056:  [CodePoint(Internal(1059))] AVMOpcode(PushStatic)		Line: 378, Column: 9
+1057:  [1] AVMOpcode(Tget)		Line: 378, Column: 9
+1058:  AVMOpcode(Jump)		Line: 378, Column: 9
+1059:  [1] AVMOpcode(Xget)		Line: 377, Column: 36
+1060:  [0] AVMOpcode(Xget)		Line: 377, Column: 31
+1061:  [CodePoint(Internal(1064))] AVMOpcode(PushStatic)		Line: 377, Column: 9
+1062:  [1] AVMOpcode(Tget)		Line: 377, Column: 9
+1063:  AVMOpcode(Jump)		Line: 377, Column: 9
+1064:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 376, Column: 12
+1065:  [0] AVMOpcode(Tset)		Line: 376, Column: 12
+1066:  [1] AVMOpcode(Tset)		Line: 376, Column: 12
+1067:  AVMOpcode(AuxPop)		Line: 376, Column: 5
+1068:  AVMOpcode(Pop)		Line: 376, Column: 5
+1069:  AVMOpcode(AuxPop)		Line: 376, Column: 5
+1070:  AVMOpcode(Jump)		Line: 376, Column: 5
+1071:  AVMOpcode(AuxPush)		Line: 183, Column: 1
+1072:  [Tuple(_, _, _, _, _)] AVMOpcode(AuxPush)		Line: 183, Column: 1
+1073:  [0] AVMOpcode(Xset)		Line: 183, Column: 1
+1074:  [1] AVMOpcode(Xset)		Line: 183, Column: 1
+1075:  [2] AVMOpcode(Xset)		Line: 183, Column: 1
+1076:  [0] AVMOpcode(Xget)		Line: 184, Column: 19
+1077:  [0] AVMOpcode(Tget)		Line: 184, Column: 19
+1078:  [1] AVMOpcode(Xget)		Line: 184, Column: 9
+1079:  AVMOpcode(LessThan)		Line: 184, Column: 9
+1080:  [CodePoint(Internal(1087))] AVMOpcode(Cjump)		Line: 184, Column: 5
+1081:  [1] AVMOpcode(Xget)		Line: 185, Column: 30
+1082:  [1] AVMOpcode(Plus)		Line: 185, Column: 30
+1083:  [0] AVMOpcode(Xget)		Line: 185, Column: 14
+1084:  [0] AVMOpcode(Tset)		Line: 185, Column: 14
+1085:  [0] AVMOpcode(Xset)		Line: 185, Column: 9
+1086:  [CodePoint(Internal(1087))] AVMOpcode(Jump)		Line: 184, Column: 5
+1087:  [0] AVMOpcode(Xget)		Line: 187, Column: 23
+1088:  [1] AVMOpcode(Tget)		Line: 187, Column: 23
+1089:  [1] AVMOpcode(Xget)		Line: 187, Column: 14
+1090:  AVMOpcode(Plus)		Line: 187, Column: 14
+1091:  [1] AVMOpcode(Xset)		Line: 187, Column: 5
+1092:  [2] AVMOpcode(Xget)		Line: 193, Column: 35
+1093:  [32] AVMOpcode(Noop)		Line: 193, Column: 30
+1094:  [1] AVMOpcode(Xget)		Line: 193, Column: 23
+1095:  AVMOpcode(Mod)		Line: 193, Column: 23
+1096:  [31] AVMOpcode(Minus)		Line: 193, Column: 19
+1097:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 193, Column: 18
+1098:  [0] AVMOpcode(Tset)		Line: 193, Column: 18
+1099:  [1] AVMOpcode(Tset)		Line: 193, Column: 18
+1100:  [CodePoint(Internal(1165))] AVMOpcode(Noop)		Line: 192, Column: 42
+1101:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 191, Column: 9
+1102:  [0] AVMOpcode(Tset)		Line: 191, Column: 9
+1103:  [1] AVMOpcode(Tset)		Line: 191, Column: 9
+1104:  [32] AVMOpcode(Noop)		Line: 190, Column: 16
+1105:  [1] AVMOpcode(Xget)		Line: 190, Column: 9
+1106:  AVMOpcode(Div)		Line: 190, Column: 9
+1107:  [0] AVMOpcode(Xget)		Line: 189, Column: 9
+1108:  [2] AVMOpcode(Tget)		Line: 189, Column: 9
+1109:  [CodePoint(Internal(1111))] AVMOpcode(Noop)		Line: 188, Column: 28
+1110:  [CodePoint(Internal(1123))] AVMOpcode(Jump)		Line: 188, Column: 28
+1111:  AVMOpcode(Dup0)		Line: 188, Column: 5
+1112:  [0] AVMOpcode(Tget)		Line: 188, Column: 5
+1113:  [3] AVMOpcode(Xset)		Line: 188, Column: 5
+1114:  [1] AVMOpcode(Tget)		Line: 188, Column: 5
+1115:  [4] AVMOpcode(Xset)		Line: 188, Column: 5
+1116:  [3] AVMOpcode(Xget)		Line: 196, Column: 32
+1117:  [0] AVMOpcode(Xget)		Line: 196, Column: 12
+1118:  [2] AVMOpcode(Tset)		Line: 196, Column: 12
+1119:  AVMOpcode(AuxPop)		Line: 196, Column: 5
+1120:  AVMOpcode(Pop)		Line: 196, Column: 5
+1121:  AVMOpcode(AuxPop)		Line: 196, Column: 5
+1122:  AVMOpcode(Jump)		Line: 196, Column: 5
+1123:  AVMOpcode(AuxPush)		Line: 408, Column: 1
+1124:  [Tuple(_, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 408, Column: 1
+1125:  [0] AVMOpcode(Xset)		Line: 408, Column: 1
+1126:  [1] AVMOpcode(Xset)		Line: 408, Column: 1
+1127:  [2] AVMOpcode(Xset)		Line: 408, Column: 1
+1128:  [CodePoint(Internal(1131))] AVMOpcode(Noop)		Line: 413, Column: 5
+1129:  [3] AVMOpcode(Xset)		Line: 413, Column: 5
+1130:  [CodePoint(Internal(1135))] AVMOpcode(Jump)		Line: 413, Column: 5
+1131:  [0] AVMOpcode(Xget)		Line: 414, Column: 38
+1132:  [CodePoint(Internal(1134))] AVMOpcode(Noop)		Line: 414, Column: 15
+1133:  [CodePoint(Internal(1644))] AVMOpcode(Jump)		Line: 414, Column: 15
+1134:  [0] AVMOpcode(Xset)		Line: 414, Column: 9
+1135:  [0] AVMOpcode(Xget)		Line: 413, Column: 20
+1136:  [0] AVMOpcode(Tget)		Line: 413, Column: 20
+1137:  [1] AVMOpcode(Xget)		Line: 413, Column: 12
+1138:  AVMOpcode(GreaterThan)		Line: 413, Column: 12
+1139:  [3] AVMOpcode(Xget)		Line: 413, Column: 5
+1140:  AVMOpcode(Cjump)		Line: 413, Column: 5
+1141:  [2] AVMOpcode(Xget)		Line: 416, Column: 66
+1142:  [1] AVMOpcode(Xget)		Line: 416, Column: 59
+1143:  [0] AVMOpcode(Xget)		Line: 416, Column: 48
+1144:  [1] AVMOpcode(Tget)		Line: 416, Column: 48
+1145:  [0] AVMOpcode(Xget)		Line: 416, Column: 34
+1146:  [2] AVMOpcode(Tget)		Line: 416, Column: 34
+1147:  [CodePoint(Internal(1149))] AVMOpcode(Noop)		Line: 416, Column: 26
+1148:  [CodePoint(Internal(1755))] AVMOpcode(Jump)		Line: 416, Column: 26
+1149:  AVMOpcode(Dup0)		Line: 416, Column: 5
+1150:  [0] AVMOpcode(Tget)		Line: 416, Column: 5
+1151:  [4] AVMOpcode(Xset)		Line: 416, Column: 5
+1152:  [1] AVMOpcode(Tget)		Line: 416, Column: 5
+1153:  [5] AVMOpcode(Xset)		Line: 416, Column: 5
+1154:  [5] AVMOpcode(Xget)		Line: 419, Column: 9
+1155:  [4] AVMOpcode(Xget)		Line: 418, Column: 30
+1156:  [0] AVMOpcode(Xget)		Line: 418, Column: 9
+1157:  [2] AVMOpcode(Tset)		Line: 418, Column: 9
+1158:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 417, Column: 12
+1159:  [0] AVMOpcode(Tset)		Line: 417, Column: 12
+1160:  [1] AVMOpcode(Tset)		Line: 417, Column: 12
+1161:  AVMOpcode(AuxPop)		Line: 417, Column: 5
+1162:  AVMOpcode(Pop)		Line: 417, Column: 5
+1163:  AVMOpcode(AuxPop)		Line: 417, Column: 5
+1164:  AVMOpcode(Jump)		Line: 417, Column: 5
+1165:  AVMOpcode(AuxPush)		Line: 298, Column: 1
+1166:  [Tuple(_, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 298, Column: 1
+1167:  [0] AVMOpcode(Xset)		Line: 298, Column: 1
+1168:  [1] AVMOpcode(Xset)		Line: 298, Column: 1
+1169:  [0] AVMOpcode(Xget)		Line: 299, Column: 30
+1170:  AVMOpcode(Dup0)		Line: 299, Column: 5
+1171:  [0] AVMOpcode(Tget)		Line: 299, Column: 5
+1172:  [2] AVMOpcode(Xset)		Line: 299, Column: 5
+1173:  [1] AVMOpcode(Tget)		Line: 299, Column: 5
+1174:  [3] AVMOpcode(Xset)		Line: 299, Column: 5
+1175:  [2] AVMOpcode(Xget)		Line: 300, Column: 30
+1176:  [8] AVMOpcode(Mul)		Line: 300, Column: 28
+1177:  [2] AVMOpcode(Exp)		Line: 300, Column: 45
+1178:  [4] AVMOpcode(Xset)		Line: 300, Column: 5
+1179:  [4] AVMOpcode(Xget)		Line: 301, Column: 23
+1180:  [255] AVMOpcode(Mul)		Line: 301, Column: 16
+1181:  [5] AVMOpcode(Xset)		Line: 301, Column: 5
+1182:  [4] AVMOpcode(Xget)		Line: 302, Column: 38
+1183:  [3] AVMOpcode(Xget)		Line: 302, Column: 20
+1184:  [255] AVMOpcode(BitwiseAnd)		Line: 302, Column: 20
+1185:  AVMOpcode(Mul)		Line: 302, Column: 19
+1186:  [6] AVMOpcode(Xset)		Line: 302, Column: 5
+1187:  [0] AVMOpcode(Noop)		Line: 305, Column: 9
+1188:  [6] AVMOpcode(Xget)		Line: 304, Column: 28
+1189:  [5] AVMOpcode(Xget)		Line: 304, Column: 20
+1190:  AVMOpcode(BitwiseNeg)		Line: 304, Column: 19
+1191:  [1] AVMOpcode(Xget)		Line: 304, Column: 10
+1192:  AVMOpcode(BitwiseAnd)		Line: 304, Column: 10
+1193:  AVMOpcode(BitwiseOr)		Line: 304, Column: 9
+1194:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 303, Column: 12
+1195:  [0] AVMOpcode(Tset)		Line: 303, Column: 12
+1196:  [1] AVMOpcode(Tset)		Line: 303, Column: 12
+1197:  AVMOpcode(AuxPop)		Line: 303, Column: 5
+1198:  AVMOpcode(Pop)		Line: 303, Column: 5
+1199:  AVMOpcode(AuxPop)		Line: 303, Column: 5
+1200:  AVMOpcode(Jump)		Line: 303, Column: 5
+1201:  AVMOpcode(AuxPush)		Line: 200, Column: 1
+1202:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 200, Column: 1
+1203:  [0] AVMOpcode(Xset)		Line: 200, Column: 1
+1204:  [1] AVMOpcode(Xset)		Line: 200, Column: 1
+1205:  [2] AVMOpcode(Xset)		Line: 200, Column: 1
+1206:  [0] AVMOpcode(Xget)		Line: 201, Column: 20
+1207:  [0] AVMOpcode(Tget)		Line: 201, Column: 20
+1208:  [1] AVMOpcode(Xget)		Line: 201, Column: 9
+1209:  [8] AVMOpcode(Plus)		Line: 201, Column: 9
+1210:  AVMOpcode(GreaterThan)		Line: 201, Column: 9
+1211:  AVMOpcode(IsZero)		Line: 201, Column: 5
+1212:  [CodePoint(Internal(1219))] AVMOpcode(Cjump)		Line: 201, Column: 5
+1213:  [1] AVMOpcode(Xget)		Line: 202, Column: 30
+1214:  [8] AVMOpcode(Plus)		Line: 202, Column: 30
+1215:  [0] AVMOpcode(Xget)		Line: 202, Column: 14
+1216:  [0] AVMOpcode(Tset)		Line: 202, Column: 14
+1217:  [0] AVMOpcode(Xset)		Line: 202, Column: 9
+1218:  [CodePoint(Internal(1219))] AVMOpcode(Jump)		Line: 201, Column: 5
+1219:  [0] AVMOpcode(Xget)		Line: 204, Column: 23
+1220:  [1] AVMOpcode(Tget)		Line: 204, Column: 23
+1221:  [1] AVMOpcode(Xget)		Line: 204, Column: 14
+1222:  AVMOpcode(Plus)		Line: 204, Column: 14
+1223:  [1] AVMOpcode(Xset)		Line: 204, Column: 5
+1224:  [32] AVMOpcode(Noop)		Line: 205, Column: 33
+1225:  [1] AVMOpcode(Xget)		Line: 205, Column: 24
+1226:  AVMOpcode(Div)		Line: 205, Column: 24
+1227:  [3] AVMOpcode(Xset)		Line: 205, Column: 5
+1228:  [32] AVMOpcode(Noop)		Line: 206, Column: 30
+1229:  [1] AVMOpcode(Xget)		Line: 206, Column: 21
+1230:  AVMOpcode(Mod)		Line: 206, Column: 21
+1231:  [4] AVMOpcode(Xset)		Line: 206, Column: 5
+1232:  [4] AVMOpcode(Xget)		Line: 207, Column: 9
+1233:  [24] AVMOpcode(LessThan)		Line: 207, Column: 9
+1234:  [CodePoint(Internal(1263))] AVMOpcode(Cjump)		Line: 207, Column: 5
+1235:  [2] AVMOpcode(Xget)		Line: 213, Column: 34
+1236:  [4] AVMOpcode(Xget)		Line: 213, Column: 23
+1237:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 213, Column: 22
+1238:  [0] AVMOpcode(Tset)		Line: 213, Column: 22
+1239:  [1] AVMOpcode(Tset)		Line: 213, Column: 22
+1240:  [CodePoint(Internal(1301))] AVMOpcode(Noop)		Line: 212, Column: 46
+1241:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 211, Column: 13
+1242:  [0] AVMOpcode(Tset)		Line: 211, Column: 13
+1243:  [1] AVMOpcode(Tset)		Line: 211, Column: 13
+1244:  [3] AVMOpcode(Xget)		Line: 210, Column: 13
+1245:  [0] AVMOpcode(Xget)		Line: 209, Column: 13
+1246:  [2] AVMOpcode(Tget)		Line: 209, Column: 13
+1247:  [CodePoint(Internal(1251))] AVMOpcode(PushStatic)		Line: 208, Column: 32
+1248:  [2] AVMOpcode(Tget)		Line: 208, Column: 32
+1249:  [0] AVMOpcode(Tget)		Line: 208, Column: 32
+1250:  AVMOpcode(Jump)		Line: 208, Column: 32
+1251:  AVMOpcode(Dup0)		Line: 208, Column: 9
+1252:  [0] AVMOpcode(Tget)		Line: 208, Column: 9
+1253:  [5] AVMOpcode(Xset)		Line: 208, Column: 9
+1254:  [1] AVMOpcode(Tget)		Line: 208, Column: 9
+1255:  [6] AVMOpcode(Xset)		Line: 208, Column: 9
+1256:  [5] AVMOpcode(Xget)		Line: 216, Column: 36
+1257:  [0] AVMOpcode(Xget)		Line: 216, Column: 16
+1258:  [2] AVMOpcode(Tset)		Line: 216, Column: 16
+1259:  AVMOpcode(AuxPop)		Line: 216, Column: 9
+1260:  AVMOpcode(Pop)		Line: 216, Column: 9
+1261:  AVMOpcode(AuxPop)		Line: 216, Column: 9
+1262:  AVMOpcode(Jump)		Line: 216, Column: 9
+1263:  [2] AVMOpcode(Xget)		Line: 227, Column: 34
+1264:  [4] AVMOpcode(Xget)		Line: 227, Column: 23
+1265:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 227, Column: 22
+1266:  [0] AVMOpcode(Tset)		Line: 227, Column: 22
+1267:  [1] AVMOpcode(Tset)		Line: 227, Column: 22
+1268:  [CodePoint(Internal(1437))] AVMOpcode(Noop)		Line: 226, Column: 46
+1269:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 225, Column: 13
+1270:  [0] AVMOpcode(Tset)		Line: 225, Column: 13
+1271:  [1] AVMOpcode(Tset)		Line: 225, Column: 13
+1272:  [2] AVMOpcode(Xget)		Line: 223, Column: 34
+1273:  [4] AVMOpcode(Xget)		Line: 223, Column: 23
+1274:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 223, Column: 22
+1275:  [0] AVMOpcode(Tset)		Line: 223, Column: 22
+1276:  [1] AVMOpcode(Tset)		Line: 223, Column: 22
+1277:  [CodePoint(Internal(1398))] AVMOpcode(Noop)		Line: 222, Column: 46
+1278:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 221, Column: 13
+1279:  [0] AVMOpcode(Tset)		Line: 221, Column: 13
+1280:  [1] AVMOpcode(Tset)		Line: 221, Column: 13
+1281:  [3] AVMOpcode(Xget)		Line: 220, Column: 13
+1282:  [0] AVMOpcode(Xget)		Line: 219, Column: 13
+1283:  [2] AVMOpcode(Tget)		Line: 219, Column: 13
+1284:  [CodePoint(Internal(1286))] AVMOpcode(Noop)		Line: 218, Column: 37
+1285:  [CodePoint(Internal(1337))] AVMOpcode(Jump)		Line: 218, Column: 37
+1286:  AVMOpcode(Dup0)		Line: 218, Column: 9
+1287:  [0] AVMOpcode(Tget)		Line: 218, Column: 9
+1288:  [5] AVMOpcode(Xset)		Line: 218, Column: 9
+1289:  AVMOpcode(Dup0)		Line: 218, Column: 9
+1290:  [1] AVMOpcode(Tget)		Line: 218, Column: 9
+1291:  [6] AVMOpcode(Xset)		Line: 218, Column: 9
+1292:  [2] AVMOpcode(Tget)		Line: 218, Column: 9
+1293:  [7] AVMOpcode(Xset)		Line: 218, Column: 9
+1294:  [5] AVMOpcode(Xget)		Line: 230, Column: 36
+1295:  [0] AVMOpcode(Xget)		Line: 230, Column: 16
+1296:  [2] AVMOpcode(Tset)		Line: 230, Column: 16
+1297:  AVMOpcode(AuxPop)		Line: 230, Column: 9
+1298:  AVMOpcode(Pop)		Line: 230, Column: 9
+1299:  AVMOpcode(AuxPop)		Line: 230, Column: 9
+1300:  AVMOpcode(Jump)		Line: 230, Column: 9
+1301:  AVMOpcode(AuxPush)		Line: 309, Column: 1
+1302:  [Tuple(_, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 309, Column: 1
+1303:  [0] AVMOpcode(Xset)		Line: 309, Column: 1
+1304:  [1] AVMOpcode(Xset)		Line: 309, Column: 1
+1305:  [0] AVMOpcode(Xget)		Line: 310, Column: 30
+1306:  AVMOpcode(Dup0)		Line: 310, Column: 5
+1307:  [0] AVMOpcode(Tget)		Line: 310, Column: 5
+1308:  [2] AVMOpcode(Xset)		Line: 310, Column: 5
+1309:  [1] AVMOpcode(Tget)		Line: 310, Column: 5
+1310:  [3] AVMOpcode(Xset)		Line: 310, Column: 5
+1311:  [2] AVMOpcode(Xget)		Line: 311, Column: 30
+1312:  [8] AVMOpcode(Mul)		Line: 311, Column: 28
+1313:  [2] AVMOpcode(Exp)		Line: 311, Column: 45
+1314:  [4] AVMOpcode(Xset)		Line: 311, Column: 5
+1315:  [4] AVMOpcode(Xget)		Line: 312, Column: 37
+1316:  [0xffffffffffffffff] AVMOpcode(Mul)		Line: 312, Column: 16
+1317:  [5] AVMOpcode(Xset)		Line: 312, Column: 5
+1318:  [4] AVMOpcode(Xget)		Line: 313, Column: 38
+1319:  [3] AVMOpcode(Xget)		Line: 313, Column: 20
+1320:  [255] AVMOpcode(BitwiseAnd)		Line: 313, Column: 20
+1321:  AVMOpcode(Mul)		Line: 313, Column: 19
+1322:  [6] AVMOpcode(Xset)		Line: 313, Column: 5
+1323:  [0] AVMOpcode(Noop)		Line: 316, Column: 9
+1324:  [6] AVMOpcode(Xget)		Line: 315, Column: 28
+1325:  [5] AVMOpcode(Xget)		Line: 315, Column: 20
+1326:  AVMOpcode(BitwiseNeg)		Line: 315, Column: 19
+1327:  [1] AVMOpcode(Xget)		Line: 315, Column: 10
+1328:  AVMOpcode(BitwiseAnd)		Line: 315, Column: 10
+1329:  AVMOpcode(BitwiseOr)		Line: 315, Column: 9
+1330:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 314, Column: 12
+1331:  [0] AVMOpcode(Tset)		Line: 314, Column: 12
+1332:  [1] AVMOpcode(Tset)		Line: 314, Column: 12
+1333:  AVMOpcode(AuxPop)		Line: 314, Column: 5
+1334:  AVMOpcode(Pop)		Line: 314, Column: 5
+1335:  AVMOpcode(AuxPop)		Line: 314, Column: 5
+1336:  AVMOpcode(Jump)		Line: 314, Column: 5
+1337:  AVMOpcode(AuxPush)		Line: 450, Column: 1
+1338:  [Tuple(_, _, _, _, _, _, _, Tuple(_, _))] AVMOpcode(AuxPush)		Line: 450, Column: 1
+1339:  [0] AVMOpcode(Xset)		Line: 450, Column: 1
+1340:  [1] AVMOpcode(Xset)		Line: 450, Column: 1
+1341:  [2] AVMOpcode(Xset)		Line: 450, Column: 1
+1342:  [3] AVMOpcode(Xset)		Line: 450, Column: 1
+1343:  [CodePoint(Internal(1346))] AVMOpcode(Noop)		Line: 457, Column: 5
+1344:  [4] AVMOpcode(Xset)		Line: 457, Column: 5
+1345:  [CodePoint(Internal(1350))] AVMOpcode(Jump)		Line: 457, Column: 5
+1346:  [0] AVMOpcode(Xget)		Line: 458, Column: 38
+1347:  [CodePoint(Internal(1349))] AVMOpcode(Noop)		Line: 458, Column: 15
+1348:  [CodePoint(Internal(1644))] AVMOpcode(Jump)		Line: 458, Column: 15
+1349:  [0] AVMOpcode(Xset)		Line: 458, Column: 9
+1350:  [0] AVMOpcode(Xget)		Line: 457, Column: 20
+1351:  [0] AVMOpcode(Tget)		Line: 457, Column: 20
+1352:  [1] AVMOpcode(Xget)		Line: 457, Column: 12
+1353:  AVMOpcode(GreaterThan)		Line: 457, Column: 12
+1354:  [4] AVMOpcode(Xget)		Line: 457, Column: 5
+1355:  AVMOpcode(Cjump)		Line: 457, Column: 5
+1356:  [2] AVMOpcode(Xget)		Line: 460, Column: 57
+1357:  [1] AVMOpcode(Xget)		Line: 460, Column: 50
+1358:  [0] AVMOpcode(Xget)		Line: 460, Column: 45
+1359:  [CodePoint(Internal(1363))] AVMOpcode(PushStatic)		Line: 460, Column: 24
+1360:  [2] AVMOpcode(Tget)		Line: 460, Column: 24
+1361:  [0] AVMOpcode(Tget)		Line: 460, Column: 24
+1362:  AVMOpcode(Jump)		Line: 460, Column: 24
+1363:  AVMOpcode(Dup0)		Line: 460, Column: 5
+1364:  [0] AVMOpcode(Tget)		Line: 460, Column: 5
+1365:  [5] AVMOpcode(Xset)		Line: 460, Column: 5
+1366:  [1] AVMOpcode(Tget)		Line: 460, Column: 5
+1367:  [6] AVMOpcode(Xset)		Line: 460, Column: 5
+1368:  [3] AVMOpcode(Xget)		Line: 461, Column: 60
+1369:  [1] AVMOpcode(Xget)		Line: 461, Column: 51
+1370:  [1] AVMOpcode(Plus)		Line: 461, Column: 51
+1371:  [5] AVMOpcode(Xget)		Line: 461, Column: 45
+1372:  [CodePoint(Internal(1376))] AVMOpcode(PushStatic)		Line: 461, Column: 24
+1373:  [2] AVMOpcode(Tget)		Line: 461, Column: 24
+1374:  [0] AVMOpcode(Tget)		Line: 461, Column: 24
+1375:  AVMOpcode(Jump)		Line: 461, Column: 24
+1376:  AVMOpcode(Dup0)		Line: 461, Column: 5
+1377:  [0] AVMOpcode(Tget)		Line: 461, Column: 5
+1378:  [7] AVMOpcode(Xget)		Line: 461, Column: 5
+1379:  [0] AVMOpcode(Tset)		Line: 461, Column: 5
+1380:  [7] AVMOpcode(Xset)		Line: 461, Column: 5
+1381:  [1] AVMOpcode(Tget)		Line: 461, Column: 5
+1382:  [7] AVMOpcode(Xget)		Line: 461, Column: 5
+1383:  [1] AVMOpcode(Tset)		Line: 461, Column: 5
+1384:  [7] AVMOpcode(Xset)		Line: 461, Column: 5
+1385:  [7] AVMOpcode(Xget)		Line: 462, Column: 25
+1386:  [1] AVMOpcode(Tget)		Line: 462, Column: 25
+1387:  [6] AVMOpcode(Xget)		Line: 462, Column: 19
+1388:  [7] AVMOpcode(Xget)		Line: 462, Column: 13
+1389:  [0] AVMOpcode(Tget)		Line: 462, Column: 13
+1390:  [Tuple(_, _, _)] AVMOpcode(Noop)		Line: 462, Column: 12
+1391:  [0] AVMOpcode(Tset)		Line: 462, Column: 12
+1392:  [1] AVMOpcode(Tset)		Line: 462, Column: 12
+1393:  [2] AVMOpcode(Tset)		Line: 462, Column: 12
+1394:  AVMOpcode(AuxPop)		Line: 462, Column: 5
+1395:  AVMOpcode(Pop)		Line: 462, Column: 5
+1396:  AVMOpcode(AuxPop)		Line: 462, Column: 5
+1397:  AVMOpcode(Jump)		Line: 462, Column: 5
+1398:  AVMOpcode(AuxPush)		Line: 328, Column: 1
+1399:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 328, Column: 1
+1400:  [0] AVMOpcode(Xset)		Line: 328, Column: 1
+1401:  [1] AVMOpcode(Xset)		Line: 328, Column: 1
+1402:  [0] AVMOpcode(Xget)		Line: 329, Column: 31
+1403:  AVMOpcode(Dup0)		Line: 329, Column: 5
+1404:  [0] AVMOpcode(Tget)		Line: 329, Column: 5
+1405:  [2] AVMOpcode(Xset)		Line: 329, Column: 5
+1406:  [1] AVMOpcode(Tget)		Line: 329, Column: 5
+1407:  [3] AVMOpcode(Xset)		Line: 329, Column: 5
+1408:  [2] AVMOpcode(Xget)		Line: 330, Column: 26
+1409:  [8] AVMOpcode(Minus)		Line: 330, Column: 24
+1410:  [4] AVMOpcode(Xset)		Line: 330, Column: 5
+1411:  [2] AVMOpcode(Xget)		Line: 331, Column: 27
+1412:  [8] AVMOpcode(Mul)		Line: 331, Column: 25
+1413:  [2] AVMOpcode(Exp)		Line: 331, Column: 45
+1414:  [5] AVMOpcode(Xset)		Line: 331, Column: 5
+1415:  [4] AVMOpcode(Xget)		Line: 332, Column: 30
+1416:  [8] AVMOpcode(Mul)		Line: 332, Column: 28
+1417:  [2] AVMOpcode(Exp)		Line: 332, Column: 51
+1418:  [6] AVMOpcode(Xset)		Line: 332, Column: 5
+1419:  [6] AVMOpcode(Xget)		Line: 333, Column: 46
+1420:  [0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff] AVMOpcode(Mul)		Line: 333, Column: 46
+1421:  [1] AVMOpcode(Xget)		Line: 333, Column: 36
+1422:  AVMOpcode(BitwiseAnd)		Line: 333, Column: 36
+1423:  [5] AVMOpcode(Xget)		Line: 333, Column: 25
+1424:  [3] AVMOpcode(Xget)		Line: 333, Column: 19
+1425:  AVMOpcode(Div)		Line: 333, Column: 19
+1426:  AVMOpcode(BitwiseOr)		Line: 333, Column: 18
+1427:  [7] AVMOpcode(Xset)		Line: 333, Column: 5
+1428:  [0] AVMOpcode(Noop)		Line: 334, Column: 21
+1429:  [7] AVMOpcode(Xget)		Line: 334, Column: 13
+1430:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 334, Column: 12
+1431:  [0] AVMOpcode(Tset)		Line: 334, Column: 12
+1432:  [1] AVMOpcode(Tset)		Line: 334, Column: 12
+1433:  AVMOpcode(AuxPop)		Line: 334, Column: 5
+1434:  AVMOpcode(Pop)		Line: 334, Column: 5
+1435:  AVMOpcode(AuxPop)		Line: 334, Column: 5
+1436:  AVMOpcode(Jump)		Line: 334, Column: 5
+1437:  AVMOpcode(AuxPush)		Line: 320, Column: 1
+1438:  [Tuple(_, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 320, Column: 1
+1439:  [0] AVMOpcode(Xset)		Line: 320, Column: 1
+1440:  [1] AVMOpcode(Xset)		Line: 320, Column: 1
+1441:  [0] AVMOpcode(Xget)		Line: 321, Column: 31
+1442:  AVMOpcode(Dup0)		Line: 321, Column: 5
+1443:  [0] AVMOpcode(Tget)		Line: 321, Column: 5
+1444:  [2] AVMOpcode(Xset)		Line: 321, Column: 5
+1445:  [1] AVMOpcode(Tget)		Line: 321, Column: 5
+1446:  [3] AVMOpcode(Xset)		Line: 321, Column: 5
+1447:  [2] AVMOpcode(Xget)		Line: 322, Column: 27
+1448:  [32] AVMOpcode(Minus)		Line: 322, Column: 24
+1449:  [4] AVMOpcode(Xset)		Line: 322, Column: 5
+1450:  [4] AVMOpcode(Xget)		Line: 323, Column: 27
+1451:  [8] AVMOpcode(Mul)		Line: 323, Column: 25
+1452:  [2] AVMOpcode(Exp)		Line: 323, Column: 48
+1453:  [5] AVMOpcode(Xset)		Line: 323, Column: 5
+1454:  [1] AVMOpcode(Noop)		Line: 324, Column: 53
+1455:  [5] AVMOpcode(Xget)		Line: 324, Column: 46
+1456:  AVMOpcode(Minus)		Line: 324, Column: 46
+1457:  [1] AVMOpcode(Xget)		Line: 324, Column: 36
+1458:  AVMOpcode(BitwiseAnd)		Line: 324, Column: 36
+1459:  [5] AVMOpcode(Xget)		Line: 324, Column: 25
+1460:  [3] AVMOpcode(Xget)		Line: 324, Column: 19
+1461:  AVMOpcode(Mul)		Line: 324, Column: 19
+1462:  AVMOpcode(BitwiseOr)		Line: 324, Column: 18
+1463:  [6] AVMOpcode(Xset)		Line: 324, Column: 5
+1464:  [0] AVMOpcode(Noop)		Line: 325, Column: 21
+1465:  [6] AVMOpcode(Xget)		Line: 325, Column: 13
+1466:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 325, Column: 12
+1467:  [0] AVMOpcode(Tset)		Line: 325, Column: 12
+1468:  [1] AVMOpcode(Tset)		Line: 325, Column: 12
+1469:  AVMOpcode(AuxPop)		Line: 325, Column: 5
+1470:  AVMOpcode(Pop)		Line: 325, Column: 5
+1471:  AVMOpcode(AuxPop)		Line: 325, Column: 5
+1472:  AVMOpcode(Jump)		Line: 325, Column: 5
+1473:  AVMOpcode(AuxPush)		Line: 382, Column: 1
+1474:  [Tuple(_, _, _, _)] AVMOpcode(AuxPush)		Line: 382, Column: 1
+1475:  [0] AVMOpcode(Xset)		Line: 382, Column: 1
+1476:  [1] AVMOpcode(Xset)		Line: 382, Column: 1
+1477:  [2] AVMOpcode(Xset)		Line: 382, Column: 1
+1478:  [CodePoint(Internal(1481))] AVMOpcode(Noop)		Line: 383, Column: 5
+1479:  [3] AVMOpcode(Xset)		Line: 383, Column: 5
+1480:  [CodePoint(Internal(1485))] AVMOpcode(Jump)		Line: 383, Column: 5
+1481:  [0] AVMOpcode(Xget)		Line: 384, Column: 38
+1482:  [CodePoint(Internal(1484))] AVMOpcode(Noop)		Line: 384, Column: 15
+1483:  [CodePoint(Internal(1644))] AVMOpcode(Jump)		Line: 384, Column: 15
+1484:  [0] AVMOpcode(Xset)		Line: 384, Column: 9
+1485:  [0] AVMOpcode(Xget)		Line: 383, Column: 20
+1486:  [0] AVMOpcode(Tget)		Line: 383, Column: 20
+1487:  [1] AVMOpcode(Xget)		Line: 383, Column: 12
+1488:  AVMOpcode(GreaterThan)		Line: 383, Column: 12
+1489:  [3] AVMOpcode(Xget)		Line: 383, Column: 5
+1490:  AVMOpcode(Cjump)		Line: 383, Column: 5
+1491:  [2] AVMOpcode(Xget)		Line: 387, Column: 60
+1492:  [1] AVMOpcode(Xget)		Line: 387, Column: 53
+1493:  [0] AVMOpcode(Xget)		Line: 387, Column: 42
+1494:  [1] AVMOpcode(Tget)		Line: 387, Column: 42
+1495:  [0] AVMOpcode(Xget)		Line: 387, Column: 28
+1496:  [2] AVMOpcode(Tget)		Line: 387, Column: 28
+1497:  [CodePoint(Internal(1499))] AVMOpcode(Noop)		Line: 387, Column: 19
+1498:  [CodePoint(Internal(1712))] AVMOpcode(Jump)		Line: 387, Column: 19
+1499:  [0] AVMOpcode(Xget)		Line: 386, Column: 12
+1500:  [2] AVMOpcode(Tset)		Line: 386, Column: 12
+1501:  AVMOpcode(AuxPop)		Line: 386, Column: 5
+1502:  AVMOpcode(Pop)		Line: 386, Column: 5
+1503:  AVMOpcode(AuxPop)		Line: 386, Column: 5
+1504:  AVMOpcode(Jump)		Line: 386, Column: 5
+1505:  AVMOpcode(AuxPush)		Line: 337, Column: 1
+1506:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 337, Column: 1
+1507:  [0] AVMOpcode(Xset)		Line: 337, Column: 1
+1508:  [1] AVMOpcode(Xset)		Line: 337, Column: 1
+1509:  [0] AVMOpcode(Xget)		Line: 338, Column: 31
+1510:  AVMOpcode(Dup0)		Line: 338, Column: 5
+1511:  [0] AVMOpcode(Tget)		Line: 338, Column: 5
+1512:  [2] AVMOpcode(Xset)		Line: 338, Column: 5
+1513:  [1] AVMOpcode(Tget)		Line: 338, Column: 5
+1514:  [3] AVMOpcode(Xset)		Line: 338, Column: 5
+1515:  [2] AVMOpcode(Xget)		Line: 339, Column: 27
+1516:  [32] AVMOpcode(Minus)		Line: 339, Column: 24
+1517:  [4] AVMOpcode(Xset)		Line: 339, Column: 5
+1518:  [2] AVMOpcode(Xget)		Line: 340, Column: 27
+1519:  [8] AVMOpcode(Mul)		Line: 340, Column: 25
+1520:  [2] AVMOpcode(Exp)		Line: 340, Column: 45
+1521:  [5] AVMOpcode(Xset)		Line: 340, Column: 5
+1522:  [4] AVMOpcode(Xget)		Line: 341, Column: 30
+1523:  [8] AVMOpcode(Mul)		Line: 341, Column: 28
+1524:  [2] AVMOpcode(Exp)		Line: 341, Column: 51
+1525:  [6] AVMOpcode(Xset)		Line: 341, Column: 5
+1526:  [6] AVMOpcode(Xget)		Line: 342, Column: 46
+1527:  [0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff] AVMOpcode(Mul)		Line: 342, Column: 46
+1528:  [1] AVMOpcode(Xget)		Line: 342, Column: 36
+1529:  AVMOpcode(BitwiseAnd)		Line: 342, Column: 36
+1530:  [5] AVMOpcode(Xget)		Line: 342, Column: 25
+1531:  [3] AVMOpcode(Xget)		Line: 342, Column: 19
+1532:  AVMOpcode(Div)		Line: 342, Column: 19
+1533:  AVMOpcode(BitwiseOr)		Line: 342, Column: 18
+1534:  [7] AVMOpcode(Xset)		Line: 342, Column: 5
+1535:  [0] AVMOpcode(Noop)		Line: 343, Column: 21
+1536:  [7] AVMOpcode(Xget)		Line: 343, Column: 13
+1537:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 343, Column: 12
+1538:  [0] AVMOpcode(Tset)		Line: 343, Column: 12
+1539:  [1] AVMOpcode(Tset)		Line: 343, Column: 12
+1540:  AVMOpcode(AuxPop)		Line: 343, Column: 5
+1541:  AVMOpcode(Pop)		Line: 343, Column: 5
+1542:  AVMOpcode(AuxPop)		Line: 343, Column: 5
+1543:  AVMOpcode(Jump)		Line: 343, Column: 5
+1544:  AVMOpcode(AuxPush)		Line: 265, Column: 1
+1545:  [Tuple(_, _, _, _, _, _, _, Tuple(_, _))] AVMOpcode(AuxPush)		Line: 265, Column: 1
+1546:  [0] AVMOpcode(Xset)		Line: 265, Column: 1
+1547:  [1] AVMOpcode(Xset)		Line: 265, Column: 1
+1548:  [2] AVMOpcode(Xset)		Line: 265, Column: 1
+1549:  [3] AVMOpcode(Xset)		Line: 265, Column: 1
+1550:  [4] AVMOpcode(Xset)		Line: 265, Column: 1
+1551:  [CodePoint(Internal(1554))] AVMOpcode(Noop)		Line: 273, Column: 5
+1552:  [5] AVMOpcode(Xset)		Line: 273, Column: 5
+1553:  [CodePoint(Internal(1579))] AVMOpcode(Jump)		Line: 273, Column: 5
+1554:  [1] AVMOpcode(Xget)		Line: 274, Column: 42
+1555:  [0] AVMOpcode(Xget)		Line: 274, Column: 36
+1556:  [CodePoint(Internal(1560))] AVMOpcode(PushStatic)		Line: 274, Column: 19
+1557:  [2] AVMOpcode(Tget)		Line: 274, Column: 19
+1558:  [1] AVMOpcode(Tget)		Line: 274, Column: 19
+1559:  AVMOpcode(Jump)		Line: 274, Column: 19
+1560:  [6] AVMOpcode(Xset)		Line: 274, Column: 9
+1561:  [6] AVMOpcode(Xget)		Line: 275, Column: 45
+1562:  [3] AVMOpcode(Xget)		Line: 275, Column: 35
+1563:  [2] AVMOpcode(Xget)		Line: 275, Column: 31
+1564:  [CodePoint(Internal(1568))] AVMOpcode(PushStatic)		Line: 275, Column: 14
+1565:  [2] AVMOpcode(Tget)		Line: 275, Column: 14
+1566:  [2] AVMOpcode(Tget)		Line: 275, Column: 14
+1567:  AVMOpcode(Jump)		Line: 275, Column: 14
+1568:  [2] AVMOpcode(Xset)		Line: 275, Column: 9
+1569:  [1] AVMOpcode(Xget)		Line: 276, Column: 25
+1570:  [32] AVMOpcode(Plus)		Line: 276, Column: 22
+1571:  [1] AVMOpcode(Xset)		Line: 276, Column: 9
+1572:  [3] AVMOpcode(Xget)		Line: 277, Column: 23
+1573:  [32] AVMOpcode(Plus)		Line: 277, Column: 20
+1574:  [3] AVMOpcode(Xset)		Line: 277, Column: 9
+1575:  [32] AVMOpcode(Noop)		Line: 278, Column: 25
+1576:  [4] AVMOpcode(Xget)		Line: 278, Column: 18
+1577:  AVMOpcode(Minus)		Line: 278, Column: 18
+1578:  [4] AVMOpcode(Xset)		Line: 278, Column: 9
+1579:  [4] AVMOpcode(Xget)		Line: 273, Column: 12
+1580:  [32] AVMOpcode(GreaterThan)		Line: 273, Column: 12
+1581:  AVMOpcode(IsZero)		Line: 273, Column: 12
+1582:  [5] AVMOpcode(Xget)		Line: 273, Column: 5
+1583:  AVMOpcode(Cjump)		Line: 273, Column: 5
+1584:  [CodePoint(Internal(1589))] AVMOpcode(Noop)		Line: 280, Column: 5
+1585:  [7] AVMOpcode(Xget)		Line: 280, Column: 5
+1586:  [0] AVMOpcode(Tset)		Line: 280, Column: 5
+1587:  [7] AVMOpcode(Xset)		Line: 280, Column: 5
+1588:  [CodePoint(Internal(1617))] AVMOpcode(Jump)		Line: 280, Column: 5
+1589:  [1] AVMOpcode(Xget)		Line: 281, Column: 43
+1590:  [0] AVMOpcode(Xget)		Line: 281, Column: 37
+1591:  [CodePoint(Internal(1595))] AVMOpcode(PushStatic)		Line: 281, Column: 19
+1592:  [2] AVMOpcode(Tget)		Line: 281, Column: 19
+1593:  [3] AVMOpcode(Tget)		Line: 281, Column: 19
+1594:  AVMOpcode(Jump)		Line: 281, Column: 19
+1595:  [7] AVMOpcode(Xget)		Line: 281, Column: 9
+1596:  [1] AVMOpcode(Tset)		Line: 281, Column: 9
+1597:  [7] AVMOpcode(Xset)		Line: 281, Column: 9
+1598:  [7] AVMOpcode(Xget)		Line: 282, Column: 46
+1599:  [1] AVMOpcode(Tget)		Line: 282, Column: 46
+1600:  [3] AVMOpcode(Xget)		Line: 282, Column: 36
+1601:  [2] AVMOpcode(Xget)		Line: 282, Column: 32
+1602:  [CodePoint(Internal(1606))] AVMOpcode(PushStatic)		Line: 282, Column: 14
+1603:  [2] AVMOpcode(Tget)		Line: 282, Column: 14
+1604:  [4] AVMOpcode(Tget)		Line: 282, Column: 14
+1605:  AVMOpcode(Jump)		Line: 282, Column: 14
+1606:  [2] AVMOpcode(Xset)		Line: 282, Column: 9
+1607:  [1] AVMOpcode(Xget)		Line: 283, Column: 24
+1608:  [1] AVMOpcode(Plus)		Line: 283, Column: 22
+1609:  [1] AVMOpcode(Xset)		Line: 283, Column: 9
+1610:  [3] AVMOpcode(Xget)		Line: 284, Column: 22
+1611:  [1] AVMOpcode(Plus)		Line: 284, Column: 20
+1612:  [3] AVMOpcode(Xset)		Line: 284, Column: 9
+1613:  [1] AVMOpcode(Noop)		Line: 285, Column: 25
+1614:  [4] AVMOpcode(Xget)		Line: 285, Column: 18
+1615:  AVMOpcode(Minus)		Line: 285, Column: 18
+1616:  [4] AVMOpcode(Xset)		Line: 285, Column: 9
+1617:  [4] AVMOpcode(Xget)		Line: 280, Column: 12
+1618:  [0] AVMOpcode(LessThan)		Line: 280, Column: 12
+1619:  [7] AVMOpcode(Xget)		Line: 280, Column: 5
+1620:  [0] AVMOpcode(Tget)		Line: 280, Column: 5
+1621:  AVMOpcode(Cjump)		Line: 280, Column: 5
+1622:  [2] AVMOpcode(Xget)		Line: 287, Column: 12
+1623:  AVMOpcode(AuxPop)		Line: 287, Column: 5
+1624:  AVMOpcode(Pop)		Line: 287, Column: 5
+1625:  AVMOpcode(AuxPop)		Line: 287, Column: 5
+1626:  AVMOpcode(Jump)		Line: 287, Column: 5
+1627:  AVMOpcode(AuxPush)		Line: 290, Column: 1
+1628:  [Tuple(_, _, _)] AVMOpcode(AuxPush)		Line: 290, Column: 1
+1629:  [0] AVMOpcode(Xset)		Line: 290, Column: 1
+1630:  [1] AVMOpcode(Xset)		Line: 290, Column: 1
+1631:  [2] AVMOpcode(Xset)		Line: 290, Column: 1
+1632:  [0] AVMOpcode(Xget)		Line: 294, Column: 31
+1633:  [1] AVMOpcode(Tget)		Line: 294, Column: 31
+1634:  [1] AVMOpcode(Xget)		Line: 294, Column: 22
+1635:  AVMOpcode(Plus)		Line: 294, Column: 22
+1636:  [2] AVMOpcode(Xget)		Line: 292, Column: 15
+1637:  [0] AVMOpcode(Xget)		Line: 291, Column: 12
+1638:  [0] AVMOpcode(Tset)		Line: 291, Column: 12
+1639:  [1] AVMOpcode(Tset)		Line: 291, Column: 12
+1640:  AVMOpcode(AuxPop)		Line: 291, Column: 5
+1641:  AVMOpcode(Pop)		Line: 291, Column: 5
+1642:  AVMOpcode(AuxPop)		Line: 291, Column: 5
+1643:  AVMOpcode(Jump)		Line: 291, Column: 5
+1644:  AVMOpcode(AuxPush)		Line: 465, Column: 1
+1645:  [Tuple(_, _, _, _)] AVMOpcode(AuxPush)		Line: 465, Column: 1
+1646:  [0] AVMOpcode(Xset)		Line: 465, Column: 1
+1647:  [0] AVMOpcode(Noop)		Line: 466, Column: 57
+1648:  [0] AVMOpcode(Noop)		Line: 466, Column: 55
+1649:  [0] AVMOpcode(Noop)		Line: 466, Column: 53
+1650:  [0] AVMOpcode(Noop)		Line: 466, Column: 51
+1651:  [0] AVMOpcode(Noop)		Line: 466, Column: 49
+1652:  [0] AVMOpcode(Noop)		Line: 466, Column: 47
+1653:  [0] AVMOpcode(Noop)		Line: 466, Column: 45
+1654:  [0] AVMOpcode(Noop)		Line: 466, Column: 43
+1655:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(Noop)		Line: 466, Column: 42
+1656:  [0] AVMOpcode(Tset)		Line: 466, Column: 42
+1657:  [1] AVMOpcode(Tset)		Line: 466, Column: 42
+1658:  [2] AVMOpcode(Tset)		Line: 466, Column: 42
+1659:  [3] AVMOpcode(Tset)		Line: 466, Column: 42
+1660:  [4] AVMOpcode(Tset)		Line: 466, Column: 42
+1661:  [5] AVMOpcode(Tset)		Line: 466, Column: 42
+1662:  [6] AVMOpcode(Tset)		Line: 466, Column: 42
+1663:  [7] AVMOpcode(Tset)		Line: 466, Column: 42
+1664:  [1] AVMOpcode(Xset)		Line: 466, Column: 5
+1665:  [1] AVMOpcode(Noop)		Line: 467, Column: 20
+1666:  [2] AVMOpcode(Xset)		Line: 467, Column: 5
+1667:  [CodePoint(Internal(1670))] AVMOpcode(Noop)		Line: 468, Column: 5
+1668:  [3] AVMOpcode(Xset)		Line: 468, Column: 5
+1669:  [CodePoint(Internal(1691))] AVMOpcode(Jump)		Line: 468, Column: 5
+1670:  [1] AVMOpcode(Xget)		Line: 469, Column: 59
+1671:  AVMOpcode(Dup0)		Line: 469, Column: 42
+1672:  AVMOpcode(Dup0)		Line: 469, Column: 42
+1673:  AVMOpcode(Dup0)		Line: 469, Column: 42
+1674:  AVMOpcode(Dup0)		Line: 469, Column: 42
+1675:  AVMOpcode(Dup0)		Line: 469, Column: 42
+1676:  AVMOpcode(Dup0)		Line: 469, Column: 42
+1677:  AVMOpcode(Dup0)		Line: 469, Column: 42
+1678:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(Noop)		Line: 469, Column: 42
+1679:  [0] AVMOpcode(Tset)		Line: 469, Column: 42
+1680:  [1] AVMOpcode(Tset)		Line: 469, Column: 42
+1681:  [2] AVMOpcode(Tset)		Line: 469, Column: 42
+1682:  [3] AVMOpcode(Tset)		Line: 469, Column: 42
+1683:  [4] AVMOpcode(Tset)		Line: 469, Column: 42
+1684:  [5] AVMOpcode(Tset)		Line: 469, Column: 42
+1685:  [6] AVMOpcode(Tset)		Line: 469, Column: 42
+1686:  [7] AVMOpcode(Tset)		Line: 469, Column: 42
+1687:  [1] AVMOpcode(Xset)		Line: 469, Column: 9
+1688:  [2] AVMOpcode(Xget)		Line: 470, Column: 20
+1689:  [8] AVMOpcode(Mul)		Line: 470, Column: 20
+1690:  [2] AVMOpcode(Xset)		Line: 470, Column: 9
+1691:  [0] AVMOpcode(Xget)		Line: 468, Column: 24
+1692:  [1] AVMOpcode(Tget)		Line: 468, Column: 24
+1693:  [2] AVMOpcode(Xget)		Line: 468, Column: 12
+1694:  AVMOpcode(GreaterThan)		Line: 468, Column: 12
+1695:  AVMOpcode(IsZero)		Line: 468, Column: 12
+1696:  [3] AVMOpcode(Xget)		Line: 468, Column: 5
+1697:  AVMOpcode(Cjump)		Line: 468, Column: 5
+1698:  [0] AVMOpcode(Xget)		Line: 472, Column: 44
+1699:  [2] AVMOpcode(Tget)		Line: 472, Column: 44
+1700:  [1] AVMOpcode(Xget)		Line: 472, Column: 19
+1701:  [0] AVMOpcode(Tset)		Line: 472, Column: 19
+1702:  [1] AVMOpcode(Xset)		Line: 472, Column: 5
+1703:  [2] AVMOpcode(Xget)		Line: 476, Column: 16
+1704:  [1] AVMOpcode(Xget)		Line: 474, Column: 19
+1705:  [0] AVMOpcode(Xget)		Line: 473, Column: 12
+1706:  [2] AVMOpcode(Tset)		Line: 473, Column: 12
+1707:  [1] AVMOpcode(Tset)		Line: 473, Column: 12
+1708:  AVMOpcode(AuxPop)		Line: 473, Column: 5
+1709:  AVMOpcode(Pop)		Line: 473, Column: 5
+1710:  AVMOpcode(AuxPop)		Line: 473, Column: 5
+1711:  AVMOpcode(Jump)		Line: 473, Column: 5
+1712:  AVMOpcode(AuxPush)		Line: 391, Column: 1
+1713:  [Tuple(_, _, _, _, _)] AVMOpcode(AuxPush)		Line: 391, Column: 1
+1714:  [0] AVMOpcode(Xset)		Line: 391, Column: 1
+1715:  [1] AVMOpcode(Xset)		Line: 391, Column: 1
+1716:  [2] AVMOpcode(Xset)		Line: 391, Column: 1
+1717:  [3] AVMOpcode(Xset)		Line: 391, Column: 1
+1718:  [1] AVMOpcode(Xget)		Line: 392, Column: 9
+1719:  [1] AVMOpcode(Equal)		Line: 392, Column: 9
+1720:  AVMOpcode(IsZero)		Line: 392, Column: 5
+1721:  [CodePoint(Internal(1730))] AVMOpcode(Cjump)		Line: 392, Column: 5
+1722:  [3] AVMOpcode(Xget)		Line: 393, Column: 38
+1723:  [0] AVMOpcode(Xget)		Line: 393, Column: 16
+1724:  [2] AVMOpcode(Xget)		Line: 393, Column: 29
+1725:  AVMOpcode(Tset)		Line: 393, Column: 16
+1726:  AVMOpcode(AuxPop)		Line: 393, Column: 9
+1727:  AVMOpcode(Pop)		Line: 393, Column: 9
+1728:  AVMOpcode(AuxPop)		Line: 393, Column: 9
+1729:  AVMOpcode(Jump)		Line: 393, Column: 9
+1730:  [1] AVMOpcode(Xget)		Line: 395, Column: 22
+1731:  [2] AVMOpcode(Xget)		Line: 395, Column: 16
+1732:  AVMOpcode(Div)		Line: 395, Column: 16
+1733:  [4] AVMOpcode(Xset)		Line: 395, Column: 5
+1734:  [3] AVMOpcode(Xget)		Line: 397, Column: 81
+1735:  [1] AVMOpcode(Xget)		Line: 397, Column: 74
+1736:  [2] AVMOpcode(Xget)		Line: 397, Column: 68
+1737:  AVMOpcode(Mod)		Line: 397, Column: 68
+1738:  [8] AVMOpcode(Noop)		Line: 397, Column: 65
+1739:  [1] AVMOpcode(Xget)		Line: 397, Column: 59
+1740:  AVMOpcode(Div)		Line: 397, Column: 59
+1741:  [0] AVMOpcode(Xget)		Line: 397, Column: 46
+1742:  [4] AVMOpcode(Xget)		Line: 397, Column: 51
+1743:  AVMOpcode(Tget)		Line: 397, Column: 46
+1744:  [CodePoint(Internal(1748))] AVMOpcode(PushStatic)		Line: 397, Column: 18
+1745:  [2] AVMOpcode(Tget)		Line: 397, Column: 18
+1746:  [5] AVMOpcode(Tget)		Line: 397, Column: 18
+1747:  AVMOpcode(Jump)		Line: 397, Column: 18
+1748:  [0] AVMOpcode(Xget)		Line: 396, Column: 12
+1749:  [4] AVMOpcode(Xget)		Line: 397, Column: 10
+1750:  AVMOpcode(Tset)		Line: 396, Column: 12
+1751:  AVMOpcode(AuxPop)		Line: 396, Column: 5
+1752:  AVMOpcode(Pop)		Line: 396, Column: 5
+1753:  AVMOpcode(AuxPop)		Line: 396, Column: 5
+1754:  AVMOpcode(Jump)		Line: 396, Column: 5
+1755:  AVMOpcode(AuxPush)		Line: 423, Column: 1
+1756:  [Tuple(_, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 423, Column: 1
+1757:  [0] AVMOpcode(Xset)		Line: 423, Column: 1
+1758:  [1] AVMOpcode(Xset)		Line: 423, Column: 1
+1759:  [2] AVMOpcode(Xset)		Line: 423, Column: 1
+1760:  [3] AVMOpcode(Xset)		Line: 423, Column: 1
+1761:  [1] AVMOpcode(Xget)		Line: 429, Column: 9
+1762:  [1] AVMOpcode(Equal)		Line: 429, Column: 9
+1763:  AVMOpcode(IsZero)		Line: 429, Column: 5
+1764:  [CodePoint(Internal(1791))] AVMOpcode(Cjump)		Line: 429, Column: 5
+1765:  [0] AVMOpcode(Xget)		Line: 430, Column: 81
+1766:  [2] AVMOpcode(Xget)		Line: 430, Column: 86
+1767:  AVMOpcode(Tget)		Line: 430, Column: 81
+1768:  [3] AVMOpcode(Xget)		Line: 430, Column: 51
+1769:  [1] AVMOpcode(Tget)		Line: 430, Column: 51
+1770:  [CodePoint(Internal(1774))] AVMOpcode(Noop)		Line: 430, Column: 41
+1771:  [3] AVMOpcode(Xget)		Line: 430, Column: 41
+1772:  [0] AVMOpcode(Tget)		Line: 430, Column: 41
+1773:  AVMOpcode(Jump)		Line: 430, Column: 41
+1774:  AVMOpcode(Dup0)		Line: 430, Column: 9
+1775:  [0] AVMOpcode(Tget)		Line: 430, Column: 9
+1776:  [4] AVMOpcode(Xset)		Line: 430, Column: 9
+1777:  [1] AVMOpcode(Tget)		Line: 430, Column: 9
+1778:  [5] AVMOpcode(Xset)		Line: 430, Column: 9
+1779:  [5] AVMOpcode(Xget)		Line: 433, Column: 13
+1780:  [4] AVMOpcode(Xget)		Line: 432, Column: 35
+1781:  [0] AVMOpcode(Xget)		Line: 432, Column: 13
+1782:  [2] AVMOpcode(Xget)		Line: 432, Column: 26
+1783:  AVMOpcode(Tset)		Line: 432, Column: 13
+1784:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 431, Column: 16
+1785:  [0] AVMOpcode(Tset)		Line: 431, Column: 16
+1786:  [1] AVMOpcode(Tset)		Line: 431, Column: 16
+1787:  AVMOpcode(AuxPop)		Line: 431, Column: 9
+1788:  AVMOpcode(Pop)		Line: 431, Column: 9
+1789:  AVMOpcode(AuxPop)		Line: 431, Column: 9
+1790:  AVMOpcode(Jump)		Line: 431, Column: 9
+1791:  [1] AVMOpcode(Xget)		Line: 436, Column: 28
+1792:  [2] AVMOpcode(Xget)		Line: 436, Column: 20
+1793:  AVMOpcode(Div)		Line: 436, Column: 20
+1794:  [4] AVMOpcode(Xset)		Line: 436, Column: 9
+1795:  [3] AVMOpcode(Xget)		Line: 441, Column: 13
+1796:  [1] AVMOpcode(Xget)		Line: 440, Column: 19
+1797:  [2] AVMOpcode(Xget)		Line: 440, Column: 13
+1798:  AVMOpcode(Mod)		Line: 440, Column: 13
+1799:  [8] AVMOpcode(Noop)		Line: 439, Column: 19
+1800:  [1] AVMOpcode(Xget)		Line: 439, Column: 13
+1801:  AVMOpcode(Div)		Line: 439, Column: 13
+1802:  [0] AVMOpcode(Xget)		Line: 438, Column: 32
+1803:  [4] AVMOpcode(Xget)		Line: 438, Column: 37
+1804:  AVMOpcode(Tget)		Line: 438, Column: 32
+1805:  [CodePoint(Internal(1809))] AVMOpcode(PushStatic)		Line: 437, Column: 41
+1806:  [2] AVMOpcode(Tget)		Line: 437, Column: 41
+1807:  [6] AVMOpcode(Tget)		Line: 437, Column: 41
+1808:  AVMOpcode(Jump)		Line: 437, Column: 41
+1809:  AVMOpcode(Dup0)		Line: 437, Column: 9
+1810:  [0] AVMOpcode(Tget)		Line: 437, Column: 9
+1811:  [5] AVMOpcode(Xset)		Line: 437, Column: 9
+1812:  [1] AVMOpcode(Tget)		Line: 437, Column: 9
+1813:  [6] AVMOpcode(Xset)		Line: 437, Column: 9
+1814:  [6] AVMOpcode(Xget)		Line: 445, Column: 13
+1815:  [5] AVMOpcode(Xget)		Line: 444, Column: 35
+1816:  [0] AVMOpcode(Xget)		Line: 444, Column: 13
+1817:  [2] AVMOpcode(Xget)		Line: 444, Column: 26
+1818:  AVMOpcode(Tset)		Line: 444, Column: 13
+1819:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 443, Column: 16
+1820:  [0] AVMOpcode(Tset)		Line: 443, Column: 16
+1821:  [1] AVMOpcode(Tset)		Line: 443, Column: 16
+1822:  AVMOpcode(AuxPop)		Line: 443, Column: 9
+1823:  AVMOpcode(Pop)		Line: 443, Column: 9
+1824:  AVMOpcode(AuxPop)		Line: 443, Column: 9
+1825:  AVMOpcode(Jump)		Line: 443, Column: 9
+1826:  AVMOpcode(AuxPush)		Line: 30, Column: 1
+1827:  [_] AVMOpcode(AuxPush)		Line: 30, Column: 1
+1828:  [Tuple(0, _)] AVMOpcode(Noop)		Line: 34, Column: 19
+1829:  [8] AVMOpcode(Noop)		Line: 34, Column: 36
+1830:  [CodePoint(Internal(1832))] AVMOpcode(Noop)		Line: 34, Column: 19
+1831:  [CodePoint(Internal(4918))] AVMOpcode(Jump)		Line: 34, Column: 19
+1832:  [8] AVMOpcode(Noop)		Line: 33, Column: 19
+1833:  [0] AVMOpcode(Noop)		Line: 32, Column: 15
+1834:  [Tuple(_, _, _)] AVMOpcode(Noop)		Line: 31, Column: 12
+1835:  [0] AVMOpcode(Tset)		Line: 31, Column: 12
+1836:  [1] AVMOpcode(Tset)		Line: 31, Column: 12
+1837:  [2] AVMOpcode(Tset)		Line: 31, Column: 12
+1838:  AVMOpcode(AuxPop)		Line: 31, Column: 5
+1839:  AVMOpcode(Pop)		Line: 31, Column: 5
+1840:  AVMOpcode(AuxPop)		Line: 31, Column: 5
+1841:  AVMOpcode(Jump)		Line: 31, Column: 5
+1842:  AVMOpcode(AuxPush)		Line: 38, Column: 1
+1843:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 38, Column: 1
+1844:  [0] AVMOpcode(Xset)		Line: 38, Column: 1
+1845:  [0] AVMOpcode(Xget)		Line: 39, Column: 12
+1846:  [0] AVMOpcode(Tget)		Line: 39, Column: 12
+1847:  [0] AVMOpcode(Equal)		Line: 39, Column: 12
+1848:  AVMOpcode(AuxPop)		Line: 39, Column: 5
+1849:  AVMOpcode(Pop)		Line: 39, Column: 5
+1850:  AVMOpcode(AuxPop)		Line: 39, Column: 5
+1851:  AVMOpcode(Jump)		Line: 39, Column: 5
+1852:  AVMOpcode(AuxPush)		Line: 42, Column: 1
+1853:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 42, Column: 1
+1854:  [0] AVMOpcode(Xset)		Line: 42, Column: 1
+1855:  [0] AVMOpcode(Xget)		Line: 43, Column: 12
+1856:  [0] AVMOpcode(Tget)		Line: 43, Column: 12
+1857:  AVMOpcode(AuxPop)		Line: 43, Column: 5
+1858:  AVMOpcode(Pop)		Line: 43, Column: 5
+1859:  AVMOpcode(AuxPop)		Line: 43, Column: 5
+1860:  AVMOpcode(Jump)		Line: 43, Column: 5
+1861:  AVMOpcode(AuxPush)		Line: 46, Column: 1
+1862:  [Tuple(_, _, _)] AVMOpcode(AuxPush)		Line: 46, Column: 1
+1863:  [0] AVMOpcode(Xset)		Line: 46, Column: 1
+1864:  [0] AVMOpcode(Xget)		Line: 47, Column: 27
+1865:  [CodePoint(Internal(1869))] AVMOpcode(PushStatic)		Line: 47, Column: 9
+1866:  [2] AVMOpcode(Tget)		Line: 47, Column: 9
+1867:  [7] AVMOpcode(Tget)		Line: 47, Column: 9
+1868:  AVMOpcode(Jump)		Line: 47, Column: 9
+1869:  AVMOpcode(IsZero)		Line: 47, Column: 5
+1870:  [CodePoint(Internal(1875))] AVMOpcode(Cjump)		Line: 47, Column: 5
+1871:  [Tuple(0)] AVMOpcode(AuxPop)		Line: 48, Column: 9
+1872:  AVMOpcode(Pop)		Line: 48, Column: 9
+1873:  AVMOpcode(AuxPop)		Line: 48, Column: 9
+1874:  AVMOpcode(Jump)		Line: 48, Column: 9
+1875:  [0] AVMOpcode(Noop)		Line: 50, Column: 31
+1876:  [0] AVMOpcode(Xget)		Line: 50, Column: 19
+1877:  [2] AVMOpcode(Tget)		Line: 50, Column: 19
+1878:  [CodePoint(Internal(1880))] AVMOpcode(Noop)		Line: 50, Column: 19
+1879:  [CodePoint(Internal(4981))] AVMOpcode(Jump)		Line: 50, Column: 19
+1880:  [1] AVMOpcode(Tget)		Line: 50, Column: 19
+1881:  [1] AVMOpcode(Xset)		Line: 50, Column: 9
+1882:  [1] AVMOpcode(Noop)		Line: 52, Column: 86
+1883:  [0] AVMOpcode(Xget)		Line: 52, Column: 78
+1884:  [0] AVMOpcode(Tget)		Line: 52, Column: 78
+1885:  AVMOpcode(Minus)		Line: 52, Column: 78
+1886:  [0] AVMOpcode(Xget)		Line: 52, Column: 66
+1887:  [2] AVMOpcode(Tget)		Line: 52, Column: 66
+1888:  [CodePoint(Internal(1890))] AVMOpcode(Noop)		Line: 52, Column: 66
+1889:  [CodePoint(Internal(4981))] AVMOpcode(Jump)		Line: 52, Column: 66
+1890:  [0] AVMOpcode(Noop)		Line: 52, Column: 61
+1891:  [0] AVMOpcode(Xget)		Line: 52, Column: 41
+1892:  [2] AVMOpcode(Tget)		Line: 52, Column: 41
+1893:  [CodePoint(Internal(1895))] AVMOpcode(Noop)		Line: 52, Column: 41
+1894:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 52, Column: 41
+1895:  [1] AVMOpcode(Noop)		Line: 51, Column: 45
+1896:  [0] AVMOpcode(Xget)		Line: 51, Column: 37
+1897:  [0] AVMOpcode(Tget)		Line: 51, Column: 37
+1898:  AVMOpcode(Minus)		Line: 51, Column: 37
+1899:  [0] AVMOpcode(Xget)		Line: 51, Column: 21
+1900:  [0] AVMOpcode(Tset)		Line: 51, Column: 21
+1901:  [2] AVMOpcode(Tset)		Line: 51, Column: 21
+1902:  [2] AVMOpcode(Xset)		Line: 51, Column: 9
+1903:  [0] AVMOpcode(Noop)		Line: 53, Column: 46
+1904:  [2] AVMOpcode(Xget)		Line: 53, Column: 39
+1905:  [CodePoint(Internal(1907))] AVMOpcode(Noop)		Line: 53, Column: 27
+1906:  [CodePoint(Internal(1917))] AVMOpcode(Jump)		Line: 53, Column: 27
+1907:  [1] AVMOpcode(Xget)		Line: 53, Column: 22
+1908:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 53, Column: 21
+1909:  [0] AVMOpcode(Tset)		Line: 53, Column: 21
+1910:  [1] AVMOpcode(Tset)		Line: 53, Column: 21
+1911:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 53, Column: 16
+1912:  [1] AVMOpcode(Tset)		Line: 53, Column: 16
+1913:  AVMOpcode(AuxPop)		Line: 53, Column: 9
+1914:  AVMOpcode(Pop)		Line: 53, Column: 9
+1915:  AVMOpcode(AuxPop)		Line: 53, Column: 9
+1916:  AVMOpcode(Jump)		Line: 53, Column: 9
+1917:  AVMOpcode(AuxPush)		Line: 57, Column: 1
+1918:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 57, Column: 1
+1919:  [0] AVMOpcode(Xset)		Line: 57, Column: 1
+1920:  [1] AVMOpcode(Xset)		Line: 57, Column: 1
+1921:  [CodePoint(Internal(1923))] AVMOpcode(Noop)		Line: 58, Column: 5
+1922:  [2] AVMOpcode(Xset)		Line: 58, Column: 5
+1923:  [1] AVMOpcode(Xget)		Line: 59, Column: 29
+1924:  [2] AVMOpcode(Mul)		Line: 59, Column: 27
+1925:  [1] AVMOpcode(Plus)		Line: 59, Column: 27
+1926:  [3] AVMOpcode(Xset)		Line: 59, Column: 9
+1927:  [0] AVMOpcode(Xget)		Line: 60, Column: 28
+1928:  [0] AVMOpcode(Tget)		Line: 60, Column: 28
+1929:  [3] AVMOpcode(Xget)		Line: 60, Column: 13
+1930:  AVMOpcode(LessThan)		Line: 60, Column: 13
+1931:  [CodePoint(Internal(1937))] AVMOpcode(Cjump)		Line: 60, Column: 9
+1932:  [0] AVMOpcode(Xget)		Line: 61, Column: 20
+1933:  AVMOpcode(AuxPop)		Line: 61, Column: 13
+1934:  AVMOpcode(Pop)		Line: 61, Column: 13
+1935:  AVMOpcode(AuxPop)		Line: 61, Column: 13
+1936:  AVMOpcode(Jump)		Line: 61, Column: 13
+1937:  [0] AVMOpcode(Xget)		Line: 62, Column: 36
+1938:  [0] AVMOpcode(Tget)		Line: 62, Column: 36
+1939:  [3] AVMOpcode(Xget)		Line: 62, Column: 19
+1940:  [1] AVMOpcode(Plus)		Line: 62, Column: 19
+1941:  AVMOpcode(Equal)		Line: 62, Column: 19
+1942:  AVMOpcode(IsZero)		Line: 62, Column: 11
+1943:  [CodePoint(Internal(1984))] AVMOpcode(Cjump)		Line: 62, Column: 11
+1944:  [1] AVMOpcode(Xget)		Line: 64, Column: 36
+1945:  [0] AVMOpcode(Xget)		Line: 64, Column: 24
+1946:  [2] AVMOpcode(Tget)		Line: 64, Column: 24
+1947:  [CodePoint(Internal(1949))] AVMOpcode(Noop)		Line: 64, Column: 24
+1948:  [CodePoint(Internal(4981))] AVMOpcode(Jump)		Line: 64, Column: 24
+1949:  [4] AVMOpcode(Xset)		Line: 64, Column: 13
+1950:  [3] AVMOpcode(Xget)		Line: 65, Column: 35
+1951:  [0] AVMOpcode(Xget)		Line: 65, Column: 23
+1952:  [2] AVMOpcode(Tget)		Line: 65, Column: 23
+1953:  [CodePoint(Internal(1955))] AVMOpcode(Noop)		Line: 65, Column: 23
+1954:  [CodePoint(Internal(4981))] AVMOpcode(Jump)		Line: 65, Column: 23
+1955:  [5] AVMOpcode(Xset)		Line: 65, Column: 13
+1956:  [4] AVMOpcode(Xget)		Line: 66, Column: 32
+1957:  [0] AVMOpcode(Tget)		Line: 66, Column: 32
+1958:  [5] AVMOpcode(Xget)		Line: 66, Column: 17
+1959:  [0] AVMOpcode(Tget)		Line: 66, Column: 17
+1960:  AVMOpcode(GreaterThan)		Line: 66, Column: 17
+1961:  AVMOpcode(IsZero)		Line: 66, Column: 13
+1962:  [CodePoint(Internal(1979))] AVMOpcode(Cjump)		Line: 66, Column: 13
+1963:  [4] AVMOpcode(Xget)		Line: 68, Column: 79
+1964:  [3] AVMOpcode(Xget)		Line: 68, Column: 64
+1965:  [5] AVMOpcode(Xget)		Line: 67, Column: 73
+1966:  [1] AVMOpcode(Xget)		Line: 67, Column: 64
+1967:  [0] AVMOpcode(Xget)		Line: 67, Column: 44
+1968:  [2] AVMOpcode(Tget)		Line: 67, Column: 44
+1969:  [CodePoint(Internal(1971))] AVMOpcode(Noop)		Line: 67, Column: 44
+1970:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 67, Column: 44
+1971:  [CodePoint(Internal(1973))] AVMOpcode(Noop)		Line: 67, Column: 44
+1972:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 67, Column: 44
+1973:  [0] AVMOpcode(Xget)		Line: 67, Column: 24
+1974:  [2] AVMOpcode(Tset)		Line: 67, Column: 24
+1975:  AVMOpcode(AuxPop)		Line: 67, Column: 17
+1976:  AVMOpcode(Pop)		Line: 67, Column: 17
+1977:  AVMOpcode(AuxPop)		Line: 67, Column: 17
+1978:  AVMOpcode(Jump)		Line: 67, Column: 17
+1979:  [0] AVMOpcode(Xget)		Line: 70, Column: 24
+1980:  AVMOpcode(AuxPop)		Line: 70, Column: 17
+1981:  AVMOpcode(Pop)		Line: 70, Column: 17
+1982:  AVMOpcode(AuxPop)		Line: 70, Column: 17
+1983:  AVMOpcode(Jump)		Line: 70, Column: 17
+1984:  [1] AVMOpcode(Xget)		Line: 73, Column: 36
+1985:  [0] AVMOpcode(Xget)		Line: 73, Column: 24
+1986:  [2] AVMOpcode(Tget)		Line: 73, Column: 24
+1987:  [CodePoint(Internal(1989))] AVMOpcode(Noop)		Line: 73, Column: 24
+1988:  [CodePoint(Internal(4981))] AVMOpcode(Jump)		Line: 73, Column: 24
+1989:  [4] AVMOpcode(Xset)		Line: 73, Column: 13
+1990:  [3] AVMOpcode(Xget)		Line: 74, Column: 40
+1991:  [0] AVMOpcode(Xget)		Line: 74, Column: 28
+1992:  [2] AVMOpcode(Tget)		Line: 74, Column: 28
+1993:  [CodePoint(Internal(1995))] AVMOpcode(Noop)		Line: 74, Column: 28
+1994:  [CodePoint(Internal(4981))] AVMOpcode(Jump)		Line: 74, Column: 28
+1995:  [5] AVMOpcode(Xset)		Line: 74, Column: 13
+1996:  [3] AVMOpcode(Xget)		Line: 75, Column: 32
+1997:  [1] AVMOpcode(Plus)		Line: 75, Column: 32
+1998:  [6] AVMOpcode(Xset)		Line: 75, Column: 13
+1999:  [6] AVMOpcode(Xget)		Line: 76, Column: 41
+2000:  [0] AVMOpcode(Xget)		Line: 76, Column: 29
+2001:  [2] AVMOpcode(Tget)		Line: 76, Column: 29
+2002:  [CodePoint(Internal(2004))] AVMOpcode(Noop)		Line: 76, Column: 29
+2003:  [CodePoint(Internal(4981))] AVMOpcode(Jump)		Line: 76, Column: 29
+2004:  [7] AVMOpcode(Xset)		Line: 76, Column: 13
+2005:  [7] AVMOpcode(Xget)		Line: 77, Column: 37
+2006:  [0] AVMOpcode(Tget)		Line: 77, Column: 37
+2007:  [5] AVMOpcode(Xget)		Line: 77, Column: 17
+2008:  [0] AVMOpcode(Tget)		Line: 77, Column: 17
+2009:  AVMOpcode(GreaterThan)		Line: 77, Column: 17
+2010:  AVMOpcode(IsZero)		Line: 77, Column: 13
+2011:  [CodePoint(Internal(2041))] AVMOpcode(Cjump)		Line: 77, Column: 13
+2012:  [4] AVMOpcode(Xget)		Line: 78, Column: 41
+2013:  [0] AVMOpcode(Tget)		Line: 78, Column: 41
+2014:  [5] AVMOpcode(Xget)		Line: 78, Column: 21
+2015:  [0] AVMOpcode(Tget)		Line: 78, Column: 21
+2016:  AVMOpcode(GreaterThan)		Line: 78, Column: 21
+2017:  AVMOpcode(IsZero)		Line: 78, Column: 17
+2018:  [CodePoint(Internal(2035))] AVMOpcode(Cjump)		Line: 78, Column: 17
+2019:  [4] AVMOpcode(Xget)		Line: 80, Column: 81
+2020:  [3] AVMOpcode(Xget)		Line: 80, Column: 66
+2021:  [5] AVMOpcode(Xget)		Line: 79, Column: 75
+2022:  [1] AVMOpcode(Xget)		Line: 79, Column: 66
+2023:  [0] AVMOpcode(Xget)		Line: 79, Column: 46
+2024:  [2] AVMOpcode(Tget)		Line: 79, Column: 46
+2025:  [CodePoint(Internal(2027))] AVMOpcode(Noop)		Line: 79, Column: 46
+2026:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 79, Column: 46
+2027:  [CodePoint(Internal(2029))] AVMOpcode(Noop)		Line: 79, Column: 46
+2028:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 79, Column: 46
+2029:  [0] AVMOpcode(Xget)		Line: 79, Column: 26
+2030:  [2] AVMOpcode(Tset)		Line: 79, Column: 26
+2031:  [0] AVMOpcode(Xset)		Line: 79, Column: 21
+2032:  [3] AVMOpcode(Xget)		Line: 81, Column: 29
+2033:  [1] AVMOpcode(Xset)		Line: 81, Column: 21
+2034:  [CodePoint(Internal(2040))] AVMOpcode(Jump)		Line: 78, Column: 17
+2035:  [0] AVMOpcode(Xget)		Line: 83, Column: 28
+2036:  AVMOpcode(AuxPop)		Line: 83, Column: 21
+2037:  AVMOpcode(Pop)		Line: 83, Column: 21
+2038:  AVMOpcode(AuxPop)		Line: 83, Column: 21
+2039:  AVMOpcode(Jump)		Line: 83, Column: 21
+2040:  [CodePoint(Internal(2069))] AVMOpcode(Jump)		Line: 77, Column: 13
+2041:  [4] AVMOpcode(Xget)		Line: 86, Column: 41
+2042:  [0] AVMOpcode(Tget)		Line: 86, Column: 41
+2043:  [7] AVMOpcode(Xget)		Line: 86, Column: 20
+2044:  [0] AVMOpcode(Tget)		Line: 86, Column: 20
+2045:  AVMOpcode(GreaterThan)		Line: 86, Column: 20
+2046:  AVMOpcode(IsZero)		Line: 86, Column: 16
+2047:  [CodePoint(Internal(2064))] AVMOpcode(Cjump)		Line: 86, Column: 16
+2048:  [4] AVMOpcode(Xget)		Line: 88, Column: 82
+2049:  [6] AVMOpcode(Xget)		Line: 88, Column: 66
+2050:  [7] AVMOpcode(Xget)		Line: 87, Column: 75
+2051:  [1] AVMOpcode(Xget)		Line: 87, Column: 66
+2052:  [0] AVMOpcode(Xget)		Line: 87, Column: 46
+2053:  [2] AVMOpcode(Tget)		Line: 87, Column: 46
+2054:  [CodePoint(Internal(2056))] AVMOpcode(Noop)		Line: 87, Column: 46
+2055:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 87, Column: 46
+2056:  [CodePoint(Internal(2058))] AVMOpcode(Noop)		Line: 87, Column: 46
+2057:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 87, Column: 46
+2058:  [0] AVMOpcode(Xget)		Line: 87, Column: 26
+2059:  [2] AVMOpcode(Tset)		Line: 87, Column: 26
+2060:  [0] AVMOpcode(Xset)		Line: 87, Column: 21
+2061:  [6] AVMOpcode(Xget)		Line: 89, Column: 29
+2062:  [1] AVMOpcode(Xset)		Line: 89, Column: 21
+2063:  [CodePoint(Internal(2069))] AVMOpcode(Jump)		Line: 86, Column: 16
+2064:  [0] AVMOpcode(Xget)		Line: 91, Column: 28
+2065:  AVMOpcode(AuxPop)		Line: 91, Column: 21
+2066:  AVMOpcode(Pop)		Line: 91, Column: 21
+2067:  AVMOpcode(AuxPop)		Line: 91, Column: 21
+2068:  AVMOpcode(Jump)		Line: 91, Column: 21
+2069:  [2] AVMOpcode(Xget)		Line: 58, Column: 5
+2070:  AVMOpcode(Jump)		Line: 58, Column: 5
+2071:  AVMOpcode(AuxPush)		Line: 98, Column: 1
+2072:  [Tuple(_, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 98, Column: 1
+2073:  [0] AVMOpcode(Xset)		Line: 98, Column: 1
+2074:  [1] AVMOpcode(Xset)		Line: 98, Column: 1
+2075:  [1] AVMOpcode(Xget)		Line: 99, Column: 28
+2076:  [0] AVMOpcode(Xget)		Line: 99, Column: 16
+2077:  [2] AVMOpcode(Tget)		Line: 99, Column: 16
+2078:  [CodePoint(Internal(2080))] AVMOpcode(Noop)		Line: 99, Column: 16
+2079:  [CodePoint(Internal(4981))] AVMOpcode(Jump)		Line: 99, Column: 16
+2080:  [2] AVMOpcode(Xset)		Line: 99, Column: 5
+2081:  [CodePoint(Internal(2083))] AVMOpcode(Noop)		Line: 100, Column: 5
+2082:  [3] AVMOpcode(Xset)		Line: 100, Column: 5
+2083:  [1] AVMOpcode(Xget)		Line: 101, Column: 13
+2084:  [0] AVMOpcode(Equal)		Line: 101, Column: 13
+2085:  AVMOpcode(IsZero)		Line: 101, Column: 9
+2086:  [CodePoint(Internal(2092))] AVMOpcode(Cjump)		Line: 101, Column: 9
+2087:  [0] AVMOpcode(Xget)		Line: 102, Column: 20
+2088:  AVMOpcode(AuxPop)		Line: 102, Column: 13
+2089:  AVMOpcode(Pop)		Line: 102, Column: 13
+2090:  AVMOpcode(AuxPop)		Line: 102, Column: 13
+2091:  AVMOpcode(Jump)		Line: 102, Column: 13
+2092:  [2] AVMOpcode(Noop)		Line: 104, Column: 35
+2093:  [1] AVMOpcode(Noop)		Line: 104, Column: 32
+2094:  [1] AVMOpcode(Xget)		Line: 104, Column: 26
+2095:  AVMOpcode(Minus)		Line: 104, Column: 26
+2096:  AVMOpcode(Div)		Line: 104, Column: 25
+2097:  [4] AVMOpcode(Xset)		Line: 104, Column: 9
+2098:  [4] AVMOpcode(Xget)		Line: 105, Column: 34
+2099:  [0] AVMOpcode(Xget)		Line: 105, Column: 22
+2100:  [2] AVMOpcode(Tget)		Line: 105, Column: 22
+2101:  [CodePoint(Internal(2103))] AVMOpcode(Noop)		Line: 105, Column: 22
+2102:  [CodePoint(Internal(4981))] AVMOpcode(Jump)		Line: 105, Column: 22
+2103:  [5] AVMOpcode(Xset)		Line: 105, Column: 9
+2104:  [2] AVMOpcode(Xget)		Line: 106, Column: 32
+2105:  [0] AVMOpcode(Tget)		Line: 106, Column: 32
+2106:  [5] AVMOpcode(Xget)		Line: 106, Column: 13
+2107:  [0] AVMOpcode(Tget)		Line: 106, Column: 13
+2108:  AVMOpcode(LessThan)		Line: 106, Column: 13
+2109:  [CodePoint(Internal(2115))] AVMOpcode(Cjump)		Line: 106, Column: 9
+2110:  [0] AVMOpcode(Xget)		Line: 107, Column: 20
+2111:  AVMOpcode(AuxPop)		Line: 107, Column: 13
+2112:  AVMOpcode(Pop)		Line: 107, Column: 13
+2113:  AVMOpcode(AuxPop)		Line: 107, Column: 13
+2114:  AVMOpcode(Jump)		Line: 107, Column: 13
+2115:  [2] AVMOpcode(Xget)		Line: 110, Column: 71
+2116:  [4] AVMOpcode(Xget)		Line: 110, Column: 58
+2117:  [5] AVMOpcode(Xget)		Line: 109, Column: 67
+2118:  [1] AVMOpcode(Xget)		Line: 109, Column: 58
+2119:  [0] AVMOpcode(Xget)		Line: 109, Column: 38
+2120:  [2] AVMOpcode(Tget)		Line: 109, Column: 38
+2121:  [CodePoint(Internal(2123))] AVMOpcode(Noop)		Line: 109, Column: 38
+2122:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 109, Column: 38
+2123:  [CodePoint(Internal(2125))] AVMOpcode(Noop)		Line: 109, Column: 38
+2124:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 109, Column: 38
+2125:  [0] AVMOpcode(Xget)		Line: 109, Column: 18
+2126:  [2] AVMOpcode(Tset)		Line: 109, Column: 18
+2127:  [0] AVMOpcode(Xset)		Line: 109, Column: 13
+2128:  [4] AVMOpcode(Xget)		Line: 111, Column: 21
+2129:  [1] AVMOpcode(Xset)		Line: 111, Column: 13
+2130:  [3] AVMOpcode(Xget)		Line: 100, Column: 5
+2131:  AVMOpcode(Jump)		Line: 100, Column: 5
+2132:  AVMOpcode(AuxPush)		Line: 116, Column: 1
+2133:  [Tuple(_, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 116, Column: 1
+2134:  [0] AVMOpcode(Xset)		Line: 116, Column: 1
+2135:  [1] AVMOpcode(Xset)		Line: 116, Column: 1
+2136:  [2] AVMOpcode(Xset)		Line: 116, Column: 1
+2137:  [0] AVMOpcode(Xget)		Line: 117, Column: 20
+2138:  [1] AVMOpcode(Tget)		Line: 117, Column: 20
+2139:  [0] AVMOpcode(Xget)		Line: 117, Column: 9
+2140:  [0] AVMOpcode(Tget)		Line: 117, Column: 9
+2141:  AVMOpcode(Equal)		Line: 117, Column: 9
+2142:  AVMOpcode(IsZero)		Line: 117, Column: 5
+2143:  [CodePoint(Internal(2160))] AVMOpcode(Cjump)		Line: 117, Column: 5
+2144:  [0] AVMOpcode(Xget)		Line: 118, Column: 29
+2145:  [1] AVMOpcode(Tget)		Line: 118, Column: 29
+2146:  [8] AVMOpcode(Mul)		Line: 118, Column: 27
+2147:  [3] AVMOpcode(Xset)		Line: 118, Column: 9
+2148:  [_] AVMOpcode(Noop)		Line: 120, Column: 73
+2149:  [3] AVMOpcode(Xget)		Line: 120, Column: 60
+2150:  [0] AVMOpcode(Xget)		Line: 120, Column: 47
+2151:  [2] AVMOpcode(Tget)		Line: 120, Column: 47
+2152:  [CodePoint(Internal(2154))] AVMOpcode(Noop)		Line: 120, Column: 34
+2153:  [CodePoint(Internal(5611))] AVMOpcode(Jump)		Line: 120, Column: 34
+2154:  [3] AVMOpcode(Xget)		Line: 119, Column: 34
+2155:  [0] AVMOpcode(Xget)		Line: 119, Column: 14
+2156:  [1] AVMOpcode(Tset)		Line: 119, Column: 14
+2157:  [2] AVMOpcode(Tset)		Line: 119, Column: 14
+2158:  [0] AVMOpcode(Xset)		Line: 119, Column: 9
+2159:  [CodePoint(Internal(2160))] AVMOpcode(Jump)		Line: 117, Column: 5
+2160:  [0] AVMOpcode(Xget)		Line: 122, Column: 17
+2161:  [0] AVMOpcode(Tget)		Line: 122, Column: 17
+2162:  [4] AVMOpcode(Xset)		Line: 122, Column: 5
+2163:  [1] AVMOpcode(Xget)		Line: 124, Column: 101
+2164:  [2] AVMOpcode(Xget)		Line: 124, Column: 85
+2165:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 124, Column: 66
+2166:  [0] AVMOpcode(Tset)		Line: 124, Column: 66
+2167:  [1] AVMOpcode(Tset)		Line: 124, Column: 66
+2168:  [4] AVMOpcode(Xget)		Line: 124, Column: 57
+2169:  [0] AVMOpcode(Xget)		Line: 124, Column: 37
+2170:  [2] AVMOpcode(Tget)		Line: 124, Column: 37
+2171:  [CodePoint(Internal(2173))] AVMOpcode(Noop)		Line: 124, Column: 37
+2172:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 124, Column: 37
+2173:  [4] AVMOpcode(Xget)		Line: 123, Column: 33
+2174:  [1] AVMOpcode(Plus)		Line: 123, Column: 33
+2175:  [0] AVMOpcode(Xget)		Line: 123, Column: 17
+2176:  [0] AVMOpcode(Tset)		Line: 123, Column: 17
+2177:  [2] AVMOpcode(Tset)		Line: 123, Column: 17
+2178:  [5] AVMOpcode(Xset)		Line: 123, Column: 5
+2179:  [4] AVMOpcode(Xget)		Line: 125, Column: 29
+2180:  [5] AVMOpcode(Xget)		Line: 125, Column: 22
+2181:  [CodePoint(Internal(2185))] AVMOpcode(PushStatic)		Line: 125, Column: 12
+2182:  [3] AVMOpcode(Tget)		Line: 125, Column: 12
+2183:  [0] AVMOpcode(Tget)		Line: 125, Column: 12
+2184:  AVMOpcode(Jump)		Line: 125, Column: 12
+2185:  AVMOpcode(AuxPop)		Line: 125, Column: 5
+2186:  AVMOpcode(Pop)		Line: 125, Column: 5
+2187:  AVMOpcode(AuxPop)		Line: 125, Column: 5
+2188:  AVMOpcode(Jump)		Line: 125, Column: 5
+2189:  AVMOpcode(AuxPush)		Line: 128, Column: 1
+2190:  [Tuple(_, _, _, _, _)] AVMOpcode(AuxPush)		Line: 128, Column: 1
+2191:  [0] AVMOpcode(Xset)		Line: 128, Column: 1
+2192:  [0] AVMOpcode(Xget)		Line: 129, Column: 15
+2193:  [0] AVMOpcode(Tget)		Line: 129, Column: 15
+2194:  [1] AVMOpcode(Xset)		Line: 129, Column: 5
+2195:  [0] AVMOpcode(Xget)		Line: 130, Column: 16
+2196:  [2] AVMOpcode(Tget)		Line: 130, Column: 16
+2197:  [2] AVMOpcode(Xset)		Line: 130, Column: 5
+2198:  [0] AVMOpcode(Noop)		Line: 131, Column: 13
+2199:  [3] AVMOpcode(Xset)		Line: 131, Column: 5
+2200:  [CodePoint(Internal(2203))] AVMOpcode(Noop)		Line: 132, Column: 5
+2201:  [4] AVMOpcode(Xset)		Line: 132, Column: 5
+2202:  [CodePoint(Internal(2211))] AVMOpcode(Jump)		Line: 132, Column: 5
+2203:  [3] AVMOpcode(Xget)		Line: 133, Column: 20
+2204:  [2] AVMOpcode(Xget)		Line: 133, Column: 15
+2205:  [CodePoint(Internal(2207))] AVMOpcode(Noop)		Line: 133, Column: 15
+2206:  [CodePoint(Internal(4981))] AVMOpcode(Jump)		Line: 133, Column: 15
+2207:  AVMOpcode(DebugPrint)		Line: 133, Column: 9
+2208:  [3] AVMOpcode(Xget)		Line: 134, Column: 13
+2209:  [1] AVMOpcode(Plus)		Line: 134, Column: 13
+2210:  [3] AVMOpcode(Xset)		Line: 134, Column: 9
+2211:  [1] AVMOpcode(Xget)		Line: 132, Column: 16
+2212:  [3] AVMOpcode(Xget)		Line: 132, Column: 12
+2213:  AVMOpcode(LessThan)		Line: 132, Column: 12
+2214:  [4] AVMOpcode(Xget)		Line: 132, Column: 5
+2215:  AVMOpcode(Cjump)		Line: 132, Column: 5
+2216:  [1] AVMOpcode(Xget)		Line: 136, Column: 12
+2217:  AVMOpcode(AuxPop)		Line: 136, Column: 5
+2218:  AVMOpcode(Pop)		Line: 136, Column: 5
+2219:  AVMOpcode(AuxPop)		Line: 136, Column: 5
+2220:  AVMOpcode(Jump)		Line: 136, Column: 5
+2221:  AVMOpcode(AuxPush)		Line: 19, Column: 1
+2222:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 19, Column: 1
+2223:  [0] AVMOpcode(Xset)		Line: 19, Column: 1
+2224:  [0] AVMOpcode(Xget)		Line: 20, Column: 12
+2225:  AVMOpcode(AuxPop)		Line: 20, Column: 5
+2226:  AVMOpcode(Pop)		Line: 20, Column: 5
+2227:  AVMOpcode(AuxPop)		Line: 20, Column: 5
+2228:  AVMOpcode(Jump)		Line: 20, Column: 5
+2229:  AVMOpcode(AuxPush)		Line: 23, Column: 1
+2230:  [Tuple(_, _)] AVMOpcode(AuxPush)		Line: 23, Column: 1
+2231:  [0] AVMOpcode(Xset)		Line: 23, Column: 1
+2232:  [1] AVMOpcode(Xset)		Line: 23, Column: 1
+2233:  [1] AVMOpcode(Xget)		Line: 24, Column: 23
+2234:  [0] AVMOpcode(Xget)		Line: 24, Column: 17
+2235:  AVMOpcode(Hash2)		Line: 24, Column: 12
+2236:  AVMOpcode(AuxPop)		Line: 24, Column: 5
+2237:  AVMOpcode(Pop)		Line: 24, Column: 5
+2238:  AVMOpcode(AuxPop)		Line: 24, Column: 5
+2239:  AVMOpcode(Jump)		Line: 24, Column: 5
+2240:  AVMOpcode(AuxPush)		Line: 27, Column: 1
+2241:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 27, Column: 1
+2242:  [0] AVMOpcode(Xset)		Line: 27, Column: 1
+2243:  [0] AVMOpcode(Xget)		Line: 30, Column: 26
+2244:  [1] AVMOpcode(Hash2)		Line: 30, Column: 9
+2245:  [0] AVMOpcode(Xget)		Line: 29, Column: 26
+2246:  [0] AVMOpcode(Hash2)		Line: 29, Column: 9
+2247:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 28, Column: 12
+2248:  [0] AVMOpcode(Tset)		Line: 28, Column: 12
+2249:  [1] AVMOpcode(Tset)		Line: 28, Column: 12
+2250:  AVMOpcode(AuxPop)		Line: 28, Column: 5
+2251:  AVMOpcode(Pop)		Line: 28, Column: 5
+2252:  AVMOpcode(AuxPop)		Line: 28, Column: 5
+2253:  AVMOpcode(Jump)		Line: 28, Column: 5
+2254:  AVMOpcode(AuxPush)		Line: 34, Column: 1
+2255:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 34, Column: 1
+2256:  [0] AVMOpcode(Xset)		Line: 34, Column: 1
+2257:  [1] AVMOpcode(Xset)		Line: 34, Column: 1
+2258:  [2] AVMOpcode(Xset)		Line: 34, Column: 1
+2259:  [3] AVMOpcode(Xset)		Line: 34, Column: 1
+2260:  [CodePoint(Internal(2263))] AVMOpcode(Noop)		Line: 40, Column: 5
+2261:  [4] AVMOpcode(Xset)		Line: 40, Column: 5
+2262:  [CodePoint(Internal(2311))] AVMOpcode(Jump)		Line: 40, Column: 5
+2263:  [0] AVMOpcode(Xget)		Line: 41, Column: 37
+2264:  [CodePoint(Internal(2268))] AVMOpcode(PushStatic)		Line: 41, Column: 25
+2265:  [3] AVMOpcode(Tget)		Line: 41, Column: 25
+2266:  [1] AVMOpcode(Tget)		Line: 41, Column: 25
+2267:  AVMOpcode(Jump)		Line: 41, Column: 25
+2268:  AVMOpcode(Dup0)		Line: 41, Column: 9
+2269:  [0] AVMOpcode(Tget)		Line: 41, Column: 9
+2270:  [5] AVMOpcode(Xset)		Line: 41, Column: 9
+2271:  [1] AVMOpcode(Tget)		Line: 41, Column: 9
+2272:  [6] AVMOpcode(Xset)		Line: 41, Column: 9
+2273:  [6] AVMOpcode(Xget)		Line: 42, Column: 16
+2274:  [0] AVMOpcode(Xset)		Line: 42, Column: 9
+2275:  [3] AVMOpcode(Xget)		Line: 43, Column: 28
+2276:  [5] AVMOpcode(Xget)		Line: 43, Column: 22
+2277:  AVMOpcode(Mod)		Line: 43, Column: 17
+2278:  [7] AVMOpcode(Xset)		Line: 43, Column: 9
+2279:  [7] AVMOpcode(Xget)		Line: 45, Column: 54
+2280:  [2] AVMOpcode(Xget)		Line: 45, Column: 47
+2281:  AVMOpcode(Plus)		Line: 45, Column: 47
+2282:  [1] AVMOpcode(Xget)		Line: 45, Column: 43
+2283:  [CodePoint(Internal(2285))] AVMOpcode(Noop)		Line: 45, Column: 43
+2284:  [CodePoint(Internal(4981))] AVMOpcode(Jump)		Line: 45, Column: 43
+2285:  [1] AVMOpcode(Noop)		Line: 45, Column: 38
+2286:  [3] AVMOpcode(Xget)		Line: 45, Column: 34
+2287:  [2] AVMOpcode(Xget)		Line: 45, Column: 27
+2288:  AVMOpcode(Plus)		Line: 45, Column: 27
+2289:  AVMOpcode(Minus)		Line: 45, Column: 27
+2290:  [1] AVMOpcode(Noop)		Line: 44, Column: 54
+2291:  [3] AVMOpcode(Xget)		Line: 44, Column: 50
+2292:  [2] AVMOpcode(Xget)		Line: 44, Column: 43
+2293:  AVMOpcode(Plus)		Line: 44, Column: 43
+2294:  AVMOpcode(Minus)		Line: 44, Column: 43
+2295:  [1] AVMOpcode(Xget)		Line: 44, Column: 39
+2296:  [CodePoint(Internal(2298))] AVMOpcode(Noop)		Line: 44, Column: 39
+2297:  [CodePoint(Internal(4981))] AVMOpcode(Jump)		Line: 44, Column: 39
+2298:  [7] AVMOpcode(Xget)		Line: 44, Column: 34
+2299:  [2] AVMOpcode(Xget)		Line: 44, Column: 27
+2300:  AVMOpcode(Plus)		Line: 44, Column: 27
+2301:  [1] AVMOpcode(Xget)		Line: 44, Column: 15
+2302:  [CodePoint(Internal(2304))] AVMOpcode(Noop)		Line: 44, Column: 15
+2303:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 44, Column: 15
+2304:  [CodePoint(Internal(2306))] AVMOpcode(Noop)		Line: 44, Column: 15
+2305:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 44, Column: 15
+2306:  [1] AVMOpcode(Xset)		Line: 44, Column: 9
+2307:  [1] AVMOpcode(Noop)		Line: 46, Column: 19
+2308:  [3] AVMOpcode(Xget)		Line: 46, Column: 15
+2309:  AVMOpcode(Minus)		Line: 46, Column: 15
+2310:  [3] AVMOpcode(Xset)		Line: 46, Column: 9
+2311:  [3] AVMOpcode(Xget)		Line: 40, Column: 12
+2312:  [1] AVMOpcode(LessThan)		Line: 40, Column: 12
+2313:  [4] AVMOpcode(Xget)		Line: 40, Column: 5
+2314:  AVMOpcode(Cjump)		Line: 40, Column: 5
+2315:  [0] AVMOpcode(Xget)		Line: 48, Column: 18
+2316:  [1] AVMOpcode(Xget)		Line: 48, Column: 13
+2317:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 48, Column: 12
+2318:  [0] AVMOpcode(Tset)		Line: 48, Column: 12
+2319:  [1] AVMOpcode(Tset)		Line: 48, Column: 12
+2320:  AVMOpcode(AuxPop)		Line: 48, Column: 5
+2321:  AVMOpcode(Pop)		Line: 48, Column: 5
+2322:  AVMOpcode(AuxPop)		Line: 48, Column: 5
+2323:  AVMOpcode(Jump)		Line: 48, Column: 5
+2324:  AVMOpcode(AuxPush)		Line: 24, Column: 1
+2325:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 24, Column: 1
+2326:  [0] AVMOpcode(Xset)		Line: 24, Column: 1
+2327:  [_] AVMOpcode(Noop)		Line: 29, Column: 19
+2328:  [0] AVMOpcode(Xget)		Line: 29, Column: 33
+2329:  [CodePoint(Internal(2331))] AVMOpcode(Noop)		Line: 29, Column: 19
+2330:  [CodePoint(Internal(4918))] AVMOpcode(Jump)		Line: 29, Column: 19
+2331:  [0] AVMOpcode(Noop)		Line: 28, Column: 18
+2332:  [0] AVMOpcode(Noop)		Line: 27, Column: 18
+2333:  [0] AVMOpcode(Xget)		Line: 26, Column: 19
+2334:  [Tuple(_, _, _, _)] AVMOpcode(Noop)		Line: 25, Column: 12
+2335:  [0] AVMOpcode(Tset)		Line: 25, Column: 12
+2336:  [1] AVMOpcode(Tset)		Line: 25, Column: 12
+2337:  [2] AVMOpcode(Tset)		Line: 25, Column: 12
+2338:  [3] AVMOpcode(Tset)		Line: 25, Column: 12
+2339:  AVMOpcode(AuxPop)		Line: 25, Column: 5
+2340:  AVMOpcode(Pop)		Line: 25, Column: 5
+2341:  AVMOpcode(AuxPop)		Line: 25, Column: 5
+2342:  AVMOpcode(Jump)		Line: 25, Column: 5
+2343:  AVMOpcode(AuxPush)		Line: 33, Column: 1
+2344:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 33, Column: 1
+2345:  [0] AVMOpcode(Xset)		Line: 33, Column: 1
+2346:  [0] AVMOpcode(Xget)		Line: 34, Column: 25
+2347:  [2] AVMOpcode(Tget)		Line: 34, Column: 25
+2348:  [0] AVMOpcode(Xget)		Line: 34, Column: 12
+2349:  [1] AVMOpcode(Tget)		Line: 34, Column: 12
+2350:  AVMOpcode(Equal)		Line: 34, Column: 12
+2351:  AVMOpcode(AuxPop)		Line: 34, Column: 5
+2352:  AVMOpcode(Pop)		Line: 34, Column: 5
+2353:  AVMOpcode(AuxPop)		Line: 34, Column: 5
+2354:  AVMOpcode(Jump)		Line: 34, Column: 5
+2355:  AVMOpcode(AuxPush)		Line: 37, Column: 1
+2356:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 37, Column: 1
+2357:  [0] AVMOpcode(Xset)		Line: 37, Column: 1
+2358:  [0] AVMOpcode(Xget)		Line: 38, Column: 44
+2359:  [2] AVMOpcode(Tget)		Line: 38, Column: 44
+2360:  [0] AVMOpcode(Xget)		Line: 38, Column: 29
+2361:  [0] AVMOpcode(Tget)		Line: 38, Column: 29
+2362:  [0] AVMOpcode(Xget)		Line: 38, Column: 14
+2363:  [1] AVMOpcode(Tget)		Line: 38, Column: 14
+2364:  [1] AVMOpcode(Plus)		Line: 38, Column: 14
+2365:  AVMOpcode(Mod)		Line: 38, Column: 13
+2366:  AVMOpcode(Equal)		Line: 38, Column: 12
+2367:  AVMOpcode(AuxPop)		Line: 38, Column: 5
+2368:  AVMOpcode(Pop)		Line: 38, Column: 5
+2369:  AVMOpcode(AuxPop)		Line: 38, Column: 5
+2370:  AVMOpcode(Jump)		Line: 38, Column: 5
+2371:  AVMOpcode(AuxPush)		Line: 41, Column: 1
+2372:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 41, Column: 1
+2373:  [0] AVMOpcode(Xset)		Line: 41, Column: 1
+2374:  [0] AVMOpcode(Xget)		Line: 42, Column: 51
+2375:  [0] AVMOpcode(Tget)		Line: 42, Column: 51
+2376:  [0] AVMOpcode(Xget)		Line: 42, Column: 38
+2377:  [2] AVMOpcode(Tget)		Line: 42, Column: 38
+2378:  [0] AVMOpcode(Xget)		Line: 42, Column: 25
+2379:  [0] AVMOpcode(Tget)		Line: 42, Column: 25
+2380:  [0] AVMOpcode(Xget)		Line: 42, Column: 13
+2381:  [1] AVMOpcode(Tget)		Line: 42, Column: 13
+2382:  AVMOpcode(Plus)		Line: 42, Column: 13
+2383:  AVMOpcode(Minus)		Line: 42, Column: 13
+2384:  AVMOpcode(Mod)		Line: 42, Column: 12
+2385:  AVMOpcode(AuxPop)		Line: 42, Column: 5
+2386:  AVMOpcode(Pop)		Line: 42, Column: 5
+2387:  AVMOpcode(AuxPop)		Line: 42, Column: 5
+2388:  AVMOpcode(Jump)		Line: 42, Column: 5
+2389:  AVMOpcode(AuxPush)		Line: 45, Column: 1
+2390:  [Tuple(_, _, _)] AVMOpcode(AuxPush)		Line: 45, Column: 1
+2391:  [0] AVMOpcode(Xset)		Line: 45, Column: 1
+2392:  [1] AVMOpcode(Xset)		Line: 45, Column: 1
+2393:  [0] AVMOpcode(Xget)		Line: 46, Column: 29
+2394:  [CodePoint(Internal(2398))] AVMOpcode(PushStatic)		Line: 46, Column: 9
+2395:  [3] AVMOpcode(Tget)		Line: 46, Column: 9
+2396:  [2] AVMOpcode(Tget)		Line: 46, Column: 9
+2397:  AVMOpcode(Jump)		Line: 46, Column: 9
+2398:  AVMOpcode(IsZero)		Line: 46, Column: 5
+2399:  [CodePoint(Internal(2405))] AVMOpcode(Cjump)		Line: 46, Column: 5
+2400:  [0] AVMOpcode(Xget)		Line: 47, Column: 16
+2401:  AVMOpcode(AuxPop)		Line: 47, Column: 9
+2402:  AVMOpcode(Pop)		Line: 47, Column: 9
+2403:  AVMOpcode(AuxPop)		Line: 47, Column: 9
+2404:  AVMOpcode(Jump)		Line: 47, Column: 9
+2405:  [0] AVMOpcode(Xget)		Line: 49, Column: 24
+2406:  [1] AVMOpcode(Tget)		Line: 49, Column: 24
+2407:  [2] AVMOpcode(Xset)		Line: 49, Column: 9
+2408:  [1] AVMOpcode(Xget)		Line: 51, Column: 66
+2409:  [2] AVMOpcode(Xget)		Line: 51, Column: 54
+2410:  [0] AVMOpcode(Xget)		Line: 51, Column: 35
+2411:  [3] AVMOpcode(Tget)		Line: 51, Column: 35
+2412:  [CodePoint(Internal(2414))] AVMOpcode(Noop)		Line: 51, Column: 35
+2413:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 51, Column: 35
+2414:  [0] AVMOpcode(Xget)		Line: 50, Column: 49
+2415:  [0] AVMOpcode(Tget)		Line: 50, Column: 49
+2416:  [2] AVMOpcode(Xget)		Line: 50, Column: 35
+2417:  [1] AVMOpcode(Plus)		Line: 50, Column: 35
+2418:  AVMOpcode(Mod)		Line: 50, Column: 34
+2419:  [0] AVMOpcode(Xget)		Line: 50, Column: 16
+2420:  [1] AVMOpcode(Tset)		Line: 50, Column: 16
+2421:  [3] AVMOpcode(Tset)		Line: 50, Column: 16
+2422:  AVMOpcode(AuxPop)		Line: 50, Column: 9
+2423:  AVMOpcode(Pop)		Line: 50, Column: 9
+2424:  AVMOpcode(AuxPop)		Line: 50, Column: 9
+2425:  AVMOpcode(Jump)		Line: 50, Column: 9
+2426:  AVMOpcode(AuxPush)		Line: 55, Column: 1
+2427:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 55, Column: 1
+2428:  [0] AVMOpcode(Xset)		Line: 55, Column: 1
+2429:  [0] AVMOpcode(Xget)		Line: 56, Column: 30
+2430:  [CodePoint(Internal(2434))] AVMOpcode(PushStatic)		Line: 56, Column: 9
+2431:  [3] AVMOpcode(Tget)		Line: 56, Column: 9
+2432:  [3] AVMOpcode(Tget)		Line: 56, Column: 9
+2433:  AVMOpcode(Jump)		Line: 56, Column: 9
+2434:  AVMOpcode(IsZero)		Line: 56, Column: 5
+2435:  [CodePoint(Internal(2440))] AVMOpcode(Cjump)		Line: 56, Column: 5
+2436:  [Tuple(0)] AVMOpcode(AuxPop)		Line: 57, Column: 9
+2437:  AVMOpcode(Pop)		Line: 57, Column: 9
+2438:  AVMOpcode(AuxPop)		Line: 57, Column: 9
+2439:  AVMOpcode(Jump)		Line: 57, Column: 9
+2440:  [0] AVMOpcode(Xget)		Line: 61, Column: 24
+2441:  [2] AVMOpcode(Tget)		Line: 61, Column: 24
+2442:  [0] AVMOpcode(Xget)		Line: 61, Column: 13
+2443:  [3] AVMOpcode(Tget)		Line: 61, Column: 13
+2444:  [CodePoint(Internal(2446))] AVMOpcode(Noop)		Line: 61, Column: 13
+2445:  [CodePoint(Internal(4981))] AVMOpcode(Jump)		Line: 61, Column: 13
+2446:  [0] AVMOpcode(Xget)		Line: 60, Column: 47
+2447:  [0] AVMOpcode(Tget)		Line: 60, Column: 47
+2448:  [0] AVMOpcode(Xget)		Line: 60, Column: 32
+2449:  [2] AVMOpcode(Tget)		Line: 60, Column: 32
+2450:  [1] AVMOpcode(Plus)		Line: 60, Column: 32
+2451:  AVMOpcode(Mod)		Line: 60, Column: 31
+2452:  [0] AVMOpcode(Xget)		Line: 60, Column: 13
+2453:  [2] AVMOpcode(Tset)		Line: 60, Column: 13
+2454:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 59, Column: 21
+2455:  [0] AVMOpcode(Tset)		Line: 59, Column: 21
+2456:  [1] AVMOpcode(Tset)		Line: 59, Column: 21
+2457:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 59, Column: 16
+2458:  [1] AVMOpcode(Tset)		Line: 59, Column: 16
+2459:  AVMOpcode(AuxPop)		Line: 59, Column: 9
+2460:  AVMOpcode(Pop)		Line: 59, Column: 9
+2461:  AVMOpcode(AuxPop)		Line: 59, Column: 9
+2462:  AVMOpcode(Jump)		Line: 59, Column: 9
+2463:  AVMOpcode(AuxPush)		Line: 66, Column: 1
+2464:  [Tuple(_, _, _, _, _)] AVMOpcode(AuxPush)		Line: 66, Column: 1
+2465:  [0] AVMOpcode(Xset)		Line: 66, Column: 1
+2466:  [1] AVMOpcode(Xset)		Line: 66, Column: 1
+2467:  [0] AVMOpcode(Xget)		Line: 67, Column: 20
+2468:  [0] AVMOpcode(Tget)		Line: 67, Column: 20
+2469:  [1] AVMOpcode(Xget)		Line: 67, Column: 9
+2470:  AVMOpcode(GreaterThan)		Line: 67, Column: 9
+2471:  [CodePoint(Internal(2473))] AVMOpcode(Cjump)		Line: 67, Column: 5
+2472:  AVMOpcode(Panic)		Line: 68, Column: 9
+2473:  [1] AVMOpcode(Xget)		Line: 70, Column: 33
+2474:  [CodePoint(Internal(2478))] AVMOpcode(PushStatic)		Line: 70, Column: 16
+2475:  [3] AVMOpcode(Tget)		Line: 70, Column: 16
+2476:  [4] AVMOpcode(Tget)		Line: 70, Column: 16
+2477:  AVMOpcode(Jump)		Line: 70, Column: 16
+2478:  [2] AVMOpcode(Xset)		Line: 70, Column: 5
+2479:  [CodePoint(Internal(2482))] AVMOpcode(Noop)		Line: 71, Column: 5
+2480:  [3] AVMOpcode(Xset)		Line: 71, Column: 5
+2481:  [CodePoint(Internal(2507))] AVMOpcode(Jump)		Line: 71, Column: 5
+2482:  [0] AVMOpcode(Xget)		Line: 72, Column: 45
+2483:  [CodePoint(Internal(2487))] AVMOpcode(PushStatic)		Line: 72, Column: 28
+2484:  [3] AVMOpcode(Tget)		Line: 72, Column: 28
+2485:  [5] AVMOpcode(Tget)		Line: 72, Column: 28
+2486:  AVMOpcode(Jump)		Line: 72, Column: 28
+2487:  AVMOpcode(Dup0)		Line: 72, Column: 9
+2488:  [0] AVMOpcode(Tget)		Line: 72, Column: 9
+2489:  AVMOpcode(IsZero)		Line: 72, Column: 9
+2490:  [CodePoint(Internal(2505))] AVMOpcode(Cjump)		Line: 72, Column: 9
+2491:  [1] AVMOpcode(Tget)		Line: 72, Column: 9
+2492:  [4] AVMOpcode(Xset)		Line: 72, Column: 9
+2493:  [4] AVMOpcode(Xget)		Line: 73, Column: 17
+2494:  [0] AVMOpcode(Tget)		Line: 73, Column: 17
+2495:  [0] AVMOpcode(Xset)		Line: 73, Column: 13
+2496:  [4] AVMOpcode(Xget)		Line: 74, Column: 43
+2497:  [1] AVMOpcode(Tget)		Line: 74, Column: 43
+2498:  [2] AVMOpcode(Xget)		Line: 74, Column: 37
+2499:  [CodePoint(Internal(2503))] AVMOpcode(PushStatic)		Line: 74, Column: 20
+2500:  [3] AVMOpcode(Tget)		Line: 74, Column: 20
+2501:  [6] AVMOpcode(Tget)		Line: 74, Column: 20
+2502:  AVMOpcode(Jump)		Line: 74, Column: 20
+2503:  [2] AVMOpcode(Xset)		Line: 74, Column: 13
+2504:  [CodePoint(Internal(2507))] AVMOpcode(Jump)		Line: 72, Column: 9
+2505:  AVMOpcode(Pop)		Line: 72, Column: 9
+2506:  AVMOpcode(Panic)		Line: 76, Column: 13
+2507:  [0] AVMOpcode(Xget)		Line: 71, Column: 36
+2508:  [CodePoint(Internal(2512))] AVMOpcode(PushStatic)		Line: 71, Column: 15
+2509:  [3] AVMOpcode(Tget)		Line: 71, Column: 15
+2510:  [3] AVMOpcode(Tget)		Line: 71, Column: 15
+2511:  AVMOpcode(Jump)		Line: 71, Column: 15
+2512:  AVMOpcode(IsZero)		Line: 71, Column: 13
+2513:  [3] AVMOpcode(Xget)		Line: 71, Column: 5
+2514:  AVMOpcode(Cjump)		Line: 71, Column: 5
+2515:  [2] AVMOpcode(Xget)		Line: 79, Column: 12
+2516:  AVMOpcode(AuxPop)		Line: 79, Column: 5
+2517:  AVMOpcode(Pop)		Line: 79, Column: 5
+2518:  AVMOpcode(AuxPop)		Line: 79, Column: 5
+2519:  AVMOpcode(Jump)		Line: 79, Column: 5
+2520:  AVMOpcode(AuxPush)		Line: 84, Column: 1
+2521:  [_] AVMOpcode(AuxPush)		Line: 84, Column: 1
+2522:  [8] AVMOpcode(Noop)		Line: 85, Column: 29
+2523:  [CodePoint(Internal(2527))] AVMOpcode(PushStatic)		Line: 85, Column: 12
+2524:  [3] AVMOpcode(Tget)		Line: 85, Column: 12
+2525:  [4] AVMOpcode(Tget)		Line: 85, Column: 12
+2526:  AVMOpcode(Jump)		Line: 85, Column: 12
+2527:  AVMOpcode(AuxPop)		Line: 85, Column: 5
+2528:  AVMOpcode(Pop)		Line: 85, Column: 5
+2529:  AVMOpcode(AuxPop)		Line: 85, Column: 5
+2530:  AVMOpcode(Jump)		Line: 85, Column: 5
+2531:  AVMOpcode(AuxPush)		Line: 88, Column: 1
+2532:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 88, Column: 1
+2533:  [0] AVMOpcode(Xset)		Line: 88, Column: 1
+2534:  [0] AVMOpcode(Xget)		Line: 89, Column: 33
+2535:  [CodePoint(Internal(2539))] AVMOpcode(PushStatic)		Line: 89, Column: 12
+2536:  [3] AVMOpcode(Tget)		Line: 89, Column: 12
+2537:  [3] AVMOpcode(Tget)		Line: 89, Column: 12
+2538:  AVMOpcode(Jump)		Line: 89, Column: 12
+2539:  AVMOpcode(AuxPop)		Line: 89, Column: 5
+2540:  AVMOpcode(Pop)		Line: 89, Column: 5
+2541:  AVMOpcode(AuxPop)		Line: 89, Column: 5
+2542:  AVMOpcode(Jump)		Line: 89, Column: 5
+2543:  AVMOpcode(AuxPush)		Line: 92, Column: 1
+2544:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 92, Column: 1
+2545:  [0] AVMOpcode(Xset)		Line: 92, Column: 1
+2546:  [0] AVMOpcode(Xget)		Line: 93, Column: 30
+2547:  [CodePoint(Internal(2551))] AVMOpcode(PushStatic)		Line: 93, Column: 12
+2548:  [3] AVMOpcode(Tget)		Line: 93, Column: 12
+2549:  [7] AVMOpcode(Tget)		Line: 93, Column: 12
+2550:  AVMOpcode(Jump)		Line: 93, Column: 12
+2551:  AVMOpcode(AuxPop)		Line: 93, Column: 5
+2552:  AVMOpcode(Pop)		Line: 93, Column: 5
+2553:  AVMOpcode(AuxPop)		Line: 93, Column: 5
+2554:  AVMOpcode(Jump)		Line: 93, Column: 5
+2555:  AVMOpcode(AuxPush)		Line: 96, Column: 1
+2556:  [Tuple(_, _)] AVMOpcode(AuxPush)		Line: 96, Column: 1
+2557:  [0] AVMOpcode(Xset)		Line: 96, Column: 1
+2558:  [1] AVMOpcode(Xset)		Line: 96, Column: 1
+2559:  [0] AVMOpcode(Xget)		Line: 97, Column: 29
+2560:  [CodePoint(Internal(2564))] AVMOpcode(PushStatic)		Line: 97, Column: 9
+2561:  [3] AVMOpcode(Tget)		Line: 97, Column: 9
+2562:  [2] AVMOpcode(Tget)		Line: 97, Column: 9
+2563:  AVMOpcode(Jump)		Line: 97, Column: 9
+2564:  AVMOpcode(IsZero)		Line: 97, Column: 5
+2565:  [CodePoint(Internal(2576))] AVMOpcode(Cjump)		Line: 97, Column: 5
+2566:  [0] AVMOpcode(Xget)		Line: 98, Column: 38
+2567:  [0] AVMOpcode(Tget)		Line: 98, Column: 38
+2568:  [2] AVMOpcode(Mul)		Line: 98, Column: 36
+2569:  [0] AVMOpcode(Xget)		Line: 98, Column: 33
+2570:  [CodePoint(Internal(2574))] AVMOpcode(PushStatic)		Line: 98, Column: 13
+2571:  [4] AVMOpcode(Tget)		Line: 98, Column: 13
+2572:  [0] AVMOpcode(Tget)		Line: 98, Column: 13
+2573:  AVMOpcode(Jump)		Line: 98, Column: 13
+2574:  [0] AVMOpcode(Xset)		Line: 98, Column: 9
+2575:  [CodePoint(Internal(2576))] AVMOpcode(Jump)		Line: 97, Column: 5
+2576:  [1] AVMOpcode(Xget)		Line: 100, Column: 32
+2577:  [0] AVMOpcode(Xget)		Line: 100, Column: 29
+2578:  [CodePoint(Internal(2582))] AVMOpcode(PushStatic)		Line: 100, Column: 12
+2579:  [3] AVMOpcode(Tget)		Line: 100, Column: 12
+2580:  [6] AVMOpcode(Tget)		Line: 100, Column: 12
+2581:  AVMOpcode(Jump)		Line: 100, Column: 12
+2582:  AVMOpcode(AuxPop)		Line: 100, Column: 5
+2583:  AVMOpcode(Pop)		Line: 100, Column: 5
+2584:  AVMOpcode(AuxPop)		Line: 100, Column: 5
+2585:  AVMOpcode(Jump)		Line: 100, Column: 5
+2586:  AVMOpcode(AuxPush)		Line: 103, Column: 1
+2587:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 103, Column: 1
+2588:  [0] AVMOpcode(Xset)		Line: 103, Column: 1
+2589:  [0] AVMOpcode(Xget)		Line: 104, Column: 29
+2590:  [CodePoint(Internal(2594))] AVMOpcode(PushStatic)		Line: 104, Column: 12
+2591:  [3] AVMOpcode(Tget)		Line: 104, Column: 12
+2592:  [5] AVMOpcode(Tget)		Line: 104, Column: 12
+2593:  AVMOpcode(Jump)		Line: 104, Column: 12
+2594:  AVMOpcode(AuxPop)		Line: 104, Column: 5
+2595:  AVMOpcode(Pop)		Line: 104, Column: 5
+2596:  AVMOpcode(AuxPop)		Line: 104, Column: 5
+2597:  AVMOpcode(Jump)		Line: 104, Column: 5
+2598:  AVMOpcode(AuxPush)		Line: 28, Column: 1
+2599:  [Tuple(_, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 28, Column: 1
+2600:  [0] AVMOpcode(Xset)		Line: 28, Column: 1
+2601:  [1] AVMOpcode(Xset)		Line: 28, Column: 1
+2602:  [2] AVMOpcode(Xset)		Line: 28, Column: 1
+2603:  [2] AVMOpcode(Xget)		Line: 29, Column: 9
+2604:  [32] AVMOpcode(Equal)		Line: 29, Column: 9
+2605:  AVMOpcode(IsZero)		Line: 29, Column: 5
+2606:  [CodePoint(Internal(2618))] AVMOpcode(Cjump)		Line: 29, Column: 5
+2607:  [1] AVMOpcode(Xget)		Line: 30, Column: 42
+2608:  [0] AVMOpcode(Xget)		Line: 30, Column: 38
+2609:  [CodePoint(Internal(2613))] AVMOpcode(PushStatic)		Line: 30, Column: 21
+2610:  [2] AVMOpcode(Tget)		Line: 30, Column: 21
+2611:  [1] AVMOpcode(Tget)		Line: 30, Column: 21
+2612:  AVMOpcode(Jump)		Line: 30, Column: 21
+2613:  AVMOpcode(Hash)		Line: 30, Column: 16
+2614:  AVMOpcode(AuxPop)		Line: 30, Column: 9
+2615:  AVMOpcode(Pop)		Line: 30, Column: 9
+2616:  AVMOpcode(AuxPop)		Line: 30, Column: 9
+2617:  AVMOpcode(Jump)		Line: 30, Column: 9
+2618:  [2] AVMOpcode(Xget)		Line: 32, Column: 9
+2619:  [64] AVMOpcode(Equal)		Line: 32, Column: 9
+2620:  AVMOpcode(IsZero)		Line: 32, Column: 5
+2621:  [CodePoint(Internal(2640))] AVMOpcode(Cjump)		Line: 32, Column: 5
+2622:  [1] AVMOpcode(Xget)		Line: 35, Column: 42
+2623:  [32] AVMOpcode(Plus)		Line: 35, Column: 42
+2624:  [0] AVMOpcode(Xget)		Line: 35, Column: 38
+2625:  [CodePoint(Internal(2629))] AVMOpcode(PushStatic)		Line: 35, Column: 21
+2626:  [2] AVMOpcode(Tget)		Line: 35, Column: 21
+2627:  [1] AVMOpcode(Tget)		Line: 35, Column: 21
+2628:  AVMOpcode(Jump)		Line: 35, Column: 21
+2629:  [1] AVMOpcode(Xget)		Line: 34, Column: 42
+2630:  [0] AVMOpcode(Xget)		Line: 34, Column: 38
+2631:  [CodePoint(Internal(2635))] AVMOpcode(PushStatic)		Line: 34, Column: 21
+2632:  [2] AVMOpcode(Tget)		Line: 34, Column: 21
+2633:  [1] AVMOpcode(Tget)		Line: 34, Column: 21
+2634:  AVMOpcode(Jump)		Line: 34, Column: 21
+2635:  AVMOpcode(Hash2)		Line: 33, Column: 16
+2636:  AVMOpcode(AuxPop)		Line: 33, Column: 9
+2637:  AVMOpcode(Pop)		Line: 33, Column: 9
+2638:  AVMOpcode(AuxPop)		Line: 33, Column: 9
+2639:  AVMOpcode(Jump)		Line: 33, Column: 9
+2640:  [0] AVMOpcode(Noop)		Line: 39, Column: 56
+2641:  [0] AVMOpcode(Noop)		Line: 39, Column: 54
+2642:  [0] AVMOpcode(Noop)		Line: 39, Column: 52
+2643:  [0] AVMOpcode(Noop)		Line: 39, Column: 50
+2644:  [0] AVMOpcode(Noop)		Line: 39, Column: 48
+2645:  [0] AVMOpcode(Noop)		Line: 39, Column: 46
+2646:  [0] AVMOpcode(Noop)		Line: 39, Column: 44
+2647:  [Tuple(_, _, _, _, _, _, _)] AVMOpcode(Noop)		Line: 39, Column: 43
+2648:  [0] AVMOpcode(Tset)		Line: 39, Column: 43
+2649:  [1] AVMOpcode(Tset)		Line: 39, Column: 43
+2650:  [2] AVMOpcode(Tset)		Line: 39, Column: 43
+2651:  [3] AVMOpcode(Tset)		Line: 39, Column: 43
+2652:  [4] AVMOpcode(Tset)		Line: 39, Column: 43
+2653:  [5] AVMOpcode(Tset)		Line: 39, Column: 43
+2654:  [6] AVMOpcode(Tset)		Line: 39, Column: 43
+2655:  [3] AVMOpcode(Xset)		Line: 39, Column: 5
+2656:  [CodePoint(Internal(2659))] AVMOpcode(Noop)		Line: 42, Column: 5
+2657:  [4] AVMOpcode(Xset)		Line: 42, Column: 5
+2658:  [CodePoint(Internal(2673))] AVMOpcode(Jump)		Line: 42, Column: 5
+2659:  [1] AVMOpcode(Xget)		Line: 44, Column: 60
+2660:  [0] AVMOpcode(Xget)		Line: 44, Column: 56
+2661:  [3] AVMOpcode(Xget)		Line: 44, Column: 43
+2662:  [CodePoint(Internal(2664))] AVMOpcode(Noop)		Line: 44, Column: 27
+2663:  [CodePoint(Internal(2739))] AVMOpcode(Jump)		Line: 44, Column: 27
+2664:  AVMOpcode(Keccakf)		Line: 44, Column: 80
+2665:  [3] AVMOpcode(Xset)		Line: 44, Column: 9
+2666:  [1] AVMOpcode(Xget)		Line: 45, Column: 18
+2667:  [136] AVMOpcode(Plus)		Line: 45, Column: 18
+2668:  [1] AVMOpcode(Xset)		Line: 45, Column: 9
+2669:  [136] AVMOpcode(Noop)		Line: 46, Column: 25
+2670:  [2] AVMOpcode(Xget)		Line: 46, Column: 18
+2671:  AVMOpcode(Minus)		Line: 46, Column: 18
+2672:  [2] AVMOpcode(Xset)		Line: 46, Column: 9
+2673:  [2] AVMOpcode(Xget)		Line: 42, Column: 12
+2674:  [136] AVMOpcode(GreaterThan)		Line: 42, Column: 12
+2675:  AVMOpcode(IsZero)		Line: 42, Column: 12
+2676:  [4] AVMOpcode(Xget)		Line: 42, Column: 5
+2677:  AVMOpcode(Cjump)		Line: 42, Column: 5
+2678:  [136] AVMOpcode(Noop)		Line: 50, Column: 35
+2679:  [CodePoint(Internal(2682))] AVMOpcode(PushStatic)		Line: 50, Column: 21
+2680:  [0] AVMOpcode(Tget)		Line: 50, Column: 21
+2681:  AVMOpcode(Jump)		Line: 50, Column: 21
+2682:  [5] AVMOpcode(Xset)		Line: 50, Column: 5
+2683:  [2] AVMOpcode(Xget)		Line: 51, Column: 58
+2684:  [0] AVMOpcode(Noop)		Line: 51, Column: 55
+2685:  [5] AVMOpcode(Xget)		Line: 51, Column: 44
+2686:  [1] AVMOpcode(Xget)		Line: 51, Column: 36
+2687:  [0] AVMOpcode(Xget)		Line: 51, Column: 32
+2688:  [CodePoint(Internal(2692))] AVMOpcode(PushStatic)		Line: 51, Column: 17
+2689:  [4] AVMOpcode(Tget)		Line: 51, Column: 17
+2690:  [1] AVMOpcode(Tget)		Line: 51, Column: 17
+2691:  AVMOpcode(Jump)		Line: 51, Column: 17
+2692:  [5] AVMOpcode(Xset)		Line: 51, Column: 5
+2693:  [2] AVMOpcode(Xget)		Line: 54, Column: 9
+2694:  [135] AVMOpcode(Equal)		Line: 54, Column: 9
+2695:  AVMOpcode(IsZero)		Line: 54, Column: 5
+2696:  [CodePoint(Internal(2706))] AVMOpcode(Cjump)		Line: 54, Column: 5
+2697:  [129] AVMOpcode(Noop)		Line: 56, Column: 55
+2698:  [135] AVMOpcode(Noop)		Line: 56, Column: 50
+2699:  [5] AVMOpcode(Xget)		Line: 56, Column: 39
+2700:  [CodePoint(Internal(2704))] AVMOpcode(PushStatic)		Line: 56, Column: 21
+2701:  [2] AVMOpcode(Tget)		Line: 56, Column: 21
+2702:  [4] AVMOpcode(Tget)		Line: 56, Column: 21
+2703:  AVMOpcode(Jump)		Line: 56, Column: 21
+2704:  [5] AVMOpcode(Xset)		Line: 56, Column: 9
+2705:  [CodePoint(Internal(2720))] AVMOpcode(Jump)		Line: 54, Column: 5
+2706:  [1] AVMOpcode(Noop)		Line: 63, Column: 13
+2707:  [2] AVMOpcode(Xget)		Line: 62, Column: 13
+2708:  [128] AVMOpcode(Noop)		Line: 61, Column: 47
+2709:  [135] AVMOpcode(Noop)		Line: 61, Column: 42
+2710:  [5] AVMOpcode(Xget)		Line: 61, Column: 31
+2711:  [CodePoint(Internal(2715))] AVMOpcode(PushStatic)		Line: 61, Column: 13
+2712:  [2] AVMOpcode(Tget)		Line: 61, Column: 13
+2713:  [4] AVMOpcode(Tget)		Line: 61, Column: 13
+2714:  AVMOpcode(Jump)		Line: 61, Column: 13
+2715:  [CodePoint(Internal(2719))] AVMOpcode(PushStatic)		Line: 60, Column: 21
+2716:  [2] AVMOpcode(Tget)		Line: 60, Column: 21
+2717:  [4] AVMOpcode(Tget)		Line: 60, Column: 21
+2718:  AVMOpcode(Jump)		Line: 60, Column: 21
+2719:  [5] AVMOpcode(Xset)		Line: 60, Column: 9
+2720:  [0] AVMOpcode(Noop)		Line: 68, Column: 63
+2721:  [5] AVMOpcode(Xget)		Line: 68, Column: 52
+2722:  [3] AVMOpcode(Xget)		Line: 68, Column: 39
+2723:  [CodePoint(Internal(2725))] AVMOpcode(Noop)		Line: 68, Column: 23
+2724:  [CodePoint(Internal(2739))] AVMOpcode(Jump)		Line: 68, Column: 23
+2725:  AVMOpcode(Keccakf)		Line: 68, Column: 78
+2726:  [3] AVMOpcode(Xset)		Line: 68, Column: 5
+2727:  [3] AVMOpcode(Xget)		Line: 71, Column: 34
+2728:  [0] AVMOpcode(Dup0)		Line: 71, Column: 34
+2729:  [7] AVMOpcode(GreaterThan)		Line: 71, Column: 34
+2730:  [CodePoint(Internal(2732))] AVMOpcode(Cjump)		Line: 71, Column: 34
+2731:  AVMOpcode(Panic)		Line: 71, Column: 34
+2732:  AVMOpcode(Tget)		Line: 71, Column: 34
+2733:  [CodePoint(Internal(2735))] AVMOpcode(Noop)		Line: 71, Column: 20
+2734:  [CodePoint(Internal(2853))] AVMOpcode(Jump)		Line: 71, Column: 20
+2735:  AVMOpcode(AuxPop)		Line: 71, Column: 5
+2736:  AVMOpcode(Pop)		Line: 71, Column: 5
+2737:  AVMOpcode(AuxPop)		Line: 71, Column: 5
+2738:  AVMOpcode(Jump)		Line: 71, Column: 5
+2739:  AVMOpcode(AuxPush)		Line: 74, Column: 1
+2740:  [Tuple(_, _, _)] AVMOpcode(AuxPush)		Line: 74, Column: 1
+2741:  [0] AVMOpcode(Xset)		Line: 74, Column: 1
+2742:  [1] AVMOpcode(Xset)		Line: 74, Column: 1
+2743:  [2] AVMOpcode(Xset)		Line: 74, Column: 1
+2744:  [2] AVMOpcode(Xget)		Line: 84, Column: 65
+2745:  [128] AVMOpcode(Plus)		Line: 84, Column: 65
+2746:  [1] AVMOpcode(Xget)		Line: 84, Column: 61
+2747:  [CodePoint(Internal(2751))] AVMOpcode(PushStatic)		Line: 84, Column: 45
+2748:  [4] AVMOpcode(Tget)		Line: 84, Column: 45
+2749:  [2] AVMOpcode(Tget)		Line: 84, Column: 45
+2750:  AVMOpcode(Jump)		Line: 84, Column: 45
+2751:  [CodePoint(Internal(2753))] AVMOpcode(Noop)		Line: 84, Column: 32
+2752:  [CodePoint(Internal(2887))] AVMOpcode(Jump)		Line: 84, Column: 32
+2753:  [0] AVMOpcode(Xget)		Line: 84, Column: 15
+2754:  [4] AVMOpcode(Dup0)		Line: 84, Column: 15
+2755:  [7] AVMOpcode(GreaterThan)		Line: 84, Column: 15
+2756:  [CodePoint(Internal(2758))] AVMOpcode(Cjump)		Line: 84, Column: 15
+2757:  AVMOpcode(Panic)		Line: 84, Column: 15
+2758:  AVMOpcode(Tget)		Line: 84, Column: 15
+2759:  AVMOpcode(BitwiseXor)		Line: 84, Column: 15
+2760:  [2] AVMOpcode(Xget)		Line: 82, Column: 67
+2761:  [96] AVMOpcode(Plus)		Line: 82, Column: 67
+2762:  [1] AVMOpcode(Xget)		Line: 82, Column: 63
+2763:  [CodePoint(Internal(2767))] AVMOpcode(PushStatic)		Line: 82, Column: 46
+2764:  [2] AVMOpcode(Tget)		Line: 82, Column: 46
+2765:  [1] AVMOpcode(Tget)		Line: 82, Column: 46
+2766:  AVMOpcode(Jump)		Line: 82, Column: 46
+2767:  [CodePoint(Internal(2769))] AVMOpcode(Noop)		Line: 82, Column: 32
+2768:  [CodePoint(Internal(2853))] AVMOpcode(Jump)		Line: 82, Column: 32
+2769:  [0] AVMOpcode(Xget)		Line: 82, Column: 15
+2770:  [3] AVMOpcode(Dup0)		Line: 82, Column: 15
+2771:  [7] AVMOpcode(GreaterThan)		Line: 82, Column: 15
+2772:  [CodePoint(Internal(2774))] AVMOpcode(Cjump)		Line: 82, Column: 15
+2773:  AVMOpcode(Panic)		Line: 82, Column: 15
+2774:  AVMOpcode(Tget)		Line: 82, Column: 15
+2775:  AVMOpcode(BitwiseXor)		Line: 82, Column: 15
+2776:  [2] AVMOpcode(Xget)		Line: 80, Column: 67
+2777:  [64] AVMOpcode(Plus)		Line: 80, Column: 67
+2778:  [1] AVMOpcode(Xget)		Line: 80, Column: 63
+2779:  [CodePoint(Internal(2783))] AVMOpcode(PushStatic)		Line: 80, Column: 46
+2780:  [2] AVMOpcode(Tget)		Line: 80, Column: 46
+2781:  [1] AVMOpcode(Tget)		Line: 80, Column: 46
+2782:  AVMOpcode(Jump)		Line: 80, Column: 46
+2783:  [CodePoint(Internal(2785))] AVMOpcode(Noop)		Line: 80, Column: 32
+2784:  [CodePoint(Internal(2853))] AVMOpcode(Jump)		Line: 80, Column: 32
+2785:  [0] AVMOpcode(Xget)		Line: 80, Column: 15
+2786:  [2] AVMOpcode(Dup0)		Line: 80, Column: 15
+2787:  [7] AVMOpcode(GreaterThan)		Line: 80, Column: 15
+2788:  [CodePoint(Internal(2790))] AVMOpcode(Cjump)		Line: 80, Column: 15
+2789:  AVMOpcode(Panic)		Line: 80, Column: 15
+2790:  AVMOpcode(Tget)		Line: 80, Column: 15
+2791:  AVMOpcode(BitwiseXor)		Line: 80, Column: 15
+2792:  [2] AVMOpcode(Xget)		Line: 78, Column: 67
+2793:  [32] AVMOpcode(Plus)		Line: 78, Column: 67
+2794:  [1] AVMOpcode(Xget)		Line: 78, Column: 63
+2795:  [CodePoint(Internal(2799))] AVMOpcode(PushStatic)		Line: 78, Column: 46
+2796:  [2] AVMOpcode(Tget)		Line: 78, Column: 46
+2797:  [1] AVMOpcode(Tget)		Line: 78, Column: 46
+2798:  AVMOpcode(Jump)		Line: 78, Column: 46
+2799:  [CodePoint(Internal(2801))] AVMOpcode(Noop)		Line: 78, Column: 32
+2800:  [CodePoint(Internal(2853))] AVMOpcode(Jump)		Line: 78, Column: 32
+2801:  [0] AVMOpcode(Xget)		Line: 78, Column: 15
+2802:  [1] AVMOpcode(Dup0)		Line: 78, Column: 15
+2803:  [7] AVMOpcode(GreaterThan)		Line: 78, Column: 15
+2804:  [CodePoint(Internal(2806))] AVMOpcode(Cjump)		Line: 78, Column: 15
+2805:  AVMOpcode(Panic)		Line: 78, Column: 15
+2806:  AVMOpcode(Tget)		Line: 78, Column: 15
+2807:  AVMOpcode(BitwiseXor)		Line: 78, Column: 15
+2808:  [2] AVMOpcode(Xget)		Line: 76, Column: 67
+2809:  [1] AVMOpcode(Xget)		Line: 76, Column: 63
+2810:  [CodePoint(Internal(2814))] AVMOpcode(PushStatic)		Line: 76, Column: 46
+2811:  [2] AVMOpcode(Tget)		Line: 76, Column: 46
+2812:  [1] AVMOpcode(Tget)		Line: 76, Column: 46
+2813:  AVMOpcode(Jump)		Line: 76, Column: 46
+2814:  [CodePoint(Internal(2816))] AVMOpcode(Noop)		Line: 76, Column: 32
+2815:  [CodePoint(Internal(2853))] AVMOpcode(Jump)		Line: 76, Column: 32
+2816:  [0] AVMOpcode(Xget)		Line: 76, Column: 15
+2817:  [0] AVMOpcode(Dup0)		Line: 76, Column: 15
+2818:  [7] AVMOpcode(GreaterThan)		Line: 76, Column: 15
+2819:  [CodePoint(Internal(2821))] AVMOpcode(Cjump)		Line: 76, Column: 15
+2820:  AVMOpcode(Panic)		Line: 76, Column: 15
+2821:  AVMOpcode(Tget)		Line: 76, Column: 15
+2822:  AVMOpcode(BitwiseXor)		Line: 76, Column: 15
+2823:  [0] AVMOpcode(Xget)		Line: 75, Column: 12
+2824:  [0] AVMOpcode(Dup0)		Line: 75, Column: 12
+2825:  [7] AVMOpcode(GreaterThan)		Line: 75, Column: 12
+2826:  [CodePoint(Internal(2828))] AVMOpcode(Cjump)		Line: 75, Column: 12
+2827:  AVMOpcode(Panic)		Line: 75, Column: 12
+2828:  AVMOpcode(Tset)		Line: 75, Column: 12
+2829:  [1] AVMOpcode(Dup0)		Line: 75, Column: 12
+2830:  [7] AVMOpcode(GreaterThan)		Line: 75, Column: 12
+2831:  [CodePoint(Internal(2833))] AVMOpcode(Cjump)		Line: 75, Column: 12
+2832:  AVMOpcode(Panic)		Line: 75, Column: 12
+2833:  AVMOpcode(Tset)		Line: 75, Column: 12
+2834:  [2] AVMOpcode(Dup0)		Line: 75, Column: 12
+2835:  [7] AVMOpcode(GreaterThan)		Line: 75, Column: 12
+2836:  [CodePoint(Internal(2838))] AVMOpcode(Cjump)		Line: 75, Column: 12
+2837:  AVMOpcode(Panic)		Line: 75, Column: 12
+2838:  AVMOpcode(Tset)		Line: 75, Column: 12
+2839:  [3] AVMOpcode(Dup0)		Line: 75, Column: 12
+2840:  [7] AVMOpcode(GreaterThan)		Line: 75, Column: 12
+2841:  [CodePoint(Internal(2843))] AVMOpcode(Cjump)		Line: 75, Column: 12
+2842:  AVMOpcode(Panic)		Line: 75, Column: 12
+2843:  AVMOpcode(Tset)		Line: 75, Column: 12
+2844:  [4] AVMOpcode(Dup0)		Line: 75, Column: 12
+2845:  [7] AVMOpcode(GreaterThan)		Line: 75, Column: 12
+2846:  [CodePoint(Internal(2848))] AVMOpcode(Cjump)		Line: 75, Column: 12
+2847:  AVMOpcode(Panic)		Line: 75, Column: 12
+2848:  AVMOpcode(Tset)		Line: 75, Column: 12
+2849:  AVMOpcode(AuxPop)		Line: 75, Column: 5
+2850:  AVMOpcode(Pop)		Line: 75, Column: 5
+2851:  AVMOpcode(AuxPop)		Line: 75, Column: 5
+2852:  AVMOpcode(Jump)		Line: 75, Column: 5
+2853:  AVMOpcode(AuxPush)		Line: 99, Column: 1
+2854:  [Tuple(_, _, _, _)] AVMOpcode(AuxPush)		Line: 99, Column: 1
+2855:  [0] AVMOpcode(Xset)		Line: 99, Column: 1
+2856:  [0] AVMOpcode(Noop)		Line: 100, Column: 15
+2857:  [1] AVMOpcode(Xset)		Line: 100, Column: 5
+2858:  [0] AVMOpcode(Noop)		Line: 101, Column: 13
+2859:  [2] AVMOpcode(Xset)		Line: 101, Column: 5
+2860:  [CodePoint(Internal(2863))] AVMOpcode(Noop)		Line: 102, Column: 5
+2861:  [3] AVMOpcode(Xset)		Line: 102, Column: 5
+2862:  [CodePoint(Internal(2878))] AVMOpcode(Jump)		Line: 102, Column: 5
+2863:  [0] AVMOpcode(Xget)		Line: 103, Column: 56
+2864:  [0xffffffffffffffff] AVMOpcode(BitwiseAnd)		Line: 103, Column: 56
+2865:  [CodePoint(Internal(2867))] AVMOpcode(Noop)		Line: 103, Column: 43
+2866:  [CodePoint(Internal(2887))] AVMOpcode(Jump)		Line: 103, Column: 43
+2867:  [1] AVMOpcode(Xget)		Line: 103, Column: 37
+2868:  [0x10000000000000000] AVMOpcode(Mul)		Line: 103, Column: 15
+2869:  AVMOpcode(Plus)		Line: 103, Column: 15
+2870:  [1] AVMOpcode(Xset)		Line: 103, Column: 9
+2871:  [0x10000000000000000] AVMOpcode(Noop)		Line: 104, Column: 17
+2872:  [0] AVMOpcode(Xget)		Line: 104, Column: 13
+2873:  AVMOpcode(Div)		Line: 104, Column: 13
+2874:  [0] AVMOpcode(Xset)		Line: 104, Column: 9
+2875:  [2] AVMOpcode(Xget)		Line: 105, Column: 13
+2876:  [1] AVMOpcode(Plus)		Line: 105, Column: 13
+2877:  [2] AVMOpcode(Xset)		Line: 105, Column: 9
+2878:  [2] AVMOpcode(Xget)		Line: 102, Column: 12
+2879:  [4] AVMOpcode(GreaterThan)		Line: 102, Column: 12
+2880:  [3] AVMOpcode(Xget)		Line: 102, Column: 5
+2881:  AVMOpcode(Cjump)		Line: 102, Column: 5
+2882:  [1] AVMOpcode(Xget)		Line: 107, Column: 12
+2883:  AVMOpcode(AuxPop)		Line: 107, Column: 5
+2884:  AVMOpcode(Pop)		Line: 107, Column: 5
+2885:  AVMOpcode(AuxPop)		Line: 107, Column: 5
+2886:  AVMOpcode(Jump)		Line: 107, Column: 5
+2887:  AVMOpcode(AuxPush)		Line: 92, Column: 1
+2888:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 92, Column: 1
+2889:  [0] AVMOpcode(Xset)		Line: 92, Column: 1
+2890:  [0x100000000] AVMOpcode(Noop)		Line: 93, Column: 50
+2891:  [0] AVMOpcode(Xget)		Line: 93, Column: 46
+2892:  AVMOpcode(Div)		Line: 93, Column: 46
+2893:  [4294967295] AVMOpcode(BitwiseAnd)		Line: 93, Column: 45
+2894:  [0] AVMOpcode(Xget)		Line: 93, Column: 11
+2895:  [4294967295] AVMOpcode(BitwiseAnd)		Line: 93, Column: 11
+2896:  [0x100000000] AVMOpcode(Mul)		Line: 93, Column: 10
+2897:  AVMOpcode(BitwiseOr)		Line: 93, Column: 9
+2898:  [0] AVMOpcode(Xset)		Line: 93, Column: 5
+2899:  [65536] AVMOpcode(Noop)		Line: 94, Column: 50
+2900:  [0] AVMOpcode(Xget)		Line: 94, Column: 46
+2901:  AVMOpcode(Div)		Line: 94, Column: 46
+2902:  [0xffff0000ffff] AVMOpcode(BitwiseAnd)		Line: 94, Column: 45
+2903:  [0] AVMOpcode(Xget)		Line: 94, Column: 11
+2904:  [0xffff0000ffff] AVMOpcode(BitwiseAnd)		Line: 94, Column: 11
+2905:  [65536] AVMOpcode(Mul)		Line: 94, Column: 10
+2906:  AVMOpcode(BitwiseOr)		Line: 94, Column: 9
+2907:  [0] AVMOpcode(Xset)		Line: 94, Column: 5
+2908:  [256] AVMOpcode(Noop)		Line: 95, Column: 50
+2909:  [0] AVMOpcode(Xget)		Line: 95, Column: 46
+2910:  AVMOpcode(Div)		Line: 95, Column: 46
+2911:  [0xff00ff00ff00ff] AVMOpcode(BitwiseAnd)		Line: 95, Column: 45
+2912:  [0] AVMOpcode(Xget)		Line: 95, Column: 11
+2913:  [0xff00ff00ff00ff] AVMOpcode(BitwiseAnd)		Line: 95, Column: 11
+2914:  [256] AVMOpcode(Mul)		Line: 95, Column: 10
+2915:  AVMOpcode(BitwiseOr)		Line: 95, Column: 9
+2916:  [0] AVMOpcode(Xset)		Line: 95, Column: 5
+2917:  [0] AVMOpcode(Xget)		Line: 96, Column: 12
+2918:  AVMOpcode(AuxPop)		Line: 96, Column: 5
+2919:  AVMOpcode(Pop)		Line: 96, Column: 5
+2920:  AVMOpcode(AuxPop)		Line: 96, Column: 5
+2921:  AVMOpcode(Jump)		Line: 96, Column: 5
+2922:  AVMOpcode(AuxPush)		Line: 88, Column: 1
+2923:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 88, Column: 1
+2924:  [0] AVMOpcode(Xset)		Line: 88, Column: 1
+2925:  [0] AVMOpcode(Xget)		Line: 89, Column: 16
+2926:  AVMOpcode(Keccakf)		Line: 89, Column: 30
+2927:  AVMOpcode(AuxPop)		Line: 89, Column: 5
+2928:  AVMOpcode(Pop)		Line: 89, Column: 5
+2929:  AVMOpcode(AuxPop)		Line: 89, Column: 5
+2930:  AVMOpcode(Jump)		Line: 89, Column: 5
+2931:  AVMOpcode(AuxPush)		Line: 32, Column: 1
+2932:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 32, Column: 1
+2933:  [0] AVMOpcode(Xset)		Line: 32, Column: 1
+2934:  [Tuple(0)] AVMOpcode(Noop)		Line: 37, Column: 16
+2935:  [0] AVMOpcode(Noop)		Line: 36, Column: 24
+2936:  [0] AVMOpcode(Xget)		Line: 35, Column: 34
+2937:  [CodePoint(Internal(2941))] AVMOpcode(PushStatic)		Line: 35, Column: 19
+2938:  [4] AVMOpcode(Tget)		Line: 35, Column: 19
+2939:  [3] AVMOpcode(Tget)		Line: 35, Column: 19
+2940:  AVMOpcode(Jump)		Line: 35, Column: 19
+2941:  [0] AVMOpcode(Xget)		Line: 34, Column: 19
+2942:  [Tuple(_, _, _, _)] AVMOpcode(Noop)		Line: 33, Column: 12
+2943:  [0] AVMOpcode(Tset)		Line: 33, Column: 12
+2944:  [1] AVMOpcode(Tset)		Line: 33, Column: 12
+2945:  [2] AVMOpcode(Tset)		Line: 33, Column: 12
+2946:  [3] AVMOpcode(Tset)		Line: 33, Column: 12
+2947:  AVMOpcode(AuxPop)		Line: 33, Column: 5
+2948:  AVMOpcode(Pop)		Line: 33, Column: 5
+2949:  AVMOpcode(AuxPop)		Line: 33, Column: 5
+2950:  AVMOpcode(Jump)		Line: 33, Column: 5
+2951:  AVMOpcode(AuxPush)		Line: 41, Column: 1
+2952:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 41, Column: 1
+2953:  [0] AVMOpcode(Xset)		Line: 41, Column: 1
+2954:  [0] AVMOpcode(Xget)		Line: 42, Column: 32
+2955:  [1] AVMOpcode(Tget)		Line: 42, Column: 32
+2956:  [0] AVMOpcode(Xget)		Line: 42, Column: 12
+2957:  [2] AVMOpcode(Tget)		Line: 42, Column: 12
+2958:  AVMOpcode(LessThan)		Line: 42, Column: 12
+2959:  AVMOpcode(IsZero)		Line: 42, Column: 12
+2960:  AVMOpcode(AuxPop)		Line: 42, Column: 5
+2961:  AVMOpcode(Pop)		Line: 42, Column: 5
+2962:  AVMOpcode(AuxPop)		Line: 42, Column: 5
+2963:  AVMOpcode(Jump)		Line: 42, Column: 5
+2964:  AVMOpcode(AuxPush)		Line: 45, Column: 1
+2965:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 45, Column: 1
+2966:  [0] AVMOpcode(Xset)		Line: 45, Column: 1
+2967:  [0] AVMOpcode(Xget)		Line: 46, Column: 12
+2968:  [2] AVMOpcode(Tget)		Line: 46, Column: 12
+2969:  AVMOpcode(AuxPop)		Line: 46, Column: 5
+2970:  AVMOpcode(Pop)		Line: 46, Column: 5
+2971:  AVMOpcode(AuxPop)		Line: 46, Column: 5
+2972:  AVMOpcode(Jump)		Line: 46, Column: 5
+2973:  AVMOpcode(AuxPush)		Line: 49, Column: 1
+2974:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 49, Column: 1
+2975:  [0] AVMOpcode(Xset)		Line: 49, Column: 1
+2976:  [0] AVMOpcode(Xget)		Line: 50, Column: 26
+2977:  [2] AVMOpcode(Tget)		Line: 50, Column: 26
+2978:  [0] AVMOpcode(Xget)		Line: 50, Column: 12
+2979:  [1] AVMOpcode(Tget)		Line: 50, Column: 12
+2980:  AVMOpcode(Minus)		Line: 50, Column: 12
+2981:  AVMOpcode(AuxPop)		Line: 50, Column: 5
+2982:  AVMOpcode(Pop)		Line: 50, Column: 5
+2983:  AVMOpcode(AuxPop)		Line: 50, Column: 5
+2984:  AVMOpcode(Jump)		Line: 50, Column: 5
+2985:  AVMOpcode(AuxPush)		Line: 53, Column: 1
+2986:  [Tuple(_, _, _)] AVMOpcode(AuxPush)		Line: 53, Column: 1
+2987:  [0] AVMOpcode(Xset)		Line: 53, Column: 1
+2988:  [1] AVMOpcode(Xset)		Line: 53, Column: 1
+2989:  [1] AVMOpcode(Xget)		Line: 54, Column: 40
+2990:  [0] AVMOpcode(Xget)		Line: 54, Column: 21
+2991:  [2] AVMOpcode(Tget)		Line: 54, Column: 21
+2992:  AVMOpcode(Plus)		Line: 54, Column: 21
+2993:  [2] AVMOpcode(Xset)		Line: 54, Column: 5
+2994:  [0] AVMOpcode(Xget)		Line: 55, Column: 22
+2995:  [1] AVMOpcode(Tget)		Line: 55, Column: 22
+2996:  [2] AVMOpcode(Xget)		Line: 55, Column: 9
+2997:  AVMOpcode(GreaterThan)		Line: 55, Column: 9
+2998:  [CodePoint(Internal(3010))] AVMOpcode(Cjump)		Line: 55, Column: 5
+2999:  [Tuple(0)] AVMOpcode(Noop)		Line: 56, Column: 72
+3000:  [2] AVMOpcode(Xget)		Line: 56, Column: 46
+3001:  [0] AVMOpcode(Xget)		Line: 56, Column: 21
+3002:  [2] AVMOpcode(Tset)		Line: 56, Column: 21
+3003:  [3] AVMOpcode(Tset)		Line: 56, Column: 21
+3004:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 56, Column: 16
+3005:  [1] AVMOpcode(Tset)		Line: 56, Column: 16
+3006:  AVMOpcode(AuxPop)		Line: 56, Column: 9
+3007:  AVMOpcode(Pop)		Line: 56, Column: 9
+3008:  AVMOpcode(AuxPop)		Line: 56, Column: 9
+3009:  AVMOpcode(Jump)		Line: 56, Column: 9
+3010:  [Tuple(0)] AVMOpcode(AuxPop)		Line: 58, Column: 9
+3011:  AVMOpcode(Pop)		Line: 58, Column: 9
+3012:  AVMOpcode(AuxPop)		Line: 58, Column: 9
+3013:  AVMOpcode(Jump)		Line: 58, Column: 9
+3014:  AVMOpcode(AuxPush)		Line: 62, Column: 1
+3015:  [Tuple(_, _)] AVMOpcode(AuxPush)		Line: 62, Column: 1
+3016:  [0] AVMOpcode(Xset)		Line: 62, Column: 1
+3017:  [1] AVMOpcode(Xset)		Line: 62, Column: 1
+3018:  [0] AVMOpcode(Xget)		Line: 63, Column: 16
+3019:  [1] AVMOpcode(Tget)		Line: 63, Column: 16
+3020:  [1] AVMOpcode(Xget)		Line: 63, Column: 9
+3021:  AVMOpcode(LessThan)		Line: 63, Column: 9
+3022:  AVMOpcode(IsZero)		Line: 63, Column: 5
+3023:  [CodePoint(Internal(3045))] AVMOpcode(Cjump)		Line: 63, Column: 5
+3024:  [0] AVMOpcode(Xget)		Line: 64, Column: 20
+3025:  [2] AVMOpcode(Tget)		Line: 64, Column: 20
+3026:  [1] AVMOpcode(Xget)		Line: 64, Column: 13
+3027:  AVMOpcode(LessThan)		Line: 64, Column: 13
+3028:  AVMOpcode(IsZero)		Line: 64, Column: 9
+3029:  [CodePoint(Internal(3038))] AVMOpcode(Cjump)		Line: 64, Column: 9
+3030:  [0] AVMOpcode(Xget)		Line: 65, Column: 40
+3031:  [2] AVMOpcode(Tget)		Line: 65, Column: 40
+3032:  [0] AVMOpcode(Xget)		Line: 65, Column: 20
+3033:  [1] AVMOpcode(Tset)		Line: 65, Column: 20
+3034:  AVMOpcode(AuxPop)		Line: 65, Column: 13
+3035:  AVMOpcode(Pop)		Line: 65, Column: 13
+3036:  AVMOpcode(AuxPop)		Line: 65, Column: 13
+3037:  AVMOpcode(Jump)		Line: 65, Column: 13
+3038:  [1] AVMOpcode(Xget)		Line: 67, Column: 40
+3039:  [0] AVMOpcode(Xget)		Line: 67, Column: 20
+3040:  [1] AVMOpcode(Tset)		Line: 67, Column: 20
+3041:  AVMOpcode(AuxPop)		Line: 67, Column: 13
+3042:  AVMOpcode(Pop)		Line: 67, Column: 13
+3043:  AVMOpcode(AuxPop)		Line: 67, Column: 13
+3044:  AVMOpcode(Jump)		Line: 67, Column: 13
+3045:  [0] AVMOpcode(Xget)		Line: 70, Column: 16
+3046:  AVMOpcode(AuxPop)		Line: 70, Column: 9
+3047:  AVMOpcode(Pop)		Line: 70, Column: 9
+3048:  AVMOpcode(AuxPop)		Line: 70, Column: 9
+3049:  AVMOpcode(Jump)		Line: 70, Column: 9
+3050:  AVMOpcode(AuxPush)		Line: 74, Column: 1
+3051:  [Tuple(_, _, _, _)] AVMOpcode(AuxPush)		Line: 74, Column: 1
+3052:  [0] AVMOpcode(Xset)		Line: 74, Column: 1
+3053:  [0] AVMOpcode(Xget)		Line: 75, Column: 29
+3054:  [1] AVMOpcode(Tget)		Line: 75, Column: 29
+3055:  [0] AVMOpcode(Xget)		Line: 75, Column: 9
+3056:  [2] AVMOpcode(Tget)		Line: 75, Column: 9
+3057:  AVMOpcode(LessThan)		Line: 75, Column: 9
+3058:  [CodePoint(Internal(3063))] AVMOpcode(Cjump)		Line: 75, Column: 5
+3059:  [Tuple(0)] AVMOpcode(AuxPop)		Line: 76, Column: 9
+3060:  AVMOpcode(Pop)		Line: 76, Column: 9
+3061:  AVMOpcode(AuxPop)		Line: 76, Column: 9
+3062:  AVMOpcode(Jump)		Line: 76, Column: 9
+3063:  [0] AVMOpcode(Noop)		Line: 78, Column: 21
+3064:  [1] AVMOpcode(Xset)		Line: 78, Column: 9
+3065:  [32] AVMOpcode(Noop)		Line: 79, Column: 46
+3066:  [0] AVMOpcode(Xget)		Line: 79, Column: 27
+3067:  [2] AVMOpcode(Tget)		Line: 79, Column: 27
+3068:  AVMOpcode(Mod)		Line: 79, Column: 27
+3069:  [2] AVMOpcode(Xset)		Line: 79, Column: 9
+3070:  [0] AVMOpcode(Xget)		Line: 80, Column: 26
+3071:  [3] AVMOpcode(Tget)		Line: 80, Column: 26
+3072:  AVMOpcode(Dup0)		Line: 80, Column: 9
+3073:  [0] AVMOpcode(Tget)		Line: 80, Column: 9
+3074:  AVMOpcode(IsZero)		Line: 80, Column: 9
+3075:  [CodePoint(Internal(3101))] AVMOpcode(Cjump)		Line: 80, Column: 9
+3076:  [1] AVMOpcode(Tget)		Line: 80, Column: 9
+3077:  [3] AVMOpcode(Xset)		Line: 80, Column: 9
+3078:  [2] AVMOpcode(Xget)		Line: 81, Column: 17
+3079:  [0] AVMOpcode(Equal)		Line: 81, Column: 17
+3080:  AVMOpcode(IsZero)		Line: 81, Column: 13
+3081:  [CodePoint(Internal(3098))] AVMOpcode(Cjump)		Line: 81, Column: 13
+3082:  [0] AVMOpcode(Xget)		Line: 82, Column: 55
+3083:  [2] AVMOpcode(Tget)		Line: 82, Column: 55
+3084:  [0] AVMOpcode(Xget)		Line: 82, Column: 42
+3085:  [0] AVMOpcode(Tget)		Line: 82, Column: 42
+3086:  [CodePoint(Internal(3090))] AVMOpcode(PushStatic)		Line: 82, Column: 25
+3087:  [2] AVMOpcode(Tget)		Line: 82, Column: 25
+3088:  [1] AVMOpcode(Tget)		Line: 82, Column: 25
+3089:  AVMOpcode(Jump)		Line: 82, Column: 25
+3090:  [1] AVMOpcode(Xset)		Line: 82, Column: 17
+3091:  [1] AVMOpcode(Xget)		Line: 83, Column: 44
+3092:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 83, Column: 39
+3093:  [1] AVMOpcode(Tset)		Line: 83, Column: 39
+3094:  [0] AVMOpcode(Xget)		Line: 83, Column: 22
+3095:  [3] AVMOpcode(Tset)		Line: 83, Column: 22
+3096:  [0] AVMOpcode(Xset)		Line: 83, Column: 17
+3097:  [CodePoint(Internal(3100))] AVMOpcode(Jump)		Line: 81, Column: 13
+3098:  [3] AVMOpcode(Xget)		Line: 85, Column: 25
+3099:  [1] AVMOpcode(Xset)		Line: 85, Column: 17
+3100:  [CodePoint(Internal(3118))] AVMOpcode(Jump)		Line: 80, Column: 9
+3101:  AVMOpcode(Pop)		Line: 80, Column: 9
+3102:  [0] AVMOpcode(Xget)		Line: 88, Column: 51
+3103:  [2] AVMOpcode(Tget)		Line: 88, Column: 51
+3104:  [0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0] AVMOpcode(BitwiseAnd)		Line: 88, Column: 51
+3105:  [0] AVMOpcode(Xget)		Line: 88, Column: 38
+3106:  [0] AVMOpcode(Tget)		Line: 88, Column: 38
+3107:  [CodePoint(Internal(3111))] AVMOpcode(PushStatic)		Line: 88, Column: 21
+3108:  [2] AVMOpcode(Tget)		Line: 88, Column: 21
+3109:  [1] AVMOpcode(Tget)		Line: 88, Column: 21
+3110:  AVMOpcode(Jump)		Line: 88, Column: 21
+3111:  [1] AVMOpcode(Xset)		Line: 88, Column: 13
+3112:  [1] AVMOpcode(Xget)		Line: 89, Column: 40
+3113:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 89, Column: 35
+3114:  [1] AVMOpcode(Tset)		Line: 89, Column: 35
+3115:  [0] AVMOpcode(Xget)		Line: 89, Column: 18
+3116:  [3] AVMOpcode(Tset)		Line: 89, Column: 18
+3117:  [0] AVMOpcode(Xset)		Line: 89, Column: 13
+3118:  [2] AVMOpcode(Xget)		Line: 93, Column: 36
+3119:  [31] AVMOpcode(Minus)		Line: 93, Column: 33
+3120:  [8] AVMOpcode(Mul)		Line: 93, Column: 30
+3121:  [2] AVMOpcode(Exp)		Line: 93, Column: 57
+3122:  [1] AVMOpcode(Xget)		Line: 93, Column: 14
+3123:  AVMOpcode(Div)		Line: 93, Column: 14
+3124:  [255] AVMOpcode(BitwiseAnd)		Line: 93, Column: 13
+3125:  [0] AVMOpcode(Xget)		Line: 92, Column: 38
+3126:  [2] AVMOpcode(Tget)		Line: 92, Column: 38
+3127:  [1] AVMOpcode(Plus)		Line: 92, Column: 38
+3128:  [0] AVMOpcode(Xget)		Line: 92, Column: 13
+3129:  [2] AVMOpcode(Tset)		Line: 92, Column: 13
+3130:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 91, Column: 21
+3131:  [0] AVMOpcode(Tset)		Line: 91, Column: 21
+3132:  [1] AVMOpcode(Tset)		Line: 91, Column: 21
+3133:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 91, Column: 16
+3134:  [1] AVMOpcode(Tset)		Line: 91, Column: 16
+3135:  AVMOpcode(AuxPop)		Line: 91, Column: 9
+3136:  AVMOpcode(Pop)		Line: 91, Column: 9
+3137:  AVMOpcode(AuxPop)		Line: 91, Column: 9
+3138:  AVMOpcode(Jump)		Line: 91, Column: 9
+3139:  AVMOpcode(AuxPush)		Line: 98, Column: 1
+3140:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 98, Column: 1
+3141:  [0] AVMOpcode(Xset)		Line: 98, Column: 1
+3142:  [0] AVMOpcode(Xget)		Line: 99, Column: 30
+3143:  [1] AVMOpcode(Tget)		Line: 99, Column: 30
+3144:  [0] AVMOpcode(Xget)		Line: 99, Column: 9
+3145:  [2] AVMOpcode(Tget)		Line: 99, Column: 9
+3146:  [8] AVMOpcode(Plus)		Line: 99, Column: 9
+3147:  AVMOpcode(GreaterThan)		Line: 99, Column: 9
+3148:  AVMOpcode(IsZero)		Line: 99, Column: 5
+3149:  [CodePoint(Internal(3154))] AVMOpcode(Cjump)		Line: 99, Column: 5
+3150:  [Tuple(0)] AVMOpcode(AuxPop)		Line: 100, Column: 9
+3151:  AVMOpcode(Pop)		Line: 100, Column: 9
+3152:  AVMOpcode(AuxPop)		Line: 100, Column: 9
+3153:  AVMOpcode(Jump)		Line: 100, Column: 9
+3154:  [0] AVMOpcode(Xget)		Line: 104, Column: 42
+3155:  [2] AVMOpcode(Tget)		Line: 104, Column: 42
+3156:  [0] AVMOpcode(Xget)		Line: 104, Column: 29
+3157:  [0] AVMOpcode(Tget)		Line: 104, Column: 29
+3158:  [CodePoint(Internal(3162))] AVMOpcode(PushStatic)		Line: 104, Column: 13
+3159:  [4] AVMOpcode(Tget)		Line: 104, Column: 13
+3160:  [2] AVMOpcode(Tget)		Line: 104, Column: 13
+3161:  AVMOpcode(Jump)		Line: 104, Column: 13
+3162:  [Tuple(0)] AVMOpcode(Noop)		Line: 103, Column: 73
+3163:  [0] AVMOpcode(Xget)		Line: 103, Column: 38
+3164:  [2] AVMOpcode(Tget)		Line: 103, Column: 38
+3165:  [8] AVMOpcode(Plus)		Line: 103, Column: 38
+3166:  [0] AVMOpcode(Xget)		Line: 103, Column: 13
+3167:  [2] AVMOpcode(Tset)		Line: 103, Column: 13
+3168:  [3] AVMOpcode(Tset)		Line: 103, Column: 13
+3169:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 102, Column: 21
+3170:  [0] AVMOpcode(Tset)		Line: 102, Column: 21
+3171:  [1] AVMOpcode(Tset)		Line: 102, Column: 21
+3172:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 102, Column: 16
+3173:  [1] AVMOpcode(Tset)		Line: 102, Column: 16
+3174:  AVMOpcode(AuxPop)		Line: 102, Column: 9
+3175:  AVMOpcode(Pop)		Line: 102, Column: 9
+3176:  AVMOpcode(AuxPop)		Line: 102, Column: 9
+3177:  AVMOpcode(Jump)		Line: 102, Column: 9
+3178:  AVMOpcode(AuxPush)		Line: 109, Column: 1
+3179:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 109, Column: 1
+3180:  [0] AVMOpcode(Xset)		Line: 109, Column: 1
+3181:  [0] AVMOpcode(Xget)		Line: 110, Column: 31
+3182:  [1] AVMOpcode(Tget)		Line: 110, Column: 31
+3183:  [0] AVMOpcode(Xget)		Line: 110, Column: 9
+3184:  [2] AVMOpcode(Tget)		Line: 110, Column: 9
+3185:  [32] AVMOpcode(Plus)		Line: 110, Column: 9
+3186:  AVMOpcode(GreaterThan)		Line: 110, Column: 9
+3187:  AVMOpcode(IsZero)		Line: 110, Column: 5
+3188:  [CodePoint(Internal(3193))] AVMOpcode(Cjump)		Line: 110, Column: 5
+3189:  [Tuple(0)] AVMOpcode(AuxPop)		Line: 111, Column: 9
+3190:  AVMOpcode(Pop)		Line: 111, Column: 9
+3191:  AVMOpcode(AuxPop)		Line: 111, Column: 9
+3192:  AVMOpcode(Jump)		Line: 111, Column: 9
+3193:  [0] AVMOpcode(Xget)		Line: 115, Column: 43
+3194:  [2] AVMOpcode(Tget)		Line: 115, Column: 43
+3195:  [0] AVMOpcode(Xget)		Line: 115, Column: 30
+3196:  [0] AVMOpcode(Tget)		Line: 115, Column: 30
+3197:  [CodePoint(Internal(3201))] AVMOpcode(PushStatic)		Line: 115, Column: 13
+3198:  [2] AVMOpcode(Tget)		Line: 115, Column: 13
+3199:  [1] AVMOpcode(Tget)		Line: 115, Column: 13
+3200:  AVMOpcode(Jump)		Line: 115, Column: 13
+3201:  [Tuple(0)] AVMOpcode(Noop)		Line: 114, Column: 74
+3202:  [0] AVMOpcode(Xget)		Line: 114, Column: 38
+3203:  [2] AVMOpcode(Tget)		Line: 114, Column: 38
+3204:  [32] AVMOpcode(Plus)		Line: 114, Column: 38
+3205:  [0] AVMOpcode(Xget)		Line: 114, Column: 13
+3206:  [2] AVMOpcode(Tset)		Line: 114, Column: 13
+3207:  [3] AVMOpcode(Tset)		Line: 114, Column: 13
+3208:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 113, Column: 21
+3209:  [0] AVMOpcode(Tset)		Line: 113, Column: 21
+3210:  [1] AVMOpcode(Tset)		Line: 113, Column: 21
+3211:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 113, Column: 16
+3212:  [1] AVMOpcode(Tset)		Line: 113, Column: 16
+3213:  AVMOpcode(AuxPop)		Line: 113, Column: 9
+3214:  AVMOpcode(Pop)		Line: 113, Column: 9
+3215:  AVMOpcode(AuxPop)		Line: 113, Column: 9
+3216:  AVMOpcode(Jump)		Line: 113, Column: 9
+3217:  AVMOpcode(AuxPush)		Line: 120, Column: 1
+3218:  [Tuple(_, _)] AVMOpcode(AuxPush)		Line: 120, Column: 1
+3219:  [0] AVMOpcode(Xset)		Line: 120, Column: 1
+3220:  [1] AVMOpcode(Xset)		Line: 120, Column: 1
+3221:  [0] AVMOpcode(Xget)		Line: 121, Column: 37
+3222:  [1] AVMOpcode(Tget)		Line: 121, Column: 37
+3223:  [1] AVMOpcode(Xget)		Line: 121, Column: 28
+3224:  [0] AVMOpcode(Xget)		Line: 121, Column: 9
+3225:  [2] AVMOpcode(Tget)		Line: 121, Column: 9
+3226:  AVMOpcode(Plus)		Line: 121, Column: 9
+3227:  AVMOpcode(GreaterThan)		Line: 121, Column: 9
+3228:  AVMOpcode(IsZero)		Line: 121, Column: 5
+3229:  [CodePoint(Internal(3234))] AVMOpcode(Cjump)		Line: 121, Column: 5
+3230:  [Tuple(0)] AVMOpcode(AuxPop)		Line: 122, Column: 9
+3231:  AVMOpcode(Pop)		Line: 122, Column: 9
+3232:  AVMOpcode(AuxPop)		Line: 122, Column: 9
+3233:  AVMOpcode(Jump)		Line: 122, Column: 9
+3234:  [1] AVMOpcode(Xget)		Line: 127, Column: 58
+3235:  [0] AVMOpcode(Xget)		Line: 127, Column: 40
+3236:  [2] AVMOpcode(Tget)		Line: 127, Column: 40
+3237:  [0] AVMOpcode(Xget)		Line: 127, Column: 27
+3238:  [0] AVMOpcode(Tget)		Line: 127, Column: 27
+3239:  [CodePoint(Internal(3243))] AVMOpcode(PushStatic)		Line: 127, Column: 9
+3240:  [4] AVMOpcode(Tget)		Line: 127, Column: 9
+3241:  [4] AVMOpcode(Tget)		Line: 127, Column: 9
+3242:  AVMOpcode(Jump)		Line: 127, Column: 9
+3243:  [1] AVMOpcode(Xget)		Line: 126, Column: 53
+3244:  [0] AVMOpcode(Xget)		Line: 126, Column: 34
+3245:  [2] AVMOpcode(Tget)		Line: 126, Column: 34
+3246:  AVMOpcode(Plus)		Line: 126, Column: 34
+3247:  [0] AVMOpcode(Xget)		Line: 126, Column: 9
+3248:  [2] AVMOpcode(Tset)		Line: 126, Column: 9
+3249:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 125, Column: 17
+3250:  [0] AVMOpcode(Tset)		Line: 125, Column: 17
+3251:  [1] AVMOpcode(Tset)		Line: 125, Column: 17
+3252:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 125, Column: 12
+3253:  [1] AVMOpcode(Tset)		Line: 125, Column: 12
+3254:  AVMOpcode(AuxPop)		Line: 125, Column: 5
+3255:  AVMOpcode(Pop)		Line: 125, Column: 5
+3256:  AVMOpcode(AuxPop)		Line: 125, Column: 5
+3257:  AVMOpcode(Jump)		Line: 125, Column: 5
+3258:  AVMOpcode(AuxPush)		Line: 131, Column: 1
+3259:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 131, Column: 1
+3260:  [0] AVMOpcode(Xset)		Line: 131, Column: 1
+3261:  [0] AVMOpcode(Xget)		Line: 135, Column: 23
+3262:  [2] AVMOpcode(Tget)		Line: 135, Column: 23
+3263:  [0] AVMOpcode(Xget)		Line: 135, Column: 9
+3264:  [1] AVMOpcode(Tget)		Line: 135, Column: 9
+3265:  AVMOpcode(Minus)		Line: 135, Column: 9
+3266:  [0] AVMOpcode(Xget)		Line: 134, Column: 9
+3267:  [2] AVMOpcode(Tget)		Line: 134, Column: 9
+3268:  [0] AVMOpcode(Xget)		Line: 133, Column: 9
+3269:  [0] AVMOpcode(Tget)		Line: 133, Column: 9
+3270:  [CodePoint(Internal(3274))] AVMOpcode(PushStatic)		Line: 132, Column: 12
+3271:  [4] AVMOpcode(Tget)		Line: 132, Column: 12
+3272:  [4] AVMOpcode(Tget)		Line: 132, Column: 12
+3273:  AVMOpcode(Jump)		Line: 132, Column: 12
+3274:  AVMOpcode(AuxPop)		Line: 132, Column: 5
+3275:  AVMOpcode(Pop)		Line: 132, Column: 5
+3276:  AVMOpcode(AuxPop)		Line: 132, Column: 5
+3277:  AVMOpcode(Jump)		Line: 132, Column: 5
+3278:  AVMOpcode(AuxPush)		Line: 25, Column: 1
+3279:  [_] AVMOpcode(AuxPush)		Line: 25, Column: 1
+3280:  [Tuple(0)] AVMOpcode(AuxPop)		Line: 26, Column: 5
+3281:  AVMOpcode(Pop)		Line: 26, Column: 5
+3282:  AVMOpcode(AuxPop)		Line: 26, Column: 5
+3283:  AVMOpcode(Jump)		Line: 26, Column: 5
+3284:  AVMOpcode(AuxPush)		Line: 29, Column: 1
+3285:  [Tuple(_, _)] AVMOpcode(AuxPush)		Line: 29, Column: 1
+3286:  [0] AVMOpcode(Xset)		Line: 29, Column: 1
+3287:  [1] AVMOpcode(Xset)		Line: 29, Column: 1
+3288:  [0] AVMOpcode(Xget)		Line: 32, Column: 15
+3289:  [1] AVMOpcode(Xget)		Line: 31, Column: 14
+3290:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 30, Column: 17
+3291:  [0] AVMOpcode(Tset)		Line: 30, Column: 17
+3292:  [1] AVMOpcode(Tset)		Line: 30, Column: 17
+3293:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 30, Column: 12
+3294:  [1] AVMOpcode(Tset)		Line: 30, Column: 12
+3295:  AVMOpcode(AuxPop)		Line: 30, Column: 5
+3296:  AVMOpcode(Pop)		Line: 30, Column: 5
+3297:  AVMOpcode(AuxPop)		Line: 30, Column: 5
+3298:  AVMOpcode(Jump)		Line: 30, Column: 5
+3299:  AVMOpcode(AuxPush)		Line: 36, Column: 1
+3300:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 36, Column: 1
+3301:  [0] AVMOpcode(Xset)		Line: 36, Column: 1
+3302:  [Tuple(0)] AVMOpcode(Noop)		Line: 37, Column: 21
+3303:  [0] AVMOpcode(Xget)		Line: 37, Column: 12
+3304:  AVMOpcode(Equal)		Line: 37, Column: 12
+3305:  AVMOpcode(AuxPop)		Line: 37, Column: 5
+3306:  AVMOpcode(Pop)		Line: 37, Column: 5
+3307:  AVMOpcode(AuxPop)		Line: 37, Column: 5
+3308:  AVMOpcode(Jump)		Line: 37, Column: 5
+3309:  AVMOpcode(AuxPush)		Line: 40, Column: 1
+3310:  [Tuple(_, _)] AVMOpcode(AuxPush)		Line: 40, Column: 1
+3311:  [0] AVMOpcode(Xset)		Line: 40, Column: 1
+3312:  [0] AVMOpcode(Xget)		Line: 41, Column: 16
+3313:  AVMOpcode(Dup0)		Line: 41, Column: 16
+3314:  [0] AVMOpcode(Tget)		Line: 41, Column: 16
+3315:  [CodePoint(Internal(3320))] AVMOpcode(Cjump)		Line: 41, Column: 16
+3316:  AVMOpcode(AuxPop)		Line: 41, Column: 16
+3317:  AVMOpcode(Pop)		Line: 41, Column: 16
+3318:  AVMOpcode(AuxPop)		Line: 41, Column: 16
+3319:  AVMOpcode(Jump)		Line: 41, Column: 16
+3320:  [1] AVMOpcode(Tget)		Line: 41, Column: 16
+3321:  [1] AVMOpcode(Xset)		Line: 41, Column: 5
+3322:  [1] AVMOpcode(Xget)		Line: 44, Column: 9
+3323:  [0] AVMOpcode(Tget)		Line: 44, Column: 9
+3324:  [1] AVMOpcode(Xget)		Line: 43, Column: 27
+3325:  [1] AVMOpcode(Tget)		Line: 43, Column: 27
+3326:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 42, Column: 17
+3327:  [0] AVMOpcode(Tset)		Line: 42, Column: 17
+3328:  [1] AVMOpcode(Tset)		Line: 42, Column: 17
+3329:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 42, Column: 12
+3330:  [1] AVMOpcode(Tset)		Line: 42, Column: 12
+3331:  AVMOpcode(AuxPop)		Line: 42, Column: 5
+3332:  AVMOpcode(Pop)		Line: 42, Column: 5
+3333:  AVMOpcode(AuxPop)		Line: 42, Column: 5
+3334:  AVMOpcode(Jump)		Line: 42, Column: 5
+3335:  AVMOpcode(AuxPush)		Line: 36, Column: 1
+3336:  [Tuple(_, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 36, Column: 1
+3337:  [0] AVMOpcode(Xset)		Line: 36, Column: 1
+3338:  [1] AVMOpcode(Xset)		Line: 36, Column: 1
+3339:  [2] AVMOpcode(Xset)		Line: 36, Column: 1
+3340:  [0] AVMOpcode(Xget)		Line: 40, Column: 9
+3341:  [0] AVMOpcode(Equal)		Line: 40, Column: 9
+3342:  AVMOpcode(IsZero)		Line: 40, Column: 5
+3343:  [CodePoint(Internal(3359))] AVMOpcode(Cjump)		Line: 40, Column: 5
+3344:  [1] AVMOpcode(Noop)		Line: 43, Column: 13
+3345:  [128] AVMOpcode(Noop)		Line: 42, Column: 43
+3346:  [2] AVMOpcode(Xget)		Line: 42, Column: 35
+3347:  [1] AVMOpcode(Xget)		Line: 42, Column: 31
+3348:  [CodePoint(Internal(3352))] AVMOpcode(PushStatic)		Line: 42, Column: 13
+3349:  [2] AVMOpcode(Tget)		Line: 42, Column: 13
+3350:  [4] AVMOpcode(Tget)		Line: 42, Column: 13
+3351:  AVMOpcode(Jump)		Line: 42, Column: 13
+3352:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 41, Column: 16
+3353:  [0] AVMOpcode(Tset)		Line: 41, Column: 16
+3354:  [1] AVMOpcode(Tset)		Line: 41, Column: 16
+3355:  AVMOpcode(AuxPop)		Line: 41, Column: 9
+3356:  AVMOpcode(Pop)		Line: 41, Column: 9
+3357:  AVMOpcode(AuxPop)		Line: 41, Column: 9
+3358:  AVMOpcode(Jump)		Line: 41, Column: 9
+3359:  [0] AVMOpcode(Xget)		Line: 45, Column: 15
+3360:  [127] AVMOpcode(LessThan)		Line: 45, Column: 15
+3361:  [CodePoint(Internal(3377))] AVMOpcode(Cjump)		Line: 45, Column: 7
+3362:  [1] AVMOpcode(Noop)		Line: 48, Column: 13
+3363:  [0] AVMOpcode(Xget)		Line: 47, Column: 43
+3364:  [2] AVMOpcode(Xget)		Line: 47, Column: 35
+3365:  [1] AVMOpcode(Xget)		Line: 47, Column: 31
+3366:  [CodePoint(Internal(3370))] AVMOpcode(PushStatic)		Line: 47, Column: 13
+3367:  [2] AVMOpcode(Tget)		Line: 47, Column: 13
+3368:  [4] AVMOpcode(Tget)		Line: 47, Column: 13
+3369:  AVMOpcode(Jump)		Line: 47, Column: 13
+3370:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 46, Column: 16
+3371:  [0] AVMOpcode(Tset)		Line: 46, Column: 16
+3372:  [1] AVMOpcode(Tset)		Line: 46, Column: 16
+3373:  AVMOpcode(AuxPop)		Line: 46, Column: 9
+3374:  AVMOpcode(Pop)		Line: 46, Column: 9
+3375:  AVMOpcode(AuxPop)		Line: 46, Column: 9
+3376:  AVMOpcode(Jump)		Line: 46, Column: 9
+3377:  [0] AVMOpcode(Xget)		Line: 51, Column: 49
+3378:  [CodePoint(Internal(3380))] AVMOpcode(Noop)		Line: 51, Column: 22
+3379:  [CodePoint(Internal(3431))] AVMOpcode(Jump)		Line: 51, Column: 22
+3380:  [3] AVMOpcode(Xset)		Line: 51, Column: 9
+3381:  [3] AVMOpcode(Xget)		Line: 52, Column: 23
+3382:  [4] AVMOpcode(Xset)		Line: 52, Column: 9
+3383:  [3] AVMOpcode(Xget)		Line: 53, Column: 49
+3384:  [128] AVMOpcode(Plus)		Line: 53, Column: 44
+3385:  [2] AVMOpcode(Xget)		Line: 53, Column: 36
+3386:  [1] AVMOpcode(Xget)		Line: 53, Column: 32
+3387:  [CodePoint(Internal(3391))] AVMOpcode(PushStatic)		Line: 53, Column: 14
+3388:  [2] AVMOpcode(Tget)		Line: 53, Column: 14
+3389:  [4] AVMOpcode(Tget)		Line: 53, Column: 14
+3390:  AVMOpcode(Jump)		Line: 53, Column: 14
+3391:  [1] AVMOpcode(Xset)		Line: 53, Column: 9
+3392:  [2] AVMOpcode(Xget)		Line: 54, Column: 18
+3393:  [1] AVMOpcode(Plus)		Line: 54, Column: 18
+3394:  [2] AVMOpcode(Xset)		Line: 54, Column: 9
+3395:  [CodePoint(Internal(3398))] AVMOpcode(Noop)		Line: 55, Column: 9
+3396:  [5] AVMOpcode(Xset)		Line: 55, Column: 9
+3397:  [CodePoint(Internal(3417))] AVMOpcode(Jump)		Line: 55, Column: 9
+3398:  [1] AVMOpcode(Noop)		Line: 56, Column: 29
+3399:  [3] AVMOpcode(Xget)		Line: 56, Column: 22
+3400:  AVMOpcode(Minus)		Line: 56, Column: 22
+3401:  [3] AVMOpcode(Xset)		Line: 56, Column: 13
+3402:  [3] AVMOpcode(Xget)		Line: 57, Column: 64
+3403:  [256] AVMOpcode(Exp)		Line: 57, Column: 79
+3404:  [0] AVMOpcode(Xget)		Line: 57, Column: 49
+3405:  AVMOpcode(Div)		Line: 57, Column: 49
+3406:  [255] AVMOpcode(BitwiseAnd)		Line: 57, Column: 48
+3407:  [2] AVMOpcode(Xget)		Line: 57, Column: 40
+3408:  [1] AVMOpcode(Xget)		Line: 57, Column: 36
+3409:  [CodePoint(Internal(3413))] AVMOpcode(PushStatic)		Line: 57, Column: 18
+3410:  [2] AVMOpcode(Tget)		Line: 57, Column: 18
+3411:  [4] AVMOpcode(Tget)		Line: 57, Column: 18
+3412:  AVMOpcode(Jump)		Line: 57, Column: 18
+3413:  [1] AVMOpcode(Xset)		Line: 57, Column: 13
+3414:  [2] AVMOpcode(Xget)		Line: 58, Column: 22
+3415:  [1] AVMOpcode(Plus)		Line: 58, Column: 22
+3416:  [2] AVMOpcode(Xset)		Line: 58, Column: 13
+3417:  [3] AVMOpcode(Xget)		Line: 55, Column: 16
+3418:  [0] AVMOpcode(LessThan)		Line: 55, Column: 16
+3419:  [5] AVMOpcode(Xget)		Line: 55, Column: 9
+3420:  AVMOpcode(Cjump)		Line: 55, Column: 9
+3421:  [4] AVMOpcode(Xget)		Line: 60, Column: 21
+3422:  [1] AVMOpcode(Plus)		Line: 60, Column: 21
+3423:  [1] AVMOpcode(Xget)		Line: 60, Column: 17
+3424:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 60, Column: 16
+3425:  [0] AVMOpcode(Tset)		Line: 60, Column: 16
+3426:  [1] AVMOpcode(Tset)		Line: 60, Column: 16
+3427:  AVMOpcode(AuxPop)		Line: 60, Column: 9
+3428:  AVMOpcode(Pop)		Line: 60, Column: 9
+3429:  AVMOpcode(AuxPop)		Line: 60, Column: 9
+3430:  AVMOpcode(Jump)		Line: 60, Column: 9
+3431:  AVMOpcode(AuxPush)		Line: 302, Column: 1
+3432:  [Tuple(_, _, _, _, _)] AVMOpcode(AuxPush)		Line: 302, Column: 1
+3433:  [0] AVMOpcode(Xset)		Line: 302, Column: 1
+3434:  [0] AVMOpcode(Noop)		Line: 303, Column: 15
+3435:  [1] AVMOpcode(Xset)		Line: 303, Column: 5
+3436:  [16] AVMOpcode(Noop)		Line: 304, Column: 17
+3437:  [2] AVMOpcode(Xset)		Line: 304, Column: 5
+3438:  [CodePoint(Internal(3441))] AVMOpcode(Noop)		Line: 305, Column: 5
+3439:  [3] AVMOpcode(Xset)		Line: 305, Column: 5
+3440:  [CodePoint(Internal(3461))] AVMOpcode(Jump)		Line: 305, Column: 5
+3441:  [2] AVMOpcode(Xget)		Line: 306, Column: 34
+3442:  [256] AVMOpcode(Exp)		Line: 306, Column: 48
+3443:  [4] AVMOpcode(Xset)		Line: 306, Column: 9
+3444:  [4] AVMOpcode(Xget)		Line: 307, Column: 20
+3445:  [0] AVMOpcode(Xget)		Line: 307, Column: 13
+3446:  AVMOpcode(LessThan)		Line: 307, Column: 13
+3447:  [CodePoint(Internal(3457))] AVMOpcode(Cjump)		Line: 307, Column: 9
+3448:  [2] AVMOpcode(Xget)		Line: 308, Column: 25
+3449:  [1] AVMOpcode(Xget)		Line: 308, Column: 19
+3450:  AVMOpcode(Plus)		Line: 308, Column: 19
+3451:  [1] AVMOpcode(Xset)		Line: 308, Column: 13
+3452:  [4] AVMOpcode(Xget)		Line: 309, Column: 25
+3453:  [0] AVMOpcode(Xget)		Line: 309, Column: 19
+3454:  AVMOpcode(Div)		Line: 309, Column: 19
+3455:  [0] AVMOpcode(Xset)		Line: 309, Column: 13
+3456:  [CodePoint(Internal(3457))] AVMOpcode(Jump)		Line: 307, Column: 9
+3457:  [2] AVMOpcode(Noop)		Line: 311, Column: 25
+3458:  [2] AVMOpcode(Xget)		Line: 311, Column: 17
+3459:  AVMOpcode(Div)		Line: 311, Column: 17
+3460:  [2] AVMOpcode(Xset)		Line: 311, Column: 9
+3461:  [2] AVMOpcode(Xget)		Line: 305, Column: 12
+3462:  [0] AVMOpcode(LessThan)		Line: 305, Column: 12
+3463:  [3] AVMOpcode(Xget)		Line: 305, Column: 5
+3464:  AVMOpcode(Cjump)		Line: 305, Column: 5
+3465:  [0] AVMOpcode(Xget)		Line: 313, Column: 9
+3466:  [0] AVMOpcode(Equal)		Line: 313, Column: 9
+3467:  AVMOpcode(IsZero)		Line: 313, Column: 5
+3468:  [CodePoint(Internal(3474))] AVMOpcode(Cjump)		Line: 313, Column: 5
+3469:  [1] AVMOpcode(Xget)		Line: 314, Column: 16
+3470:  AVMOpcode(AuxPop)		Line: 314, Column: 9
+3471:  AVMOpcode(Pop)		Line: 314, Column: 9
+3472:  AVMOpcode(AuxPop)		Line: 314, Column: 9
+3473:  AVMOpcode(Jump)		Line: 314, Column: 9
+3474:  [1] AVMOpcode(Xget)		Line: 316, Column: 16
+3475:  [1] AVMOpcode(Plus)		Line: 316, Column: 16
+3476:  AVMOpcode(AuxPop)		Line: 316, Column: 9
+3477:  AVMOpcode(Pop)		Line: 316, Column: 9
+3478:  AVMOpcode(AuxPop)		Line: 316, Column: 9
+3479:  AVMOpcode(Jump)		Line: 316, Column: 9
+3480:  AVMOpcode(AuxPush)		Line: 64, Column: 1
+3481:  [Tuple(_, _, _)] AVMOpcode(AuxPush)		Line: 64, Column: 1
+3482:  [0] AVMOpcode(Xset)		Line: 64, Column: 1
+3483:  [1] AVMOpcode(Xset)		Line: 64, Column: 1
+3484:  [2] AVMOpcode(Xset)		Line: 64, Column: 1
+3485:  [2] AVMOpcode(Xget)		Line: 65, Column: 43
+3486:  [1] AVMOpcode(Xget)		Line: 65, Column: 39
+3487:  [0] AVMOpcode(Xget)		Line: 65, Column: 32
+3488:  [CodePoint(Internal(3492))] AVMOpcode(PushStatic)		Line: 65, Column: 12
+3489:  [4] AVMOpcode(Tget)		Line: 65, Column: 12
+3490:  [5] AVMOpcode(Tget)		Line: 65, Column: 12
+3491:  AVMOpcode(Jump)		Line: 65, Column: 12
+3492:  AVMOpcode(AuxPop)		Line: 65, Column: 5
+3493:  AVMOpcode(Pop)		Line: 65, Column: 5
+3494:  AVMOpcode(AuxPop)		Line: 65, Column: 5
+3495:  AVMOpcode(Jump)		Line: 65, Column: 5
+3496:  AVMOpcode(AuxPush)		Line: 68, Column: 1
+3497:  [Tuple(_, _, _, _, _, _, _, Tuple(_, _))] AVMOpcode(AuxPush)		Line: 68, Column: 1
+3498:  [0] AVMOpcode(Xset)		Line: 68, Column: 1
+3499:  [1] AVMOpcode(Xset)		Line: 68, Column: 1
+3500:  [2] AVMOpcode(Xset)		Line: 68, Column: 1
+3501:  [3] AVMOpcode(Xset)		Line: 68, Column: 1
+3502:  [4] AVMOpcode(Xset)		Line: 68, Column: 1
+3503:  [2] AVMOpcode(Xget)		Line: 72, Column: 9
+3504:  [0] AVMOpcode(Equal)		Line: 72, Column: 9
+3505:  AVMOpcode(IsZero)		Line: 72, Column: 5
+3506:  [CodePoint(Internal(3522))] AVMOpcode(Cjump)		Line: 72, Column: 5
+3507:  [1] AVMOpcode(Noop)		Line: 75, Column: 13
+3508:  [128] AVMOpcode(Noop)		Line: 74, Column: 52
+3509:  [4] AVMOpcode(Xget)		Line: 74, Column: 41
+3510:  [3] AVMOpcode(Xget)		Line: 74, Column: 31
+3511:  [CodePoint(Internal(3515))] AVMOpcode(PushStatic)		Line: 74, Column: 13
+3512:  [2] AVMOpcode(Tget)		Line: 74, Column: 13
+3513:  [4] AVMOpcode(Tget)		Line: 74, Column: 13
+3514:  AVMOpcode(Jump)		Line: 74, Column: 13
+3515:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 73, Column: 16
+3516:  [0] AVMOpcode(Tset)		Line: 73, Column: 16
+3517:  [1] AVMOpcode(Tset)		Line: 73, Column: 16
+3518:  AVMOpcode(AuxPop)		Line: 73, Column: 9
+3519:  AVMOpcode(Pop)		Line: 73, Column: 9
+3520:  AVMOpcode(AuxPop)		Line: 73, Column: 9
+3521:  AVMOpcode(Jump)		Line: 73, Column: 9
+3522:  [1] AVMOpcode(Xget)		Line: 79, Column: 48
+3523:  [0] AVMOpcode(Xget)		Line: 79, Column: 39
+3524:  [CodePoint(Internal(3528))] AVMOpcode(PushStatic)		Line: 79, Column: 21
+3525:  [2] AVMOpcode(Tget)		Line: 79, Column: 21
+3526:  [3] AVMOpcode(Tget)		Line: 79, Column: 21
+3527:  AVMOpcode(Jump)		Line: 79, Column: 21
+3528:  [5] AVMOpcode(Xset)		Line: 79, Column: 5
+3529:  [2] AVMOpcode(Xget)		Line: 80, Column: 11
+3530:  [1] AVMOpcode(Equal)		Line: 80, Column: 11
+3531:  AVMOpcode(Dup0)		Line: 80, Column: 10
+3532:  AVMOpcode(IsZero)		Line: 80, Column: 10
+3533:  [CodePoint(Internal(3538))] AVMOpcode(Cjump)		Line: 80, Column: 10
+3534:  AVMOpcode(Pop)		Line: 80, Column: 10
+3535:  [5] AVMOpcode(Xget)		Line: 80, Column: 28
+3536:  [127] AVMOpcode(LessThan)		Line: 80, Column: 28
+3537:  AVMOpcode(IsZero)		Line: 80, Column: 28
+3538:  AVMOpcode(IsZero)		Line: 80, Column: 5
+3539:  [CodePoint(Internal(3555))] AVMOpcode(Cjump)		Line: 80, Column: 5
+3540:  [1] AVMOpcode(Noop)		Line: 83, Column: 13
+3541:  [5] AVMOpcode(Xget)		Line: 82, Column: 52
+3542:  [4] AVMOpcode(Xget)		Line: 82, Column: 41
+3543:  [3] AVMOpcode(Xget)		Line: 82, Column: 31
+3544:  [CodePoint(Internal(3548))] AVMOpcode(PushStatic)		Line: 82, Column: 13
+3545:  [2] AVMOpcode(Tget)		Line: 82, Column: 13
+3546:  [4] AVMOpcode(Tget)		Line: 82, Column: 13
+3547:  AVMOpcode(Jump)		Line: 82, Column: 13
+3548:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 81, Column: 16
+3549:  [0] AVMOpcode(Tset)		Line: 81, Column: 16
+3550:  [1] AVMOpcode(Tset)		Line: 81, Column: 16
+3551:  AVMOpcode(AuxPop)		Line: 81, Column: 9
+3552:  AVMOpcode(Pop)		Line: 81, Column: 9
+3553:  AVMOpcode(AuxPop)		Line: 81, Column: 9
+3554:  AVMOpcode(Jump)		Line: 81, Column: 9
+3555:  [2] AVMOpcode(Xget)		Line: 87, Column: 9
+3556:  [55] AVMOpcode(LessThan)		Line: 87, Column: 9
+3557:  [CodePoint(Internal(3588))] AVMOpcode(Cjump)		Line: 87, Column: 5
+3558:  [2] AVMOpcode(Xget)		Line: 88, Column: 64
+3559:  [128] AVMOpcode(Plus)		Line: 88, Column: 59
+3560:  [4] AVMOpcode(Xget)		Line: 88, Column: 48
+3561:  [3] AVMOpcode(Xget)		Line: 88, Column: 38
+3562:  [CodePoint(Internal(3566))] AVMOpcode(PushStatic)		Line: 88, Column: 20
+3563:  [2] AVMOpcode(Tget)		Line: 88, Column: 20
+3564:  [4] AVMOpcode(Tget)		Line: 88, Column: 20
+3565:  AVMOpcode(Jump)		Line: 88, Column: 20
+3566:  [3] AVMOpcode(Xset)		Line: 88, Column: 9
+3567:  [4] AVMOpcode(Xget)		Line: 89, Column: 21
+3568:  [1] AVMOpcode(Plus)		Line: 89, Column: 21
+3569:  [4] AVMOpcode(Xset)		Line: 89, Column: 9
+3570:  [2] AVMOpcode(Xget)		Line: 92, Column: 15
+3571:  [1] AVMOpcode(Plus)		Line: 92, Column: 13
+3572:  [2] AVMOpcode(Xget)		Line: 91, Column: 68
+3573:  [4] AVMOpcode(Xget)		Line: 91, Column: 57
+3574:  [3] AVMOpcode(Xget)		Line: 91, Column: 47
+3575:  [1] AVMOpcode(Xget)		Line: 91, Column: 37
+3576:  [0] AVMOpcode(Xget)		Line: 91, Column: 28
+3577:  [CodePoint(Internal(3581))] AVMOpcode(PushStatic)		Line: 91, Column: 13
+3578:  [4] AVMOpcode(Tget)		Line: 91, Column: 13
+3579:  [1] AVMOpcode(Tget)		Line: 91, Column: 13
+3580:  AVMOpcode(Jump)		Line: 91, Column: 13
+3581:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 90, Column: 16
+3582:  [0] AVMOpcode(Tset)		Line: 90, Column: 16
+3583:  [1] AVMOpcode(Tset)		Line: 90, Column: 16
+3584:  AVMOpcode(AuxPop)		Line: 90, Column: 9
+3585:  AVMOpcode(Pop)		Line: 90, Column: 9
+3586:  AVMOpcode(AuxPop)		Line: 90, Column: 9
+3587:  AVMOpcode(Jump)		Line: 90, Column: 9
+3588:  [2] AVMOpcode(Xget)		Line: 96, Column: 49
+3589:  [CodePoint(Internal(3593))] AVMOpcode(PushStatic)		Line: 96, Column: 22
+3590:  [4] AVMOpcode(Tget)		Line: 96, Column: 22
+3591:  [6] AVMOpcode(Tget)		Line: 96, Column: 22
+3592:  AVMOpcode(Jump)		Line: 96, Column: 22
+3593:  [6] AVMOpcode(Xset)		Line: 96, Column: 5
+3594:  [6] AVMOpcode(Xget)		Line: 97, Column: 60
+3595:  [183] AVMOpcode(Plus)		Line: 97, Column: 55
+3596:  [4] AVMOpcode(Xget)		Line: 97, Column: 44
+3597:  [3] AVMOpcode(Xget)		Line: 97, Column: 34
+3598:  [CodePoint(Internal(3602))] AVMOpcode(PushStatic)		Line: 97, Column: 16
+3599:  [2] AVMOpcode(Tget)		Line: 97, Column: 16
+3600:  [4] AVMOpcode(Tget)		Line: 97, Column: 16
+3601:  AVMOpcode(Jump)		Line: 97, Column: 16
+3602:  [3] AVMOpcode(Xset)		Line: 97, Column: 5
+3603:  [4] AVMOpcode(Xget)		Line: 98, Column: 17
+3604:  [1] AVMOpcode(Plus)		Line: 98, Column: 17
+3605:  [4] AVMOpcode(Xset)		Line: 98, Column: 5
+3606:  [6] AVMOpcode(Xget)		Line: 100, Column: 13
+3607:  [7] AVMOpcode(Xget)		Line: 100, Column: 5
+3608:  [0] AVMOpcode(Tset)		Line: 100, Column: 5
+3609:  [7] AVMOpcode(Xset)		Line: 100, Column: 5
+3610:  [CodePoint(Internal(3615))] AVMOpcode(Noop)		Line: 101, Column: 5
+3611:  [7] AVMOpcode(Xget)		Line: 101, Column: 5
+3612:  [1] AVMOpcode(Tset)		Line: 101, Column: 5
+3613:  [7] AVMOpcode(Xset)		Line: 101, Column: 5
+3614:  [CodePoint(Internal(3638))] AVMOpcode(Jump)		Line: 101, Column: 5
+3615:  [1] AVMOpcode(Noop)		Line: 102, Column: 15
+3616:  [7] AVMOpcode(Xget)		Line: 102, Column: 13
+3617:  [0] AVMOpcode(Tget)		Line: 102, Column: 13
+3618:  AVMOpcode(Minus)		Line: 102, Column: 13
+3619:  [7] AVMOpcode(Xget)		Line: 102, Column: 9
+3620:  [0] AVMOpcode(Tset)		Line: 102, Column: 9
+3621:  [7] AVMOpcode(Xset)		Line: 102, Column: 9
+3622:  [7] AVMOpcode(Xget)		Line: 103, Column: 78
+3623:  [0] AVMOpcode(Tget)		Line: 103, Column: 78
+3624:  [256] AVMOpcode(Exp)		Line: 103, Column: 88
+3625:  [2] AVMOpcode(Xget)		Line: 103, Column: 60
+3626:  AVMOpcode(Div)		Line: 103, Column: 60
+3627:  [255] AVMOpcode(BitwiseAnd)		Line: 103, Column: 59
+3628:  [4] AVMOpcode(Xget)		Line: 103, Column: 48
+3629:  [3] AVMOpcode(Xget)		Line: 103, Column: 38
+3630:  [CodePoint(Internal(3634))] AVMOpcode(PushStatic)		Line: 103, Column: 20
+3631:  [2] AVMOpcode(Tget)		Line: 103, Column: 20
+3632:  [4] AVMOpcode(Tget)		Line: 103, Column: 20
+3633:  AVMOpcode(Jump)		Line: 103, Column: 20
+3634:  [3] AVMOpcode(Xset)		Line: 103, Column: 9
+3635:  [4] AVMOpcode(Xget)		Line: 104, Column: 21
+3636:  [1] AVMOpcode(Plus)		Line: 104, Column: 21
+3637:  [4] AVMOpcode(Xset)		Line: 104, Column: 9
+3638:  [7] AVMOpcode(Xget)		Line: 101, Column: 12
+3639:  [0] AVMOpcode(Tget)		Line: 101, Column: 12
+3640:  [0] AVMOpcode(LessThan)		Line: 101, Column: 12
+3641:  [7] AVMOpcode(Xget)		Line: 101, Column: 5
+3642:  [1] AVMOpcode(Tget)		Line: 101, Column: 5
+3643:  AVMOpcode(Cjump)		Line: 101, Column: 5
+3644:  [2] AVMOpcode(Xget)		Line: 108, Column: 26
+3645:  [6] AVMOpcode(Xget)		Line: 108, Column: 13
+3646:  [1] AVMOpcode(Plus)		Line: 108, Column: 9
+3647:  AVMOpcode(Plus)		Line: 108, Column: 9
+3648:  [2] AVMOpcode(Xget)		Line: 107, Column: 64
+3649:  [4] AVMOpcode(Xget)		Line: 107, Column: 53
+3650:  [3] AVMOpcode(Xget)		Line: 107, Column: 43
+3651:  [1] AVMOpcode(Xget)		Line: 107, Column: 33
+3652:  [0] AVMOpcode(Xget)		Line: 107, Column: 24
+3653:  [CodePoint(Internal(3657))] AVMOpcode(PushStatic)		Line: 107, Column: 9
+3654:  [4] AVMOpcode(Tget)		Line: 107, Column: 9
+3655:  [1] AVMOpcode(Tget)		Line: 107, Column: 9
+3656:  AVMOpcode(Jump)		Line: 107, Column: 9
+3657:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 106, Column: 12
+3658:  [0] AVMOpcode(Tset)		Line: 106, Column: 12
+3659:  [1] AVMOpcode(Tset)		Line: 106, Column: 12
+3660:  AVMOpcode(AuxPop)		Line: 106, Column: 5
+3661:  AVMOpcode(Pop)		Line: 106, Column: 5
+3662:  AVMOpcode(AuxPop)		Line: 106, Column: 5
+3663:  AVMOpcode(Jump)		Line: 106, Column: 5
+3664:  AVMOpcode(AuxPush)		Line: 112, Column: 1
+3665:  [Tuple(_, _, _, _, _, _, _, Tuple(_, _, _))] AVMOpcode(AuxPush)		Line: 112, Column: 1
+3666:  [0] AVMOpcode(Xset)		Line: 112, Column: 1
+3667:  [0] AVMOpcode(Xget)		Line: 113, Column: 47
+3668:  [CodePoint(Internal(3672))] AVMOpcode(PushStatic)		Line: 113, Column: 28
+3669:  [4] AVMOpcode(Tget)		Line: 113, Column: 28
+3670:  [7] AVMOpcode(Tget)		Line: 113, Column: 28
+3671:  AVMOpcode(Jump)		Line: 113, Column: 28
+3672:  AVMOpcode(Dup0)		Line: 113, Column: 28
+3673:  [0] AVMOpcode(Tget)		Line: 113, Column: 28
+3674:  [CodePoint(Internal(3679))] AVMOpcode(Cjump)		Line: 113, Column: 28
+3675:  AVMOpcode(AuxPop)		Line: 113, Column: 28
+3676:  AVMOpcode(Pop)		Line: 113, Column: 28
+3677:  AVMOpcode(AuxPop)		Line: 113, Column: 28
+3678:  AVMOpcode(Jump)		Line: 113, Column: 28
+3679:  [1] AVMOpcode(Tget)		Line: 113, Column: 28
+3680:  AVMOpcode(Dup0)		Line: 113, Column: 5
+3681:  [0] AVMOpcode(Tget)		Line: 113, Column: 5
+3682:  [1] AVMOpcode(Xset)		Line: 113, Column: 5
+3683:  [1] AVMOpcode(Tget)		Line: 113, Column: 5
+3684:  [2] AVMOpcode(Xset)		Line: 113, Column: 5
+3685:  [1] AVMOpcode(Xget)		Line: 114, Column: 16
+3686:  [0] AVMOpcode(Xset)		Line: 114, Column: 5
+3687:  [0] AVMOpcode(Noop)		Line: 115, Column: 32
+3688:  [CodePoint(Internal(3691))] AVMOpcode(PushStatic)		Line: 115, Column: 18
+3689:  [0] AVMOpcode(Tget)		Line: 115, Column: 18
+3690:  AVMOpcode(Jump)		Line: 115, Column: 18
+3691:  [3] AVMOpcode(Xset)		Line: 115, Column: 5
+3692:  [2] AVMOpcode(Xget)		Line: 117, Column: 9
+3693:  [127] AVMOpcode(LessThan)		Line: 117, Column: 9
+3694:  [CodePoint(Internal(3712))] AVMOpcode(Cjump)		Line: 117, Column: 5
+3695:  [2] AVMOpcode(Xget)		Line: 118, Column: 62
+3696:  [0] AVMOpcode(Noop)		Line: 118, Column: 59
+3697:  [3] AVMOpcode(Xget)		Line: 118, Column: 51
+3698:  [CodePoint(Internal(3702))] AVMOpcode(PushStatic)		Line: 118, Column: 33
+3699:  [2] AVMOpcode(Tget)		Line: 118, Column: 33
+3700:  [4] AVMOpcode(Tget)		Line: 118, Column: 33
+3701:  AVMOpcode(Jump)		Line: 118, Column: 33
+3702:  [0] AVMOpcode(Xget)		Line: 118, Column: 23
+3703:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 118, Column: 22
+3704:  [0] AVMOpcode(Tset)		Line: 118, Column: 22
+3705:  [1] AVMOpcode(Tset)		Line: 118, Column: 22
+3706:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 118, Column: 16
+3707:  [1] AVMOpcode(Tset)		Line: 118, Column: 16
+3708:  AVMOpcode(AuxPop)		Line: 118, Column: 9
+3709:  AVMOpcode(Pop)		Line: 118, Column: 9
+3710:  AVMOpcode(AuxPop)		Line: 118, Column: 9
+3711:  AVMOpcode(Jump)		Line: 118, Column: 9
+3712:  [2] AVMOpcode(Xget)		Line: 121, Column: 9
+3713:  [183] AVMOpcode(LessThan)		Line: 121, Column: 9
+3714:  [CodePoint(Internal(3727))] AVMOpcode(Cjump)		Line: 121, Column: 5
+3715:  [128] AVMOpcode(Noop)		Line: 122, Column: 71
+3716:  [2] AVMOpcode(Xget)		Line: 122, Column: 59
+3717:  AVMOpcode(Minus)		Line: 122, Column: 59
+3718:  [0] AVMOpcode(Noop)		Line: 122, Column: 56
+3719:  [3] AVMOpcode(Xget)		Line: 122, Column: 48
+3720:  [0] AVMOpcode(Xget)		Line: 122, Column: 38
+3721:  [CodePoint(Internal(3723))] AVMOpcode(Noop)		Line: 122, Column: 16
+3722:  [CodePoint(Internal(3790))] AVMOpcode(Jump)		Line: 122, Column: 16
+3723:  AVMOpcode(AuxPop)		Line: 122, Column: 9
+3724:  AVMOpcode(Pop)		Line: 122, Column: 9
+3725:  AVMOpcode(AuxPop)		Line: 122, Column: 9
+3726:  AVMOpcode(Jump)		Line: 122, Column: 9
+3727:  [183] AVMOpcode(Noop)		Line: 125, Column: 34
+3728:  [2] AVMOpcode(Xget)		Line: 125, Column: 22
+3729:  AVMOpcode(Minus)		Line: 125, Column: 22
+3730:  [4] AVMOpcode(Xset)		Line: 125, Column: 5
+3731:  [0] AVMOpcode(Noop)		Line: 126, Column: 13
+3732:  [5] AVMOpcode(Xset)		Line: 126, Column: 5
+3733:  [0] AVMOpcode(Noop)		Line: 127, Column: 18
+3734:  [6] AVMOpcode(Xset)		Line: 127, Column: 5
+3735:  [CodePoint(Internal(3740))] AVMOpcode(Noop)		Line: 128, Column: 5
+3736:  [7] AVMOpcode(Xget)		Line: 128, Column: 5
+3737:  [0] AVMOpcode(Tset)		Line: 128, Column: 5
+3738:  [7] AVMOpcode(Xset)		Line: 128, Column: 5
+3739:  [CodePoint(Internal(3774))] AVMOpcode(Jump)		Line: 128, Column: 5
+3740:  [0] AVMOpcode(Xget)		Line: 129, Column: 43
+3741:  [CodePoint(Internal(3745))] AVMOpcode(PushStatic)		Line: 129, Column: 24
+3742:  [4] AVMOpcode(Tget)		Line: 129, Column: 24
+3743:  [7] AVMOpcode(Tget)		Line: 129, Column: 24
+3744:  AVMOpcode(Jump)		Line: 129, Column: 24
+3745:  AVMOpcode(Dup0)		Line: 129, Column: 24
+3746:  [0] AVMOpcode(Tget)		Line: 129, Column: 24
+3747:  [CodePoint(Internal(3752))] AVMOpcode(Cjump)		Line: 129, Column: 24
+3748:  AVMOpcode(AuxPop)		Line: 129, Column: 24
+3749:  AVMOpcode(Pop)		Line: 129, Column: 24
+3750:  AVMOpcode(AuxPop)		Line: 129, Column: 24
+3751:  AVMOpcode(Jump)		Line: 129, Column: 24
+3752:  [1] AVMOpcode(Tget)		Line: 129, Column: 24
+3753:  AVMOpcode(Dup0)		Line: 129, Column: 9
+3754:  [0] AVMOpcode(Tget)		Line: 129, Column: 9
+3755:  [7] AVMOpcode(Xget)		Line: 129, Column: 9
+3756:  [1] AVMOpcode(Tset)		Line: 129, Column: 9
+3757:  [7] AVMOpcode(Xset)		Line: 129, Column: 9
+3758:  [1] AVMOpcode(Tget)		Line: 129, Column: 9
+3759:  [7] AVMOpcode(Xget)		Line: 129, Column: 9
+3760:  [2] AVMOpcode(Tset)		Line: 129, Column: 9
+3761:  [7] AVMOpcode(Xset)		Line: 129, Column: 9
+3762:  [7] AVMOpcode(Xget)		Line: 130, Column: 20
+3763:  [1] AVMOpcode(Tget)		Line: 130, Column: 20
+3764:  [0] AVMOpcode(Xset)		Line: 130, Column: 9
+3765:  [7] AVMOpcode(Xget)		Line: 131, Column: 31
+3766:  [2] AVMOpcode(Tget)		Line: 131, Column: 31
+3767:  [6] AVMOpcode(Xget)		Line: 131, Column: 22
+3768:  [256] AVMOpcode(Mul)		Line: 131, Column: 18
+3769:  AVMOpcode(Plus)		Line: 131, Column: 18
+3770:  [6] AVMOpcode(Xset)		Line: 131, Column: 9
+3771:  [5] AVMOpcode(Xget)		Line: 132, Column: 13
+3772:  [1] AVMOpcode(Plus)		Line: 132, Column: 13
+3773:  [5] AVMOpcode(Xset)		Line: 132, Column: 9
+3774:  [4] AVMOpcode(Xget)		Line: 128, Column: 16
+3775:  [5] AVMOpcode(Xget)		Line: 128, Column: 12
+3776:  AVMOpcode(LessThan)		Line: 128, Column: 12
+3777:  [7] AVMOpcode(Xget)		Line: 128, Column: 5
+3778:  [0] AVMOpcode(Tget)		Line: 128, Column: 5
+3779:  AVMOpcode(Cjump)		Line: 128, Column: 5
+3780:  [6] AVMOpcode(Xget)		Line: 134, Column: 55
+3781:  [0] AVMOpcode(Noop)		Line: 134, Column: 52
+3782:  [3] AVMOpcode(Xget)		Line: 134, Column: 44
+3783:  [0] AVMOpcode(Xget)		Line: 134, Column: 34
+3784:  [CodePoint(Internal(3786))] AVMOpcode(Noop)		Line: 134, Column: 12
+3785:  [CodePoint(Internal(3790))] AVMOpcode(Jump)		Line: 134, Column: 12
+3786:  AVMOpcode(AuxPop)		Line: 134, Column: 5
+3787:  AVMOpcode(Pop)		Line: 134, Column: 5
+3788:  AVMOpcode(AuxPop)		Line: 134, Column: 5
+3789:  AVMOpcode(Jump)		Line: 134, Column: 5
+3790:  AVMOpcode(AuxPush)		Line: 225, Column: 1
+3791:  [Tuple(_, _, _, _, _, _, _, Tuple(_, _, _, _))] AVMOpcode(AuxPush)		Line: 225, Column: 1
+3792:  [0] AVMOpcode(Xset)		Line: 225, Column: 1
+3793:  [1] AVMOpcode(Xset)		Line: 225, Column: 1
+3794:  [2] AVMOpcode(Xset)		Line: 225, Column: 1
+3795:  [3] AVMOpcode(Xset)		Line: 225, Column: 1
+3796:  [0] AVMOpcode(Noop)		Line: 231, Column: 18
+3797:  [4] AVMOpcode(Xset)		Line: 231, Column: 5
+3798:  [CodePoint(Internal(3801))] AVMOpcode(Noop)		Line: 232, Column: 5
+3799:  [5] AVMOpcode(Xset)		Line: 232, Column: 5
+3800:  [CodePoint(Internal(3839))] AVMOpcode(Jump)		Line: 232, Column: 5
+3801:  [0] AVMOpcode(Xget)		Line: 233, Column: 45
+3802:  [CodePoint(Internal(3806))] AVMOpcode(PushStatic)		Line: 233, Column: 27
+3803:  [5] AVMOpcode(Tget)		Line: 233, Column: 27
+3804:  [0] AVMOpcode(Tget)		Line: 233, Column: 27
+3805:  AVMOpcode(Jump)		Line: 233, Column: 27
+3806:  AVMOpcode(Dup0)		Line: 233, Column: 27
+3807:  [0] AVMOpcode(Tget)		Line: 233, Column: 27
+3808:  [CodePoint(Internal(3813))] AVMOpcode(Cjump)		Line: 233, Column: 27
+3809:  AVMOpcode(AuxPop)		Line: 233, Column: 27
+3810:  AVMOpcode(Pop)		Line: 233, Column: 27
+3811:  AVMOpcode(AuxPop)		Line: 233, Column: 27
+3812:  AVMOpcode(Jump)		Line: 233, Column: 27
+3813:  [1] AVMOpcode(Tget)		Line: 233, Column: 27
+3814:  AVMOpcode(Dup0)		Line: 233, Column: 9
+3815:  [0] AVMOpcode(Tget)		Line: 233, Column: 9
+3816:  [6] AVMOpcode(Xset)		Line: 233, Column: 9
+3817:  [1] AVMOpcode(Tget)		Line: 233, Column: 9
+3818:  [7] AVMOpcode(Xget)		Line: 233, Column: 9
+3819:  [0] AVMOpcode(Tset)		Line: 233, Column: 9
+3820:  [7] AVMOpcode(Xset)		Line: 233, Column: 9
+3821:  [6] AVMOpcode(Xget)		Line: 234, Column: 20
+3822:  [0] AVMOpcode(Xset)		Line: 234, Column: 9
+3823:  [7] AVMOpcode(Xget)		Line: 235, Column: 43
+3824:  [0] AVMOpcode(Tget)		Line: 235, Column: 43
+3825:  [4] AVMOpcode(Xget)		Line: 235, Column: 35
+3826:  [1] AVMOpcode(Xget)		Line: 235, Column: 31
+3827:  [CodePoint(Internal(3831))] AVMOpcode(PushStatic)		Line: 235, Column: 14
+3828:  [2] AVMOpcode(Tget)		Line: 235, Column: 14
+3829:  [2] AVMOpcode(Tget)		Line: 235, Column: 14
+3830:  AVMOpcode(Jump)		Line: 235, Column: 14
+3831:  [1] AVMOpcode(Xset)		Line: 235, Column: 9
+3832:  [4] AVMOpcode(Xget)		Line: 236, Column: 18
+3833:  [32] AVMOpcode(Plus)		Line: 236, Column: 18
+3834:  [4] AVMOpcode(Xset)		Line: 236, Column: 9
+3835:  [32] AVMOpcode(Noop)		Line: 237, Column: 27
+3836:  [3] AVMOpcode(Xget)		Line: 237, Column: 18
+3837:  AVMOpcode(Minus)		Line: 237, Column: 18
+3838:  [3] AVMOpcode(Xset)		Line: 237, Column: 9
+3839:  [3] AVMOpcode(Xget)		Line: 232, Column: 12
+3840:  [32] AVMOpcode(GreaterThan)		Line: 232, Column: 12
+3841:  AVMOpcode(IsZero)		Line: 232, Column: 12
+3842:  [5] AVMOpcode(Xget)		Line: 232, Column: 5
+3843:  AVMOpcode(Cjump)		Line: 232, Column: 5
+3844:  [CodePoint(Internal(3849))] AVMOpcode(Noop)		Line: 239, Column: 5
+3845:  [7] AVMOpcode(Xget)		Line: 239, Column: 5
+3846:  [1] AVMOpcode(Tset)		Line: 239, Column: 5
+3847:  [7] AVMOpcode(Xset)		Line: 239, Column: 5
+3848:  [CodePoint(Internal(3890))] AVMOpcode(Jump)		Line: 239, Column: 5
+3849:  [0] AVMOpcode(Xget)		Line: 240, Column: 43
+3850:  [CodePoint(Internal(3854))] AVMOpcode(PushStatic)		Line: 240, Column: 24
+3851:  [4] AVMOpcode(Tget)		Line: 240, Column: 24
+3852:  [7] AVMOpcode(Tget)		Line: 240, Column: 24
+3853:  AVMOpcode(Jump)		Line: 240, Column: 24
+3854:  AVMOpcode(Dup0)		Line: 240, Column: 24
+3855:  [0] AVMOpcode(Tget)		Line: 240, Column: 24
+3856:  [CodePoint(Internal(3861))] AVMOpcode(Cjump)		Line: 240, Column: 24
+3857:  AVMOpcode(AuxPop)		Line: 240, Column: 24
+3858:  AVMOpcode(Pop)		Line: 240, Column: 24
+3859:  AVMOpcode(AuxPop)		Line: 240, Column: 24
+3860:  AVMOpcode(Jump)		Line: 240, Column: 24
+3861:  [1] AVMOpcode(Tget)		Line: 240, Column: 24
+3862:  AVMOpcode(Dup0)		Line: 240, Column: 9
+3863:  [0] AVMOpcode(Tget)		Line: 240, Column: 9
+3864:  [7] AVMOpcode(Xget)		Line: 240, Column: 9
+3865:  [2] AVMOpcode(Tset)		Line: 240, Column: 9
+3866:  [7] AVMOpcode(Xset)		Line: 240, Column: 9
+3867:  [1] AVMOpcode(Tget)		Line: 240, Column: 9
+3868:  [7] AVMOpcode(Xget)		Line: 240, Column: 9
+3869:  [3] AVMOpcode(Tset)		Line: 240, Column: 9
+3870:  [7] AVMOpcode(Xset)		Line: 240, Column: 9
+3871:  [7] AVMOpcode(Xget)		Line: 241, Column: 20
+3872:  [2] AVMOpcode(Tget)		Line: 241, Column: 20
+3873:  [0] AVMOpcode(Xset)		Line: 241, Column: 9
+3874:  [7] AVMOpcode(Xget)		Line: 242, Column: 44
+3875:  [3] AVMOpcode(Tget)		Line: 242, Column: 44
+3876:  [4] AVMOpcode(Xget)		Line: 242, Column: 36
+3877:  [1] AVMOpcode(Xget)		Line: 242, Column: 32
+3878:  [CodePoint(Internal(3882))] AVMOpcode(PushStatic)		Line: 242, Column: 14
+3879:  [2] AVMOpcode(Tget)		Line: 242, Column: 14
+3880:  [4] AVMOpcode(Tget)		Line: 242, Column: 14
+3881:  AVMOpcode(Jump)		Line: 242, Column: 14
+3882:  [1] AVMOpcode(Xset)		Line: 242, Column: 9
+3883:  [4] AVMOpcode(Xget)		Line: 243, Column: 18
+3884:  [1] AVMOpcode(Plus)		Line: 243, Column: 18
+3885:  [4] AVMOpcode(Xset)		Line: 243, Column: 9
+3886:  [1] AVMOpcode(Noop)		Line: 244, Column: 27
+3887:  [3] AVMOpcode(Xget)		Line: 244, Column: 18
+3888:  AVMOpcode(Minus)		Line: 244, Column: 18
+3889:  [3] AVMOpcode(Xset)		Line: 244, Column: 9
+3890:  [3] AVMOpcode(Xget)		Line: 239, Column: 12
+3891:  [0] AVMOpcode(LessThan)		Line: 239, Column: 12
+3892:  [7] AVMOpcode(Xget)		Line: 239, Column: 5
+3893:  [1] AVMOpcode(Tget)		Line: 239, Column: 5
+3894:  AVMOpcode(Cjump)		Line: 239, Column: 5
+3895:  [1] AVMOpcode(Xget)		Line: 246, Column: 29
+3896:  [0] AVMOpcode(Xget)		Line: 246, Column: 19
+3897:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 246, Column: 18
+3898:  [0] AVMOpcode(Tset)		Line: 246, Column: 18
+3899:  [1] AVMOpcode(Tset)		Line: 246, Column: 18
+3900:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 246, Column: 12
+3901:  [1] AVMOpcode(Tset)		Line: 246, Column: 12
+3902:  AVMOpcode(AuxPop)		Line: 246, Column: 5
+3903:  AVMOpcode(Pop)		Line: 246, Column: 5
+3904:  AVMOpcode(AuxPop)		Line: 246, Column: 5
+3905:  AVMOpcode(Jump)		Line: 246, Column: 5
+3906:  AVMOpcode(AuxPush)		Line: 137, Column: 1
+3907:  [Tuple(_, _, _, _, _, _, Tuple(_, _, _, _, _, _, _, _), Tuple(_, _, _, _))] AVMOpcode(AuxPush)		Line: 137, Column: 1
+3908:  [0] AVMOpcode(Xset)		Line: 137, Column: 1
+3909:  [1] AVMOpcode(Xset)		Line: 137, Column: 1
+3910:  [2] AVMOpcode(Xset)		Line: 137, Column: 1
+3911:  [3] AVMOpcode(Xset)		Line: 137, Column: 1
+3912:  [4] AVMOpcode(Xset)		Line: 137, Column: 1
+3913:  [0] AVMOpcode(Noop)		Line: 144, Column: 21
+3914:  [5] AVMOpcode(Xset)		Line: 144, Column: 5
+3915:  [0] AVMOpcode(Noop)		Line: 145, Column: 24
+3916:  [6] AVMOpcode(Xget)		Line: 145, Column: 5
+3917:  [0] AVMOpcode(Tset)		Line: 145, Column: 5
+3918:  [6] AVMOpcode(Xset)		Line: 145, Column: 5
+3919:  [0] AVMOpcode(Noop)		Line: 146, Column: 13
+3920:  [6] AVMOpcode(Xget)		Line: 146, Column: 5
+3921:  [1] AVMOpcode(Tset)		Line: 146, Column: 5
+3922:  [6] AVMOpcode(Xset)		Line: 146, Column: 5
+3923:  [CodePoint(Internal(3928))] AVMOpcode(Noop)		Line: 147, Column: 5
+3924:  [6] AVMOpcode(Xget)		Line: 147, Column: 5
+3925:  [2] AVMOpcode(Tset)		Line: 147, Column: 5
+3926:  [6] AVMOpcode(Xset)		Line: 147, Column: 5
+3927:  [CodePoint(Internal(3961))] AVMOpcode(Jump)		Line: 147, Column: 5
+3928:  [6] AVMOpcode(Xget)		Line: 148, Column: 92
+3929:  [1] AVMOpcode(Tget)		Line: 148, Column: 92
+3930:  [1] AVMOpcode(Xget)		Line: 148, Column: 77
+3931:  AVMOpcode(Plus)		Line: 148, Column: 77
+3932:  [0] AVMOpcode(Xget)		Line: 148, Column: 63
+3933:  [CodePoint(Internal(3935))] AVMOpcode(Noop)		Line: 148, Column: 42
+3934:  [CodePoint(Internal(5024))] AVMOpcode(Jump)		Line: 148, Column: 42
+3935:  AVMOpcode(Dup0)		Line: 148, Column: 42
+3936:  [0] AVMOpcode(Tget)		Line: 148, Column: 42
+3937:  [CodePoint(Internal(3942))] AVMOpcode(Cjump)		Line: 148, Column: 42
+3938:  AVMOpcode(AuxPop)		Line: 148, Column: 42
+3939:  AVMOpcode(Pop)		Line: 148, Column: 42
+3940:  AVMOpcode(AuxPop)		Line: 148, Column: 42
+3941:  AVMOpcode(Jump)		Line: 148, Column: 42
+3942:  [1] AVMOpcode(Tget)		Line: 148, Column: 42
+3943:  [6] AVMOpcode(Xget)		Line: 148, Column: 9
+3944:  [3] AVMOpcode(Tset)		Line: 148, Column: 9
+3945:  [6] AVMOpcode(Xset)		Line: 148, Column: 9
+3946:  [6] AVMOpcode(Xget)		Line: 149, Column: 48
+3947:  [3] AVMOpcode(Tget)		Line: 149, Column: 48
+3948:  [CodePoint(Internal(3952))] AVMOpcode(PushStatic)		Line: 149, Column: 33
+3949:  [4] AVMOpcode(Tget)		Line: 149, Column: 33
+3950:  [3] AVMOpcode(Tget)		Line: 149, Column: 33
+3951:  AVMOpcode(Jump)		Line: 149, Column: 33
+3952:  [5] AVMOpcode(Xget)		Line: 149, Column: 21
+3953:  AVMOpcode(Plus)		Line: 149, Column: 21
+3954:  [5] AVMOpcode(Xset)		Line: 149, Column: 9
+3955:  [6] AVMOpcode(Xget)		Line: 150, Column: 13
+3956:  [1] AVMOpcode(Tget)		Line: 150, Column: 13
+3957:  [1] AVMOpcode(Plus)		Line: 150, Column: 13
+3958:  [6] AVMOpcode(Xget)		Line: 150, Column: 9
+3959:  [1] AVMOpcode(Tset)		Line: 150, Column: 9
+3960:  [6] AVMOpcode(Xset)		Line: 150, Column: 9
+3961:  [2] AVMOpcode(Xget)		Line: 147, Column: 16
+3962:  [6] AVMOpcode(Xget)		Line: 147, Column: 12
+3963:  [1] AVMOpcode(Tget)		Line: 147, Column: 12
+3964:  AVMOpcode(LessThan)		Line: 147, Column: 12
+3965:  [6] AVMOpcode(Xget)		Line: 147, Column: 5
+3966:  [2] AVMOpcode(Tget)		Line: 147, Column: 5
+3967:  AVMOpcode(Cjump)		Line: 147, Column: 5
+3968:  [5] AVMOpcode(Xget)		Line: 153, Column: 9
+3969:  [55] AVMOpcode(LessThan)		Line: 153, Column: 9
+3970:  [CodePoint(Internal(3989))] AVMOpcode(Cjump)		Line: 153, Column: 5
+3971:  [5] AVMOpcode(Xget)		Line: 154, Column: 66
+3972:  [192] AVMOpcode(Plus)		Line: 154, Column: 59
+3973:  [4] AVMOpcode(Xget)		Line: 154, Column: 48
+3974:  [3] AVMOpcode(Xget)		Line: 154, Column: 38
+3975:  [CodePoint(Internal(3979))] AVMOpcode(PushStatic)		Line: 154, Column: 20
+3976:  [2] AVMOpcode(Tget)		Line: 154, Column: 20
+3977:  [4] AVMOpcode(Tget)		Line: 154, Column: 20
+3978:  AVMOpcode(Jump)		Line: 154, Column: 20
+3979:  [3] AVMOpcode(Xset)		Line: 154, Column: 9
+3980:  [4] AVMOpcode(Xget)		Line: 155, Column: 21
+3981:  [1] AVMOpcode(Plus)		Line: 155, Column: 21
+3982:  [4] AVMOpcode(Xset)		Line: 155, Column: 9
+3983:  [5] AVMOpcode(Xget)		Line: 156, Column: 28
+3984:  [1] AVMOpcode(Plus)		Line: 156, Column: 24
+3985:  [6] AVMOpcode(Xget)		Line: 156, Column: 9
+3986:  [0] AVMOpcode(Tset)		Line: 156, Column: 9
+3987:  [6] AVMOpcode(Xset)		Line: 156, Column: 9
+3988:  [CodePoint(Internal(4062))] AVMOpcode(Jump)		Line: 153, Column: 5
+3989:  [5] AVMOpcode(Xget)		Line: 158, Column: 53
+3990:  [CodePoint(Internal(3994))] AVMOpcode(PushStatic)		Line: 158, Column: 26
+3991:  [4] AVMOpcode(Tget)		Line: 158, Column: 26
+3992:  [6] AVMOpcode(Tget)		Line: 158, Column: 26
+3993:  AVMOpcode(Jump)		Line: 158, Column: 26
+3994:  [6] AVMOpcode(Xget)		Line: 158, Column: 9
+3995:  [4] AVMOpcode(Tset)		Line: 158, Column: 9
+3996:  [6] AVMOpcode(Xset)		Line: 158, Column: 9
+3997:  [6] AVMOpcode(Xget)		Line: 159, Column: 66
+3998:  [4] AVMOpcode(Tget)		Line: 159, Column: 66
+3999:  [247] AVMOpcode(Plus)		Line: 159, Column: 59
+4000:  [4] AVMOpcode(Xget)		Line: 159, Column: 48
+4001:  [3] AVMOpcode(Xget)		Line: 159, Column: 38
+4002:  [CodePoint(Internal(4006))] AVMOpcode(PushStatic)		Line: 159, Column: 20
+4003:  [2] AVMOpcode(Tget)		Line: 159, Column: 20
+4004:  [4] AVMOpcode(Tget)		Line: 159, Column: 20
+4005:  AVMOpcode(Jump)		Line: 159, Column: 20
+4006:  [3] AVMOpcode(Xset)		Line: 159, Column: 9
+4007:  [4] AVMOpcode(Xget)		Line: 160, Column: 21
+4008:  [1] AVMOpcode(Plus)		Line: 160, Column: 21
+4009:  [4] AVMOpcode(Xset)		Line: 160, Column: 9
+4010:  [6] AVMOpcode(Xget)		Line: 161, Column: 17
+4011:  [4] AVMOpcode(Tget)		Line: 161, Column: 17
+4012:  [6] AVMOpcode(Xget)		Line: 161, Column: 9
+4013:  [5] AVMOpcode(Tset)		Line: 161, Column: 9
+4014:  [6] AVMOpcode(Xset)		Line: 161, Column: 9
+4015:  [CodePoint(Internal(4020))] AVMOpcode(Noop)		Line: 162, Column: 9
+4016:  [6] AVMOpcode(Xget)		Line: 162, Column: 9
+4017:  [6] AVMOpcode(Tset)		Line: 162, Column: 9
+4018:  [6] AVMOpcode(Xset)		Line: 162, Column: 9
+4019:  [CodePoint(Internal(4048))] AVMOpcode(Jump)		Line: 162, Column: 9
+4020:  [1] AVMOpcode(Noop)		Line: 163, Column: 19
+4021:  [6] AVMOpcode(Xget)		Line: 163, Column: 17
+4022:  [5] AVMOpcode(Tget)		Line: 163, Column: 17
+4023:  AVMOpcode(Minus)		Line: 163, Column: 17
+4024:  [6] AVMOpcode(Xget)		Line: 163, Column: 13
+4025:  [5] AVMOpcode(Tset)		Line: 163, Column: 13
+4026:  [6] AVMOpcode(Xset)		Line: 163, Column: 13
+4027:  [6] AVMOpcode(Xget)		Line: 164, Column: 43
+4028:  [5] AVMOpcode(Tget)		Line: 164, Column: 43
+4029:  [256] AVMOpcode(Exp)		Line: 164, Column: 53
+4030:  [5] AVMOpcode(Xget)		Line: 164, Column: 22
+4031:  AVMOpcode(Div)		Line: 164, Column: 22
+4032:  [255] AVMOpcode(BitwiseAnd)		Line: 164, Column: 21
+4033:  [6] AVMOpcode(Xget)		Line: 164, Column: 13
+4034:  [7] AVMOpcode(Tset)		Line: 164, Column: 13
+4035:  [6] AVMOpcode(Xset)		Line: 164, Column: 13
+4036:  [6] AVMOpcode(Xget)		Line: 165, Column: 63
+4037:  [7] AVMOpcode(Tget)		Line: 165, Column: 63
+4038:  [4] AVMOpcode(Xget)		Line: 165, Column: 52
+4039:  [3] AVMOpcode(Xget)		Line: 165, Column: 42
+4040:  [CodePoint(Internal(4044))] AVMOpcode(PushStatic)		Line: 165, Column: 24
+4041:  [2] AVMOpcode(Tget)		Line: 165, Column: 24
+4042:  [4] AVMOpcode(Tget)		Line: 165, Column: 24
+4043:  AVMOpcode(Jump)		Line: 165, Column: 24
+4044:  [3] AVMOpcode(Xset)		Line: 165, Column: 13
+4045:  [4] AVMOpcode(Xget)		Line: 166, Column: 25
+4046:  [1] AVMOpcode(Plus)		Line: 166, Column: 25
+4047:  [4] AVMOpcode(Xset)		Line: 166, Column: 13
+4048:  [6] AVMOpcode(Xget)		Line: 162, Column: 16
+4049:  [5] AVMOpcode(Tget)		Line: 162, Column: 16
+4050:  [0] AVMOpcode(LessThan)		Line: 162, Column: 16
+4051:  [6] AVMOpcode(Xget)		Line: 162, Column: 9
+4052:  [6] AVMOpcode(Tget)		Line: 162, Column: 9
+4053:  AVMOpcode(Cjump)		Line: 162, Column: 9
+4054:  [5] AVMOpcode(Xget)		Line: 168, Column: 41
+4055:  [6] AVMOpcode(Xget)		Line: 168, Column: 28
+4056:  [4] AVMOpcode(Tget)		Line: 168, Column: 28
+4057:  [1] AVMOpcode(Plus)		Line: 168, Column: 24
+4058:  AVMOpcode(Plus)		Line: 168, Column: 24
+4059:  [6] AVMOpcode(Xget)		Line: 168, Column: 9
+4060:  [0] AVMOpcode(Tset)		Line: 168, Column: 9
+4061:  [6] AVMOpcode(Xset)		Line: 168, Column: 9
+4062:  [0] AVMOpcode(Noop)		Line: 171, Column: 13
+4063:  [7] AVMOpcode(Xget)		Line: 171, Column: 5
+4064:  [0] AVMOpcode(Tset)		Line: 171, Column: 5
+4065:  [7] AVMOpcode(Xset)		Line: 171, Column: 5
+4066:  [CodePoint(Internal(4071))] AVMOpcode(Noop)		Line: 172, Column: 5
+4067:  [7] AVMOpcode(Xget)		Line: 172, Column: 5
+4068:  [1] AVMOpcode(Tset)		Line: 172, Column: 5
+4069:  [7] AVMOpcode(Xset)		Line: 172, Column: 5
+4070:  [CodePoint(Internal(4113))] AVMOpcode(Jump)		Line: 172, Column: 5
+4071:  [7] AVMOpcode(Xget)		Line: 173, Column: 48
+4072:  [0] AVMOpcode(Tget)		Line: 173, Column: 48
+4073:  [1] AVMOpcode(Xget)		Line: 173, Column: 33
+4074:  AVMOpcode(Plus)		Line: 173, Column: 33
+4075:  [0] AVMOpcode(Xget)		Line: 173, Column: 20
+4076:  [CodePoint(Internal(4078))] AVMOpcode(Noop)		Line: 173, Column: 20
+4077:  [CodePoint(Internal(4981))] AVMOpcode(Jump)		Line: 173, Column: 20
+4078:  [7] AVMOpcode(Xget)		Line: 173, Column: 9
+4079:  [2] AVMOpcode(Tset)		Line: 173, Column: 9
+4080:  [7] AVMOpcode(Xset)		Line: 173, Column: 9
+4081:  [7] AVMOpcode(Xget)		Line: 174, Column: 35
+4082:  [2] AVMOpcode(Tget)		Line: 174, Column: 35
+4083:  [CodePoint(Internal(4087))] AVMOpcode(PushStatic)		Line: 174, Column: 20
+4084:  [4] AVMOpcode(Tget)		Line: 174, Column: 20
+4085:  [3] AVMOpcode(Tget)		Line: 174, Column: 20
+4086:  AVMOpcode(Jump)		Line: 174, Column: 20
+4087:  [7] AVMOpcode(Xget)		Line: 174, Column: 9
+4088:  [3] AVMOpcode(Tset)		Line: 174, Column: 9
+4089:  [7] AVMOpcode(Xset)		Line: 174, Column: 9
+4090:  [7] AVMOpcode(Xget)		Line: 175, Column: 65
+4091:  [3] AVMOpcode(Tget)		Line: 175, Column: 65
+4092:  [4] AVMOpcode(Xget)		Line: 175, Column: 54
+4093:  [3] AVMOpcode(Xget)		Line: 175, Column: 44
+4094:  [0] AVMOpcode(Noop)		Line: 175, Column: 41
+4095:  [7] AVMOpcode(Xget)		Line: 175, Column: 35
+4096:  [2] AVMOpcode(Tget)		Line: 175, Column: 35
+4097:  [CodePoint(Internal(4101))] AVMOpcode(PushStatic)		Line: 175, Column: 20
+4098:  [4] AVMOpcode(Tget)		Line: 175, Column: 20
+4099:  [1] AVMOpcode(Tget)		Line: 175, Column: 20
+4100:  AVMOpcode(Jump)		Line: 175, Column: 20
+4101:  [3] AVMOpcode(Xset)		Line: 175, Column: 9
+4102:  [7] AVMOpcode(Xget)		Line: 176, Column: 33
+4103:  [3] AVMOpcode(Tget)		Line: 176, Column: 33
+4104:  [4] AVMOpcode(Xget)		Line: 176, Column: 21
+4105:  AVMOpcode(Plus)		Line: 176, Column: 21
+4106:  [4] AVMOpcode(Xset)		Line: 176, Column: 9
+4107:  [7] AVMOpcode(Xget)		Line: 177, Column: 13
+4108:  [0] AVMOpcode(Tget)		Line: 177, Column: 13
+4109:  [1] AVMOpcode(Plus)		Line: 177, Column: 13
+4110:  [7] AVMOpcode(Xget)		Line: 177, Column: 9
+4111:  [0] AVMOpcode(Tset)		Line: 177, Column: 9
+4112:  [7] AVMOpcode(Xset)		Line: 177, Column: 9
+4113:  [2] AVMOpcode(Xget)		Line: 172, Column: 16
+4114:  [7] AVMOpcode(Xget)		Line: 172, Column: 12
+4115:  [0] AVMOpcode(Tget)		Line: 172, Column: 12
+4116:  AVMOpcode(LessThan)		Line: 172, Column: 12
+4117:  [7] AVMOpcode(Xget)		Line: 172, Column: 5
+4118:  [1] AVMOpcode(Tget)		Line: 172, Column: 5
+4119:  AVMOpcode(Cjump)		Line: 172, Column: 5
+4120:  [6] AVMOpcode(Xget)		Line: 180, Column: 28
+4121:  [0] AVMOpcode(Tget)		Line: 180, Column: 28
+4122:  [3] AVMOpcode(Xget)		Line: 180, Column: 18
+4123:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 180, Column: 17
+4124:  [0] AVMOpcode(Tset)		Line: 180, Column: 17
+4125:  [1] AVMOpcode(Tset)		Line: 180, Column: 17
+4126:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 180, Column: 12
+4127:  [1] AVMOpcode(Tset)		Line: 180, Column: 12
+4128:  AVMOpcode(AuxPop)		Line: 180, Column: 5
+4129:  AVMOpcode(Pop)		Line: 180, Column: 5
+4130:  AVMOpcode(AuxPop)		Line: 180, Column: 5
+4131:  AVMOpcode(Jump)		Line: 180, Column: 5
+4132:  AVMOpcode(AuxPush)		Line: 183, Column: 1
+4133:  [Tuple(_, _, _, _, _, _, _, Tuple(_, _, _, _))] AVMOpcode(AuxPush)		Line: 183, Column: 1
+4134:  [0] AVMOpcode(Xset)		Line: 183, Column: 1
+4135:  [1] AVMOpcode(Xset)		Line: 183, Column: 1
+4136:  [2] AVMOpcode(Xset)		Line: 183, Column: 1
+4137:  [3] AVMOpcode(Xset)		Line: 183, Column: 1
+4138:  [4] AVMOpcode(Xset)		Line: 183, Column: 1
+4139:  [5] AVMOpcode(Xset)		Line: 183, Column: 1
+4140:  [6] AVMOpcode(Xset)		Line: 183, Column: 1
+4141:  [7] AVMOpcode(Xget)		Line: 183, Column: 1
+4142:  [0] AVMOpcode(Tset)		Line: 183, Column: 1
+4143:  [7] AVMOpcode(Xset)		Line: 183, Column: 1
+4144:  [7] AVMOpcode(Xget)		Line: 183, Column: 1
+4145:  [1] AVMOpcode(Tset)		Line: 183, Column: 1
+4146:  [7] AVMOpcode(Xset)		Line: 183, Column: 1
+4147:  [_] AVMOpcode(Noop)		Line: 194, Column: 49
+4148:  [9] AVMOpcode(Noop)		Line: 194, Column: 63
+4149:  [CodePoint(Internal(4151))] AVMOpcode(Noop)		Line: 194, Column: 49
+4150:  [CodePoint(Internal(4918))] AVMOpcode(Jump)		Line: 194, Column: 49
+4151:  [7] AVMOpcode(Xget)		Line: 194, Column: 5
+4152:  [2] AVMOpcode(Tset)		Line: 194, Column: 5
+4153:  [7] AVMOpcode(Xset)		Line: 194, Column: 5
+4154:  [0] AVMOpcode(Noop)		Line: 214, Column: 51
+4155:  [0] AVMOpcode(Noop)		Line: 214, Column: 47
+4156:  [CodePoint(Internal(4159))] AVMOpcode(PushStatic)		Line: 214, Column: 33
+4157:  [0] AVMOpcode(Tget)		Line: 214, Column: 33
+4158:  AVMOpcode(Jump)		Line: 214, Column: 33
+4159:  [7] AVMOpcode(Xget)		Line: 214, Column: 30
+4160:  [1] AVMOpcode(Tget)		Line: 214, Column: 30
+4161:  [CodePoint(Internal(4165))] AVMOpcode(PushStatic)		Line: 214, Column: 15
+4162:  [4] AVMOpcode(Tget)		Line: 214, Column: 15
+4163:  [5] AVMOpcode(Tget)		Line: 214, Column: 15
+4164:  AVMOpcode(Jump)		Line: 214, Column: 15
+4165:  [0] AVMOpcode(Tget)		Line: 214, Column: 15
+4166:  [8] AVMOpcode(Noop)		Line: 214, Column: 10
+4167:  [0] AVMOpcode(Noop)		Line: 212, Column: 51
+4168:  [0] AVMOpcode(Noop)		Line: 212, Column: 47
+4169:  [CodePoint(Internal(4172))] AVMOpcode(PushStatic)		Line: 212, Column: 33
+4170:  [0] AVMOpcode(Tget)		Line: 212, Column: 33
+4171:  AVMOpcode(Jump)		Line: 212, Column: 33
+4172:  [7] AVMOpcode(Xget)		Line: 212, Column: 30
+4173:  [0] AVMOpcode(Tget)		Line: 212, Column: 30
+4174:  [CodePoint(Internal(4178))] AVMOpcode(PushStatic)		Line: 212, Column: 15
+4175:  [4] AVMOpcode(Tget)		Line: 212, Column: 15
+4176:  [5] AVMOpcode(Tget)		Line: 212, Column: 15
+4177:  AVMOpcode(Jump)		Line: 212, Column: 15
+4178:  [0] AVMOpcode(Tget)		Line: 212, Column: 15
+4179:  [7] AVMOpcode(Noop)		Line: 212, Column: 10
+4180:  [0] AVMOpcode(Noop)		Line: 210, Column: 51
+4181:  [0] AVMOpcode(Noop)		Line: 210, Column: 47
+4182:  [CodePoint(Internal(4185))] AVMOpcode(PushStatic)		Line: 210, Column: 33
+4183:  [0] AVMOpcode(Tget)		Line: 210, Column: 33
+4184:  AVMOpcode(Jump)		Line: 210, Column: 33
+4185:  [6] AVMOpcode(Xget)		Line: 210, Column: 30
+4186:  [CodePoint(Internal(4190))] AVMOpcode(PushStatic)		Line: 210, Column: 15
+4187:  [4] AVMOpcode(Tget)		Line: 210, Column: 15
+4188:  [5] AVMOpcode(Tget)		Line: 210, Column: 15
+4189:  AVMOpcode(Jump)		Line: 210, Column: 15
+4190:  [0] AVMOpcode(Tget)		Line: 210, Column: 15
+4191:  [6] AVMOpcode(Noop)		Line: 210, Column: 10
+4192:  [0] AVMOpcode(Noop)		Line: 208, Column: 80
+4193:  [0] AVMOpcode(Noop)		Line: 208, Column: 76
+4194:  [CodePoint(Internal(4197))] AVMOpcode(PushStatic)		Line: 208, Column: 62
+4195:  [0] AVMOpcode(Tget)		Line: 208, Column: 62
+4196:  AVMOpcode(Jump)		Line: 208, Column: 62
+4197:  [5] AVMOpcode(Xget)		Line: 208, Column: 55
+4198:  [CodePoint(Internal(4202))] AVMOpcode(PushStatic)		Line: 208, Column: 40
+4199:  [4] AVMOpcode(Tget)		Line: 208, Column: 40
+4200:  [3] AVMOpcode(Tget)		Line: 208, Column: 40
+4201:  AVMOpcode(Jump)		Line: 208, Column: 40
+4202:  [0] AVMOpcode(Noop)		Line: 208, Column: 37
+4203:  [5] AVMOpcode(Xget)		Line: 208, Column: 31
+4204:  [CodePoint(Internal(4208))] AVMOpcode(PushStatic)		Line: 208, Column: 15
+4205:  [5] AVMOpcode(Tget)		Line: 208, Column: 15
+4206:  [1] AVMOpcode(Tget)		Line: 208, Column: 15
+4207:  AVMOpcode(Jump)		Line: 208, Column: 15
+4208:  [0] AVMOpcode(Tget)		Line: 208, Column: 15
+4209:  [5] AVMOpcode(Noop)		Line: 208, Column: 10
+4210:  [0] AVMOpcode(Noop)		Line: 206, Column: 55
+4211:  [0] AVMOpcode(Noop)		Line: 206, Column: 51
+4212:  [CodePoint(Internal(4215))] AVMOpcode(PushStatic)		Line: 206, Column: 37
+4213:  [0] AVMOpcode(Tget)		Line: 206, Column: 37
+4214:  AVMOpcode(Jump)		Line: 206, Column: 37
+4215:  [4] AVMOpcode(Xget)		Line: 206, Column: 30
+4216:  [CodePoint(Internal(4220))] AVMOpcode(PushStatic)		Line: 206, Column: 15
+4217:  [4] AVMOpcode(Tget)		Line: 206, Column: 15
+4218:  [5] AVMOpcode(Tget)		Line: 206, Column: 15
+4219:  AVMOpcode(Jump)		Line: 206, Column: 15
+4220:  [0] AVMOpcode(Tget)		Line: 206, Column: 15
+4221:  [4] AVMOpcode(Noop)		Line: 206, Column: 10
+4222:  [0] AVMOpcode(Noop)		Line: 204, Column: 55
+4223:  [0] AVMOpcode(Noop)		Line: 204, Column: 51
+4224:  [CodePoint(Internal(4227))] AVMOpcode(PushStatic)		Line: 204, Column: 37
+4225:  [0] AVMOpcode(Tget)		Line: 204, Column: 37
+4226:  AVMOpcode(Jump)		Line: 204, Column: 37
+4227:  [3] AVMOpcode(Xget)		Line: 204, Column: 33
+4228:  [CodePoint(Internal(4232))] AVMOpcode(PushStatic)		Line: 204, Column: 15
+4229:  [5] AVMOpcode(Tget)		Line: 204, Column: 15
+4230:  [2] AVMOpcode(Tget)		Line: 204, Column: 15
+4231:  AVMOpcode(Jump)		Line: 204, Column: 15
+4232:  [0] AVMOpcode(Tget)		Line: 204, Column: 15
+4233:  [3] AVMOpcode(Noop)		Line: 204, Column: 10
+4234:  [0] AVMOpcode(Noop)		Line: 202, Column: 58
+4235:  [0] AVMOpcode(Noop)		Line: 202, Column: 54
+4236:  [CodePoint(Internal(4239))] AVMOpcode(PushStatic)		Line: 202, Column: 40
+4237:  [0] AVMOpcode(Tget)		Line: 202, Column: 40
+4238:  AVMOpcode(Jump)		Line: 202, Column: 40
+4239:  [2] AVMOpcode(Xget)		Line: 202, Column: 30
+4240:  [CodePoint(Internal(4244))] AVMOpcode(PushStatic)		Line: 202, Column: 15
+4241:  [4] AVMOpcode(Tget)		Line: 202, Column: 15
+4242:  [5] AVMOpcode(Tget)		Line: 202, Column: 15
+4243:  AVMOpcode(Jump)		Line: 202, Column: 15
+4244:  [0] AVMOpcode(Tget)		Line: 202, Column: 15
+4245:  [2] AVMOpcode(Noop)		Line: 202, Column: 10
+4246:  [0] AVMOpcode(Noop)		Line: 200, Column: 58
+4247:  [0] AVMOpcode(Noop)		Line: 200, Column: 54
+4248:  [CodePoint(Internal(4251))] AVMOpcode(PushStatic)		Line: 200, Column: 40
+4249:  [0] AVMOpcode(Tget)		Line: 200, Column: 40
+4250:  AVMOpcode(Jump)		Line: 200, Column: 40
+4251:  [1] AVMOpcode(Xget)		Line: 200, Column: 30
+4252:  [CodePoint(Internal(4256))] AVMOpcode(PushStatic)		Line: 200, Column: 15
+4253:  [4] AVMOpcode(Tget)		Line: 200, Column: 15
+4254:  [5] AVMOpcode(Tget)		Line: 200, Column: 15
+4255:  AVMOpcode(Jump)		Line: 200, Column: 15
+4256:  [0] AVMOpcode(Tget)		Line: 200, Column: 15
+4257:  [1] AVMOpcode(Noop)		Line: 200, Column: 10
+4258:  [0] AVMOpcode(Noop)		Line: 198, Column: 56
+4259:  [0] AVMOpcode(Noop)		Line: 198, Column: 52
+4260:  [CodePoint(Internal(4263))] AVMOpcode(PushStatic)		Line: 198, Column: 38
+4261:  [0] AVMOpcode(Tget)		Line: 198, Column: 38
+4262:  AVMOpcode(Jump)		Line: 198, Column: 38
+4263:  [0] AVMOpcode(Xget)		Line: 198, Column: 30
+4264:  [CodePoint(Internal(4268))] AVMOpcode(PushStatic)		Line: 198, Column: 15
+4265:  [4] AVMOpcode(Tget)		Line: 198, Column: 15
+4266:  [5] AVMOpcode(Tget)		Line: 198, Column: 15
+4267:  AVMOpcode(Jump)		Line: 198, Column: 15
+4268:  [0] AVMOpcode(Tget)		Line: 198, Column: 15
+4269:  [0] AVMOpcode(Noop)		Line: 198, Column: 10
+4270:  [7] AVMOpcode(Xget)		Line: 197, Column: 21
+4271:  [2] AVMOpcode(Tget)		Line: 197, Column: 21
+4272:  [CodePoint(Internal(4274))] AVMOpcode(Noop)		Line: 197, Column: 21
+4273:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 197, Column: 21
+4274:  [CodePoint(Internal(4276))] AVMOpcode(Noop)		Line: 197, Column: 21
+4275:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 197, Column: 21
+4276:  [CodePoint(Internal(4278))] AVMOpcode(Noop)		Line: 197, Column: 21
+4277:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 197, Column: 21
+4278:  [CodePoint(Internal(4280))] AVMOpcode(Noop)		Line: 197, Column: 21
+4279:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 197, Column: 21
+4280:  [CodePoint(Internal(4282))] AVMOpcode(Noop)		Line: 197, Column: 21
+4281:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 197, Column: 21
+4282:  [CodePoint(Internal(4284))] AVMOpcode(Noop)		Line: 197, Column: 21
+4283:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 197, Column: 21
+4284:  [CodePoint(Internal(4286))] AVMOpcode(Noop)		Line: 197, Column: 21
+4285:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 197, Column: 21
+4286:  [CodePoint(Internal(4288))] AVMOpcode(Noop)		Line: 197, Column: 21
+4287:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 197, Column: 21
+4288:  [CodePoint(Internal(4290))] AVMOpcode(Noop)		Line: 197, Column: 21
+4289:  [CodePoint(Internal(5154))] AVMOpcode(Jump)		Line: 197, Column: 21
+4290:  [7] AVMOpcode(Xget)		Line: 197, Column: 5
+4291:  [2] AVMOpcode(Tset)		Line: 197, Column: 5
+4292:  [7] AVMOpcode(Xset)		Line: 197, Column: 5
+4293:  [0] AVMOpcode(Noop)		Line: 217, Column: 78
+4294:  [0] AVMOpcode(Noop)		Line: 217, Column: 74
+4295:  [CodePoint(Internal(4298))] AVMOpcode(PushStatic)		Line: 217, Column: 60
+4296:  [0] AVMOpcode(Tget)		Line: 217, Column: 60
+4297:  AVMOpcode(Jump)		Line: 217, Column: 60
+4298:  [9] AVMOpcode(Noop)		Line: 217, Column: 57
+4299:  [0] AVMOpcode(Noop)		Line: 217, Column: 54
+4300:  [7] AVMOpcode(Xget)		Line: 217, Column: 39
+4301:  [2] AVMOpcode(Tget)		Line: 217, Column: 39
+4302:  [CodePoint(Internal(4306))] AVMOpcode(PushStatic)		Line: 217, Column: 24
+4303:  [5] AVMOpcode(Tget)		Line: 217, Column: 24
+4304:  [3] AVMOpcode(Tget)		Line: 217, Column: 24
+4305:  AVMOpcode(Jump)		Line: 217, Column: 24
+4306:  AVMOpcode(Dup0)		Line: 217, Column: 5
+4307:  [0] AVMOpcode(Tget)		Line: 217, Column: 5
+4308:  AVMOpcode(IsZero)		Line: 217, Column: 5
+4309:  [CodePoint(Internal(4322))] AVMOpcode(Cjump)		Line: 217, Column: 5
+4310:  [1] AVMOpcode(Tget)		Line: 217, Column: 5
+4311:  [7] AVMOpcode(Xget)		Line: 217, Column: 5
+4312:  [3] AVMOpcode(Tset)		Line: 217, Column: 5
+4313:  [7] AVMOpcode(Xset)		Line: 217, Column: 5
+4314:  [7] AVMOpcode(Xget)		Line: 218, Column: 16
+4315:  [3] AVMOpcode(Tget)		Line: 218, Column: 16
+4316:  [0] AVMOpcode(Tget)		Line: 218, Column: 16
+4317:  AVMOpcode(AuxPop)		Line: 218, Column: 9
+4318:  AVMOpcode(Pop)		Line: 218, Column: 9
+4319:  AVMOpcode(AuxPop)		Line: 218, Column: 9
+4320:  AVMOpcode(Jump)		Line: 218, Column: 9
+4321:  [CodePoint(Internal(4324))] AVMOpcode(Jump)		Line: 217, Column: 5
+4322:  AVMOpcode(Pop)		Line: 217, Column: 5
+4323:  AVMOpcode(Panic)		Line: 221, Column: 9
+4324:  AVMOpcode(AuxPush)		Line: 249, Column: 1
+4325:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 249, Column: 1
+4326:  [0] AVMOpcode(Xset)		Line: 249, Column: 1
+4327:  [1] AVMOpcode(Xset)		Line: 249, Column: 1
+4328:  [2] AVMOpcode(Xset)		Line: 249, Column: 1
+4329:  [3] AVMOpcode(Xset)		Line: 249, Column: 1
+4330:  [3] AVMOpcode(Xget)		Line: 258, Column: 57
+4331:  [1] AVMOpcode(Plus)		Line: 258, Column: 57
+4332:  [2] AVMOpcode(Xget)		Line: 258, Column: 53
+4333:  [0] AVMOpcode(Xget)		Line: 258, Column: 47
+4334:  [CodePoint(Internal(4338))] AVMOpcode(PushStatic)		Line: 258, Column: 29
+4335:  [5] AVMOpcode(Tget)		Line: 258, Column: 29
+4336:  [2] AVMOpcode(Tget)		Line: 258, Column: 29
+4337:  AVMOpcode(Jump)		Line: 258, Column: 29
+4338:  AVMOpcode(Dup0)		Line: 258, Column: 5
+4339:  [0] AVMOpcode(Tget)		Line: 258, Column: 5
+4340:  [4] AVMOpcode(Xset)		Line: 258, Column: 5
+4341:  [1] AVMOpcode(Tget)		Line: 258, Column: 5
+4342:  [5] AVMOpcode(Xset)		Line: 258, Column: 5
+4343:  [4] AVMOpcode(Xget)		Line: 259, Column: 10
+4344:  [2] AVMOpcode(Xset)		Line: 259, Column: 5
+4345:  [5] AVMOpcode(Xget)		Line: 260, Column: 59
+4346:  [3] AVMOpcode(Xget)		Line: 260, Column: 50
+4347:  [1] AVMOpcode(Plus)		Line: 260, Column: 50
+4348:  AVMOpcode(Plus)		Line: 260, Column: 50
+4349:  [2] AVMOpcode(Xget)		Line: 260, Column: 46
+4350:  [1] AVMOpcode(Xget)		Line: 260, Column: 42
+4351:  [CodePoint(Internal(4355))] AVMOpcode(PushStatic)		Line: 260, Column: 27
+4352:  [4] AVMOpcode(Tget)		Line: 260, Column: 27
+4353:  [5] AVMOpcode(Tget)		Line: 260, Column: 27
+4354:  AVMOpcode(Jump)		Line: 260, Column: 27
+4355:  AVMOpcode(Dup0)		Line: 260, Column: 5
+4356:  [0] AVMOpcode(Tget)		Line: 260, Column: 5
+4357:  [6] AVMOpcode(Xset)		Line: 260, Column: 5
+4358:  [1] AVMOpcode(Tget)		Line: 260, Column: 5
+4359:  [7] AVMOpcode(Xset)		Line: 260, Column: 5
+4360:  [6] AVMOpcode(Xget)		Line: 261, Column: 10
+4361:  [2] AVMOpcode(Xset)		Line: 261, Column: 5
+4362:  [7] AVMOpcode(Xget)		Line: 262, Column: 56
+4363:  [5] AVMOpcode(Xget)		Line: 262, Column: 45
+4364:  [192] AVMOpcode(Plus)		Line: 262, Column: 40
+4365:  AVMOpcode(Plus)		Line: 262, Column: 40
+4366:  [3] AVMOpcode(Xget)		Line: 262, Column: 32
+4367:  [2] AVMOpcode(Xget)		Line: 262, Column: 28
+4368:  [CodePoint(Internal(4372))] AVMOpcode(PushStatic)		Line: 262, Column: 10
+4369:  [2] AVMOpcode(Tget)		Line: 262, Column: 10
+4370:  [4] AVMOpcode(Tget)		Line: 262, Column: 10
+4371:  AVMOpcode(Jump)		Line: 262, Column: 10
+4372:  [2] AVMOpcode(Xset)		Line: 262, Column: 5
+4373:  [7] AVMOpcode(Xget)		Line: 263, Column: 30
+4374:  [5] AVMOpcode(Xget)		Line: 263, Column: 19
+4375:  [1] AVMOpcode(Plus)		Line: 263, Column: 17
+4376:  AVMOpcode(Plus)		Line: 263, Column: 17
+4377:  [2] AVMOpcode(Xget)		Line: 263, Column: 13
+4378:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 263, Column: 12
+4379:  [0] AVMOpcode(Tset)		Line: 263, Column: 12
+4380:  [1] AVMOpcode(Tset)		Line: 263, Column: 12
+4381:  AVMOpcode(AuxPop)		Line: 263, Column: 5
+4382:  AVMOpcode(Pop)		Line: 263, Column: 5
+4383:  AVMOpcode(AuxPop)		Line: 263, Column: 5
+4384:  AVMOpcode(Jump)		Line: 263, Column: 5
+4385:  AVMOpcode(AuxPush)		Line: 266, Column: 1
+4386:  [Tuple(_, _, _, _, _)] AVMOpcode(AuxPush)		Line: 266, Column: 1
+4387:  [0] AVMOpcode(Xset)		Line: 266, Column: 1
+4388:  [1] AVMOpcode(Xset)		Line: 266, Column: 1
+4389:  [64] AVMOpcode(Noop)		Line: 267, Column: 28
+4390:  [CodePoint(Internal(4393))] AVMOpcode(PushStatic)		Line: 267, Column: 14
+4391:  [0] AVMOpcode(Tget)		Line: 267, Column: 14
+4392:  AVMOpcode(Jump)		Line: 267, Column: 14
+4393:  [2] AVMOpcode(Xset)		Line: 267, Column: 5
+4394:  [0] AVMOpcode(Noop)		Line: 268, Column: 62
+4395:  [2] AVMOpcode(Xget)		Line: 268, Column: 58
+4396:  [1] AVMOpcode(Xget)		Line: 268, Column: 54
+4397:  [0] AVMOpcode(Xget)		Line: 268, Column: 48
+4398:  [CodePoint(Internal(4402))] AVMOpcode(PushStatic)		Line: 268, Column: 25
+4399:  [5] AVMOpcode(Tget)		Line: 268, Column: 25
+4400:  [4] AVMOpcode(Tget)		Line: 268, Column: 25
+4401:  AVMOpcode(Jump)		Line: 268, Column: 25
+4402:  AVMOpcode(Dup0)		Line: 268, Column: 5
+4403:  [0] AVMOpcode(Tget)		Line: 268, Column: 5
+4404:  [3] AVMOpcode(Xset)		Line: 268, Column: 5
+4405:  [1] AVMOpcode(Tget)		Line: 268, Column: 5
+4406:  [4] AVMOpcode(Xset)		Line: 268, Column: 5
+4407:  [4] AVMOpcode(Xget)		Line: 269, Column: 30
+4408:  [0] AVMOpcode(Noop)		Line: 269, Column: 27
+4409:  [3] AVMOpcode(Xget)		Line: 269, Column: 22
+4410:  [CodePoint(Internal(4414))] AVMOpcode(PushStatic)		Line: 269, Column: 12
+4411:  [5] AVMOpcode(Tget)		Line: 269, Column: 12
+4412:  [5] AVMOpcode(Tget)		Line: 269, Column: 12
+4413:  AVMOpcode(Jump)		Line: 269, Column: 12
+4414:  AVMOpcode(AuxPop)		Line: 269, Column: 5
+4415:  AVMOpcode(Pop)		Line: 269, Column: 5
+4416:  AVMOpcode(AuxPop)		Line: 269, Column: 5
+4417:  AVMOpcode(Jump)		Line: 269, Column: 5
+4418:  AVMOpcode(AuxPush)		Line: 272, Column: 1
+4419:  [Tuple(_, _, _, _, _, _, _, Tuple(_, _))] AVMOpcode(AuxPush)		Line: 272, Column: 1
+4420:  [0] AVMOpcode(Xset)		Line: 272, Column: 1
+4421:  [0] AVMOpcode(Xget)		Line: 275, Column: 47
+4422:  [CodePoint(Internal(4426))] AVMOpcode(PushStatic)		Line: 275, Column: 28
+4423:  [4] AVMOpcode(Tget)		Line: 275, Column: 28
+4424:  [7] AVMOpcode(Tget)		Line: 275, Column: 28
+4425:  AVMOpcode(Jump)		Line: 275, Column: 28
+4426:  AVMOpcode(Dup0)		Line: 275, Column: 28
+4427:  [0] AVMOpcode(Tget)		Line: 275, Column: 28
+4428:  [CodePoint(Internal(4433))] AVMOpcode(Cjump)		Line: 275, Column: 28
+4429:  AVMOpcode(AuxPop)		Line: 275, Column: 28
+4430:  AVMOpcode(Pop)		Line: 275, Column: 28
+4431:  AVMOpcode(AuxPop)		Line: 275, Column: 28
+4432:  AVMOpcode(Jump)		Line: 275, Column: 28
+4433:  [1] AVMOpcode(Tget)		Line: 275, Column: 28
+4434:  AVMOpcode(Dup0)		Line: 275, Column: 5
+4435:  [0] AVMOpcode(Tget)		Line: 275, Column: 5
+4436:  [1] AVMOpcode(Xset)		Line: 275, Column: 5
+4437:  [1] AVMOpcode(Tget)		Line: 275, Column: 5
+4438:  [2] AVMOpcode(Xset)		Line: 275, Column: 5
+4439:  [1] AVMOpcode(Xget)		Line: 276, Column: 10
+4440:  [0] AVMOpcode(Xset)		Line: 276, Column: 5
+4441:  [2] AVMOpcode(Xget)		Line: 277, Column: 9
+4442:  [127] AVMOpcode(LessThan)		Line: 277, Column: 9
+4443:  [CodePoint(Internal(4455))] AVMOpcode(Cjump)		Line: 277, Column: 5
+4444:  [2] AVMOpcode(Xget)		Line: 278, Column: 26
+4445:  [0] AVMOpcode(Xget)		Line: 278, Column: 22
+4446:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 278, Column: 21
+4447:  [0] AVMOpcode(Tset)		Line: 278, Column: 21
+4448:  [1] AVMOpcode(Tset)		Line: 278, Column: 21
+4449:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 278, Column: 16
+4450:  [1] AVMOpcode(Tset)		Line: 278, Column: 16
+4451:  AVMOpcode(AuxPop)		Line: 278, Column: 9
+4452:  AVMOpcode(Pop)		Line: 278, Column: 9
+4453:  AVMOpcode(AuxPop)		Line: 278, Column: 9
+4454:  AVMOpcode(Jump)		Line: 278, Column: 9
+4455:  [128] AVMOpcode(Noop)		Line: 280, Column: 34
+4456:  [2] AVMOpcode(Xget)		Line: 280, Column: 22
+4457:  AVMOpcode(Minus)		Line: 280, Column: 22
+4458:  [3] AVMOpcode(Xset)		Line: 280, Column: 9
+4459:  [0] AVMOpcode(Noop)		Line: 281, Column: 19
+4460:  [4] AVMOpcode(Xset)		Line: 281, Column: 9
+4461:  [0] AVMOpcode(Noop)		Line: 282, Column: 17
+4462:  [5] AVMOpcode(Xset)		Line: 282, Column: 9
+4463:  [CodePoint(Internal(4466))] AVMOpcode(Noop)		Line: 283, Column: 9
+4464:  [6] AVMOpcode(Xset)		Line: 283, Column: 9
+4465:  [CodePoint(Internal(4500))] AVMOpcode(Jump)		Line: 283, Column: 9
+4466:  [0] AVMOpcode(Xget)		Line: 284, Column: 47
+4467:  [CodePoint(Internal(4471))] AVMOpcode(PushStatic)		Line: 284, Column: 28
+4468:  [4] AVMOpcode(Tget)		Line: 284, Column: 28
+4469:  [7] AVMOpcode(Tget)		Line: 284, Column: 28
+4470:  AVMOpcode(Jump)		Line: 284, Column: 28
+4471:  AVMOpcode(Dup0)		Line: 284, Column: 28
+4472:  [0] AVMOpcode(Tget)		Line: 284, Column: 28
+4473:  [CodePoint(Internal(4478))] AVMOpcode(Cjump)		Line: 284, Column: 28
+4474:  AVMOpcode(AuxPop)		Line: 284, Column: 28
+4475:  AVMOpcode(Pop)		Line: 284, Column: 28
+4476:  AVMOpcode(AuxPop)		Line: 284, Column: 28
+4477:  AVMOpcode(Jump)		Line: 284, Column: 28
+4478:  [1] AVMOpcode(Tget)		Line: 284, Column: 28
+4479:  AVMOpcode(Dup0)		Line: 284, Column: 13
+4480:  [0] AVMOpcode(Tget)		Line: 284, Column: 13
+4481:  [7] AVMOpcode(Xget)		Line: 284, Column: 13
+4482:  [0] AVMOpcode(Tset)		Line: 284, Column: 13
+4483:  [7] AVMOpcode(Xset)		Line: 284, Column: 13
+4484:  [1] AVMOpcode(Tget)		Line: 284, Column: 13
+4485:  [7] AVMOpcode(Xget)		Line: 284, Column: 13
+4486:  [1] AVMOpcode(Tset)		Line: 284, Column: 13
+4487:  [7] AVMOpcode(Xset)		Line: 284, Column: 13
+4488:  [7] AVMOpcode(Xget)		Line: 285, Column: 18
+4489:  [0] AVMOpcode(Tget)		Line: 285, Column: 18
+4490:  [0] AVMOpcode(Xset)		Line: 285, Column: 13
+4491:  [7] AVMOpcode(Xget)		Line: 286, Column: 29
+4492:  [1] AVMOpcode(Tget)		Line: 286, Column: 29
+4493:  [4] AVMOpcode(Xget)		Line: 286, Column: 23
+4494:  [256] AVMOpcode(Mul)		Line: 286, Column: 19
+4495:  AVMOpcode(Plus)		Line: 286, Column: 19
+4496:  [4] AVMOpcode(Xset)		Line: 286, Column: 13
+4497:  [5] AVMOpcode(Xget)		Line: 287, Column: 17
+4498:  [1] AVMOpcode(Plus)		Line: 287, Column: 17
+4499:  [5] AVMOpcode(Xset)		Line: 287, Column: 13
+4500:  [3] AVMOpcode(Xget)		Line: 283, Column: 20
+4501:  [5] AVMOpcode(Xget)		Line: 283, Column: 16
+4502:  AVMOpcode(LessThan)		Line: 283, Column: 16
+4503:  [6] AVMOpcode(Xget)		Line: 283, Column: 9
+4504:  AVMOpcode(Cjump)		Line: 283, Column: 9
+4505:  [4] AVMOpcode(Xget)		Line: 289, Column: 26
+4506:  [0] AVMOpcode(Xget)		Line: 289, Column: 22
+4507:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 289, Column: 21
+4508:  [0] AVMOpcode(Tset)		Line: 289, Column: 21
+4509:  [1] AVMOpcode(Tset)		Line: 289, Column: 21
+4510:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 289, Column: 16
+4511:  [1] AVMOpcode(Tset)		Line: 289, Column: 16
+4512:  AVMOpcode(AuxPop)		Line: 289, Column: 9
+4513:  AVMOpcode(Pop)		Line: 289, Column: 9
+4514:  AVMOpcode(AuxPop)		Line: 289, Column: 9
+4515:  AVMOpcode(Jump)		Line: 289, Column: 9
+4516:  AVMOpcode(AuxPush)		Line: 293, Column: 1
+4517:  [Tuple(_, _, _)] AVMOpcode(AuxPush)		Line: 293, Column: 1
+4518:  [0] AVMOpcode(Xset)		Line: 293, Column: 1
+4519:  [0] AVMOpcode(Xget)		Line: 294, Column: 36
+4520:  [CodePoint(Internal(4524))] AVMOpcode(PushStatic)		Line: 294, Column: 21
+4521:  [5] AVMOpcode(Tget)		Line: 294, Column: 21
+4522:  [6] AVMOpcode(Tget)		Line: 294, Column: 21
+4523:  AVMOpcode(Jump)		Line: 294, Column: 21
+4524:  AVMOpcode(Dup0)		Line: 294, Column: 21
+4525:  [0] AVMOpcode(Tget)		Line: 294, Column: 21
+4526:  [CodePoint(Internal(4531))] AVMOpcode(Cjump)		Line: 294, Column: 21
+4527:  AVMOpcode(AuxPop)		Line: 294, Column: 21
+4528:  AVMOpcode(Pop)		Line: 294, Column: 21
+4529:  AVMOpcode(AuxPop)		Line: 294, Column: 21
+4530:  AVMOpcode(Jump)		Line: 294, Column: 21
+4531:  [1] AVMOpcode(Tget)		Line: 294, Column: 21
+4532:  AVMOpcode(Dup0)		Line: 294, Column: 5
+4533:  [0] AVMOpcode(Tget)		Line: 294, Column: 5
+4534:  [1] AVMOpcode(Xset)		Line: 294, Column: 5
+4535:  [1] AVMOpcode(Tget)		Line: 294, Column: 5
+4536:  [2] AVMOpcode(Xset)		Line: 294, Column: 5
+4537:  [2] AVMOpcode(Xget)		Line: 295, Column: 36
+4538:  [CodePoint(Internal(4542))] AVMOpcode(PushStatic)		Line: 295, Column: 9
+4539:  [4] AVMOpcode(Tget)		Line: 295, Column: 9
+4540:  [6] AVMOpcode(Tget)		Line: 295, Column: 9
+4541:  AVMOpcode(Jump)		Line: 295, Column: 9
+4542:  [20] AVMOpcode(LessThan)		Line: 295, Column: 9
+4543:  [CodePoint(Internal(4556))] AVMOpcode(Cjump)		Line: 295, Column: 5
+4544:  [2] AVMOpcode(Xget)		Line: 296, Column: 34
+4545:  [0xffffffffffffffffffffffffffffffffffffffff] AVMOpcode(BitwiseAnd)		Line: 296, Column: 26
+4546:  [1] AVMOpcode(Xget)		Line: 296, Column: 22
+4547:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 296, Column: 21
+4548:  [0] AVMOpcode(Tset)		Line: 296, Column: 21
+4549:  [1] AVMOpcode(Tset)		Line: 296, Column: 21
+4550:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 296, Column: 16
+4551:  [1] AVMOpcode(Tset)		Line: 296, Column: 16
+4552:  AVMOpcode(AuxPop)		Line: 296, Column: 9
+4553:  AVMOpcode(Pop)		Line: 296, Column: 9
+4554:  AVMOpcode(AuxPop)		Line: 296, Column: 9
+4555:  AVMOpcode(Jump)		Line: 296, Column: 9
+4556:  [Tuple(0)] AVMOpcode(AuxPop)		Line: 298, Column: 9
+4557:  AVMOpcode(Pop)		Line: 298, Column: 9
+4558:  AVMOpcode(AuxPop)		Line: 298, Column: 9
+4559:  AVMOpcode(Jump)		Line: 298, Column: 9
+4560:  AVMOpcode(AuxPush)		Line: 50, Column: 1
+4561:  [_] AVMOpcode(AuxPush)		Line: 50, Column: 1
+4562:  [0] AVMOpcode(Noop)		Line: 53, Column: 15
+4563:  [0] AVMOpcode(Noop)		Line: 52, Column: 42
+4564:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 51, Column: 12
+4565:  [0] AVMOpcode(Tset)		Line: 51, Column: 12
+4566:  [1] AVMOpcode(Tset)		Line: 51, Column: 12
+4567:  AVMOpcode(AuxPop)		Line: 51, Column: 5
+4568:  AVMOpcode(Pop)		Line: 51, Column: 5
+4569:  AVMOpcode(AuxPop)		Line: 51, Column: 5
+4570:  AVMOpcode(Jump)		Line: 51, Column: 5
+4571:  AVMOpcode(AuxPush)		Line: 57, Column: 1
+4572:  [Tuple(_)] AVMOpcode(AuxPush)		Line: 57, Column: 1
+4573:  [0] AVMOpcode(Xset)		Line: 57, Column: 1
+4574:  [0] AVMOpcode(Xget)		Line: 58, Column: 12
+4575:  [1] AVMOpcode(Tget)		Line: 58, Column: 12
+4576:  AVMOpcode(AuxPop)		Line: 58, Column: 5
+4577:  AVMOpcode(Pop)		Line: 58, Column: 5
+4578:  AVMOpcode(AuxPop)		Line: 58, Column: 5
+4579:  AVMOpcode(Jump)		Line: 58, Column: 5
+4580:  AVMOpcode(AuxPush)		Line: 61, Column: 1
+4581:  [Tuple(_, _, _, _, _)] AVMOpcode(AuxPush)		Line: 61, Column: 1
+4582:  [0] AVMOpcode(Xset)		Line: 61, Column: 1
+4583:  [1] AVMOpcode(Xset)		Line: 61, Column: 1
+4584:  [0] AVMOpcode(Xget)		Line: 62, Column: 13
+4585:  [0] AVMOpcode(Tget)		Line: 62, Column: 13
+4586:  [2] AVMOpcode(Xset)		Line: 62, Column: 5
+4587:  [1] AVMOpcode(Noop)		Line: 63, Column: 27
+4588:  [3] AVMOpcode(Xset)		Line: 63, Column: 5
+4589:  [CodePoint(Internal(4591))] AVMOpcode(Noop)		Line: 64, Column: 5
+4590:  [4] AVMOpcode(Xset)		Line: 64, Column: 5
+4591:  [0] AVMOpcode(Noop)		Line: 65, Column: 45
+4592:  [2] AVMOpcode(Xget)		Line: 65, Column: 13
+4593:  AVMOpcode(Equal)		Line: 65, Column: 13
+4594:  AVMOpcode(IsZero)		Line: 65, Column: 9
+4595:  [CodePoint(Internal(4600))] AVMOpcode(Cjump)		Line: 65, Column: 9
+4596:  [0] AVMOpcode(AuxPop)		Line: 67, Column: 13
+4597:  AVMOpcode(Pop)		Line: 67, Column: 13
+4598:  AVMOpcode(AuxPop)		Line: 67, Column: 13
+4599:  AVMOpcode(Jump)		Line: 67, Column: 13
+4600:  [2] AVMOpcode(Xget)		Line: 68, Column: 23
+4601:  AVMOpcode(Tlen)		Line: 68, Column: 34
+4602:  [2] AVMOpcode(Equal)		Line: 68, Column: 19
+4603:  AVMOpcode(IsZero)		Line: 68, Column: 11
+4604:  [CodePoint(Internal(4621))] AVMOpcode(Cjump)		Line: 68, Column: 11
+4605:  [2] AVMOpcode(Xget)		Line: 70, Column: 51
+4606:  [0] AVMOpcode(Tget)		Line: 70, Column: 24
+4607:  [1] AVMOpcode(Xget)		Line: 70, Column: 17
+4608:  AVMOpcode(Equal)		Line: 70, Column: 17
+4609:  AVMOpcode(IsZero)		Line: 70, Column: 13
+4610:  [CodePoint(Internal(4617))] AVMOpcode(Cjump)		Line: 70, Column: 13
+4611:  [2] AVMOpcode(Xget)		Line: 71, Column: 51
+4612:  [1] AVMOpcode(Tget)		Line: 71, Column: 24
+4613:  AVMOpcode(AuxPop)		Line: 71, Column: 17
+4614:  AVMOpcode(Pop)		Line: 71, Column: 17
+4615:  AVMOpcode(AuxPop)		Line: 71, Column: 17
+4616:  AVMOpcode(Jump)		Line: 71, Column: 17
+4617:  [0] AVMOpcode(AuxPop)		Line: 73, Column: 17
+4618:  AVMOpcode(Pop)		Line: 73, Column: 17
+4619:  AVMOpcode(AuxPop)		Line: 73, Column: 17
+4620:  AVMOpcode(Jump)		Line: 73, Column: 17
+4621:  [2] AVMOpcode(Xget)		Line: 77, Column: 44
+4622:  [3] AVMOpcode(Xget)		Line: 77, Column: 51
+4623:  [1] AVMOpcode(Xget)		Line: 77, Column: 47
+4624:  AVMOpcode(Div)		Line: 77, Column: 47
+4625:  [7] AVMOpcode(BitwiseAnd)		Line: 77, Column: 46
+4626:  AVMOpcode(Tget)		Line: 77, Column: 44
+4627:  [2] AVMOpcode(Xset)		Line: 77, Column: 13
+4628:  [3] AVMOpcode(Xget)		Line: 78, Column: 31
+4629:  [8] AVMOpcode(Mul)		Line: 78, Column: 31
+4630:  [3] AVMOpcode(Xset)		Line: 78, Column: 13
+4631:  [4] AVMOpcode(Xget)		Line: 64, Column: 5
+4632:  AVMOpcode(Jump)		Line: 64, Column: 5
+4633:  AVMOpcode(AuxPush)		Line: 93, Column: 1
+4634:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 93, Column: 1
+4635:  [0] AVMOpcode(Xset)		Line: 93, Column: 1
+4636:  [1] AVMOpcode(Xset)		Line: 93, Column: 1
+4637:  [2] AVMOpcode(Xset)		Line: 93, Column: 1
+4638:  [2] AVMOpcode(Xget)		Line: 94, Column: 70
+4639:  [1] AVMOpcode(Xget)		Line: 94, Column: 65
+4640:  [0] AVMOpcode(Xget)		Line: 94, Column: 57
+4641:  [0] AVMOpcode(Tget)		Line: 94, Column: 57
+4642:  [CodePoint(Internal(4644))] AVMOpcode(Noop)		Line: 94, Column: 41
+4643:  [CodePoint(Internal(4693))] AVMOpcode(Jump)		Line: 94, Column: 41
+4644:  AVMOpcode(Dup0)		Line: 94, Column: 5
+4645:  [0] AVMOpcode(Tget)		Line: 94, Column: 5
+4646:  [3] AVMOpcode(Xset)		Line: 94, Column: 5
+4647:  AVMOpcode(Dup0)		Line: 94, Column: 5
+4648:  [1] AVMOpcode(Tget)		Line: 94, Column: 5
+4649:  [4] AVMOpcode(Xset)		Line: 94, Column: 5
+4650:  [2] AVMOpcode(Tget)		Line: 94, Column: 5
+4651:  [5] AVMOpcode(Xset)		Line: 94, Column: 5
+4652:  [CodePoint(Internal(4654))] AVMOpcode(Noop)		Line: 95, Column: 5
+4653:  [6] AVMOpcode(Xset)		Line: 95, Column: 5
+4654:  [4] AVMOpcode(Xget)		Line: 96, Column: 33
+4655:  AVMOpcode(Dup0)		Line: 96, Column: 9
+4656:  [0] AVMOpcode(Tget)		Line: 96, Column: 9
+4657:  AVMOpcode(IsZero)		Line: 96, Column: 9
+4658:  [CodePoint(Internal(4672))] AVMOpcode(Cjump)		Line: 96, Column: 9
+4659:  [1] AVMOpcode(Tget)		Line: 96, Column: 9
+4660:  [7] AVMOpcode(Xset)		Line: 96, Column: 9
+4661:  [3] AVMOpcode(Xget)		Line: 98, Column: 36
+4662:  [7] AVMOpcode(Xget)		Line: 97, Column: 21
+4663:  [0] AVMOpcode(Tget)		Line: 97, Column: 21
+4664:  [7] AVMOpcode(Xget)		Line: 98, Column: 18
+4665:  [1] AVMOpcode(Tget)		Line: 98, Column: 18
+4666:  AVMOpcode(Tset)		Line: 97, Column: 21
+4667:  [3] AVMOpcode(Xset)		Line: 97, Column: 13
+4668:  [7] AVMOpcode(Xget)		Line: 100, Column: 58
+4669:  [2] AVMOpcode(Tget)		Line: 100, Column: 58
+4670:  [4] AVMOpcode(Xset)		Line: 100, Column: 13
+4671:  [CodePoint(Internal(4691))] AVMOpcode(Jump)		Line: 96, Column: 9
+4672:  AVMOpcode(Pop)		Line: 96, Column: 9
+4673:  [5] AVMOpcode(Xget)		Line: 102, Column: 17
+4674:  [0] AVMOpcode(Equal)		Line: 102, Column: 17
+4675:  [CodePoint(Internal(4684))] AVMOpcode(Cjump)		Line: 102, Column: 13
+4676:  [5] AVMOpcode(Xget)		Line: 103, Column: 55
+4677:  [0] AVMOpcode(Xget)		Line: 103, Column: 45
+4678:  [1] AVMOpcode(Tget)		Line: 103, Column: 45
+4679:  AVMOpcode(Plus)		Line: 103, Column: 41
+4680:  [0] AVMOpcode(Xget)		Line: 103, Column: 21
+4681:  [1] AVMOpcode(Tset)		Line: 103, Column: 21
+4682:  [0] AVMOpcode(Xset)		Line: 103, Column: 17
+4683:  [CodePoint(Internal(4684))] AVMOpcode(Jump)		Line: 102, Column: 13
+4684:  [3] AVMOpcode(Xget)		Line: 105, Column: 35
+4685:  [0] AVMOpcode(Xget)		Line: 105, Column: 20
+4686:  [0] AVMOpcode(Tset)		Line: 105, Column: 20
+4687:  AVMOpcode(AuxPop)		Line: 105, Column: 13
+4688:  AVMOpcode(Pop)		Line: 105, Column: 13
+4689:  AVMOpcode(AuxPop)		Line: 105, Column: 13
+4690:  AVMOpcode(Jump)		Line: 105, Column: 13
+4691:  [6] AVMOpcode(Xget)		Line: 95, Column: 5
+4692:  AVMOpcode(Jump)		Line: 95, Column: 5
+4693:  AVMOpcode(AuxPush)		Line: 110, Column: 1
+4694:  [Tuple(_, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 110, Column: 1
+4695:  [0] AVMOpcode(Xset)		Line: 110, Column: 1
+4696:  [1] AVMOpcode(Xset)		Line: 110, Column: 1
+4697:  [2] AVMOpcode(Xset)		Line: 110, Column: 1
+4698:  [1] AVMOpcode(Noop)		Line: 111, Column: 27
+4699:  [3] AVMOpcode(Xset)		Line: 111, Column: 5
+4700:  [Tuple(0)] AVMOpcode(Noop)		Line: 112, Column: 20
+4701:  [4] AVMOpcode(Xset)		Line: 112, Column: 5
+4702:  [CodePoint(Internal(4704))] AVMOpcode(Noop)		Line: 113, Column: 5
+4703:  [5] AVMOpcode(Xset)		Line: 113, Column: 5
+4704:  [0] AVMOpcode(Noop)		Line: 114, Column: 45
+4705:  [0] AVMOpcode(Xget)		Line: 114, Column: 13
+4706:  AVMOpcode(Equal)		Line: 114, Column: 13
+4707:  AVMOpcode(IsZero)		Line: 114, Column: 9
+4708:  [CodePoint(Internal(4739))] AVMOpcode(Cjump)		Line: 114, Column: 9
+4709:  [2] AVMOpcode(Xget)		Line: 115, Column: 17
+4710:  [0] AVMOpcode(Equal)		Line: 115, Column: 17
+4711:  AVMOpcode(IsZero)		Line: 115, Column: 13
+4712:  [CodePoint(Internal(4724))] AVMOpcode(Cjump)		Line: 115, Column: 13
+4713:  [0] AVMOpcode(Noop)		Line: 117, Column: 42
+4714:  [4] AVMOpcode(Xget)		Line: 117, Column: 28
+4715:  [0] AVMOpcode(Xget)		Line: 117, Column: 25
+4716:  [Tuple(_, _, _)] AVMOpcode(Noop)		Line: 117, Column: 24
+4717:  [0] AVMOpcode(Tset)		Line: 117, Column: 24
+4718:  [1] AVMOpcode(Tset)		Line: 117, Column: 24
+4719:  [2] AVMOpcode(Tset)		Line: 117, Column: 24
+4720:  AVMOpcode(AuxPop)		Line: 117, Column: 17
+4721:  AVMOpcode(Pop)		Line: 117, Column: 17
+4722:  AVMOpcode(AuxPop)		Line: 117, Column: 17
+4723:  AVMOpcode(Jump)		Line: 117, Column: 17
+4724:  [1] AVMOpcode(Noop)		Line: 128, Column: 25
+4725:  [4] AVMOpcode(Xget)		Line: 127, Column: 21
+4726:  [2] AVMOpcode(Xget)		Line: 124, Column: 36
+4727:  [1] AVMOpcode(Xget)		Line: 123, Column: 34
+4728:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 122, Column: 25
+4729:  [0] AVMOpcode(Tset)		Line: 122, Column: 25
+4730:  [1] AVMOpcode(Tset)		Line: 122, Column: 25
+4731:  [Tuple(_, _, _)] AVMOpcode(Noop)		Line: 120, Column: 24
+4732:  [0] AVMOpcode(Tset)		Line: 120, Column: 24
+4733:  [1] AVMOpcode(Tset)		Line: 120, Column: 24
+4734:  [2] AVMOpcode(Tset)		Line: 120, Column: 24
+4735:  AVMOpcode(AuxPop)		Line: 120, Column: 17
+4736:  AVMOpcode(Pop)		Line: 120, Column: 17
+4737:  AVMOpcode(AuxPop)		Line: 120, Column: 17
+4738:  AVMOpcode(Jump)		Line: 120, Column: 17
+4739:  [0] AVMOpcode(Xget)		Line: 131, Column: 23
+4740:  AVMOpcode(Tlen)		Line: 131, Column: 34
+4741:  [2] AVMOpcode(Equal)		Line: 131, Column: 19
+4742:  AVMOpcode(IsZero)		Line: 131, Column: 11
+4743:  [CodePoint(Internal(4805))] AVMOpcode(Cjump)		Line: 131, Column: 11
+4744:  [0] AVMOpcode(Xget)		Line: 132, Column: 50
+4745:  [6] AVMOpcode(Xset)		Line: 132, Column: 13
+4746:  [1] AVMOpcode(Xget)		Line: 133, Column: 28
+4747:  [6] AVMOpcode(Xget)		Line: 133, Column: 17
+4748:  [0] AVMOpcode(Tget)		Line: 133, Column: 17
+4749:  AVMOpcode(Equal)		Line: 133, Column: 17
+4750:  AVMOpcode(IsZero)		Line: 133, Column: 13
+4751:  [CodePoint(Internal(4780))] AVMOpcode(Cjump)		Line: 133, Column: 13
+4752:  [2] AVMOpcode(Xget)		Line: 135, Column: 21
+4753:  [0] AVMOpcode(Equal)		Line: 135, Column: 21
+4754:  AVMOpcode(IsZero)		Line: 135, Column: 17
+4755:  [CodePoint(Internal(4767))] AVMOpcode(Cjump)		Line: 135, Column: 17
+4756:  [0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff] AVMOpcode(Noop)		Line: 140, Column: 26
+4757:  [4] AVMOpcode(Xget)		Line: 139, Column: 25
+4758:  [0] AVMOpcode(Noop)		Line: 138, Column: 52
+4759:  [Tuple(_, _, _)] AVMOpcode(Noop)		Line: 137, Column: 28
+4760:  [0] AVMOpcode(Tset)		Line: 137, Column: 28
+4761:  [1] AVMOpcode(Tset)		Line: 137, Column: 28
+4762:  [2] AVMOpcode(Tset)		Line: 137, Column: 28
+4763:  AVMOpcode(AuxPop)		Line: 137, Column: 21
+4764:  AVMOpcode(Pop)		Line: 137, Column: 21
+4765:  AVMOpcode(AuxPop)		Line: 137, Column: 21
+4766:  AVMOpcode(Jump)		Line: 137, Column: 21
+4767:  [0] AVMOpcode(Noop)		Line: 147, Column: 29
+4768:  [4] AVMOpcode(Xget)		Line: 146, Column: 25
+4769:  [2] AVMOpcode(Xget)		Line: 145, Column: 70
+4770:  [6] AVMOpcode(Xget)		Line: 145, Column: 52
+4771:  [1] AVMOpcode(Tset)		Line: 145, Column: 52
+4772:  [Tuple(_, _, _)] AVMOpcode(Noop)		Line: 144, Column: 28
+4773:  [0] AVMOpcode(Tset)		Line: 144, Column: 28
+4774:  [1] AVMOpcode(Tset)		Line: 144, Column: 28
+4775:  [2] AVMOpcode(Tset)		Line: 144, Column: 28
+4776:  AVMOpcode(AuxPop)		Line: 144, Column: 21
+4777:  AVMOpcode(Pop)		Line: 144, Column: 21
+4778:  AVMOpcode(AuxPop)		Line: 144, Column: 21
+4779:  AVMOpcode(Jump)		Line: 144, Column: 21
+4780:  [6] AVMOpcode(Xget)		Line: 155, Column: 57
+4781:  [0] AVMOpcode(Dup0)		Line: 154, Column: 48
+4782:  AVMOpcode(Dup0)		Line: 154, Column: 48
+4783:  AVMOpcode(Dup0)		Line: 154, Column: 48
+4784:  AVMOpcode(Dup0)		Line: 154, Column: 48
+4785:  AVMOpcode(Dup0)		Line: 154, Column: 48
+4786:  AVMOpcode(Dup0)		Line: 154, Column: 48
+4787:  AVMOpcode(Dup0)		Line: 154, Column: 48
+4788:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(Noop)		Line: 154, Column: 48
+4789:  [0] AVMOpcode(Tset)		Line: 154, Column: 48
+4790:  [1] AVMOpcode(Tset)		Line: 154, Column: 48
+4791:  [2] AVMOpcode(Tset)		Line: 154, Column: 48
+4792:  [3] AVMOpcode(Tset)		Line: 154, Column: 48
+4793:  [4] AVMOpcode(Tset)		Line: 154, Column: 48
+4794:  [5] AVMOpcode(Tset)		Line: 154, Column: 48
+4795:  [6] AVMOpcode(Tset)		Line: 154, Column: 48
+4796:  [7] AVMOpcode(Tset)		Line: 154, Column: 48
+4797:  [3] AVMOpcode(Xget)		Line: 155, Column: 31
+4798:  [6] AVMOpcode(Xget)		Line: 155, Column: 23
+4799:  [0] AVMOpcode(Tget)		Line: 155, Column: 23
+4800:  AVMOpcode(Div)		Line: 155, Column: 23
+4801:  [7] AVMOpcode(BitwiseAnd)		Line: 155, Column: 22
+4802:  AVMOpcode(Tset)		Line: 154, Column: 21
+4803:  [0] AVMOpcode(Xset)		Line: 154, Column: 17
+4804:  [CodePoint(Internal(4827))] AVMOpcode(Jump)		Line: 131, Column: 11
+4805:  [3] AVMOpcode(Xget)		Line: 162, Column: 31
+4806:  [1] AVMOpcode(Xget)		Line: 162, Column: 25
+4807:  AVMOpcode(Div)		Line: 162, Column: 25
+4808:  [7] AVMOpcode(BitwiseAnd)		Line: 162, Column: 24
+4809:  [6] AVMOpcode(Xset)		Line: 162, Column: 13
+4810:  [4] AVMOpcode(Xget)		Line: 166, Column: 23
+4811:  [6] AVMOpcode(Xget)		Line: 165, Column: 24
+4812:  [0] AVMOpcode(Xget)		Line: 164, Column: 22
+4813:  [Tuple(_, _, _)] AVMOpcode(Noop)		Line: 163, Column: 29
+4814:  [0] AVMOpcode(Tset)		Line: 163, Column: 29
+4815:  [1] AVMOpcode(Tset)		Line: 163, Column: 29
+4816:  [2] AVMOpcode(Tset)		Line: 163, Column: 29
+4817:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 163, Column: 24
+4818:  [1] AVMOpcode(Tset)		Line: 163, Column: 24
+4819:  [4] AVMOpcode(Xset)		Line: 163, Column: 13
+4820:  [0] AVMOpcode(Xget)		Line: 168, Column: 44
+4821:  [6] AVMOpcode(Xget)		Line: 168, Column: 46
+4822:  AVMOpcode(Tget)		Line: 168, Column: 44
+4823:  [0] AVMOpcode(Xset)		Line: 168, Column: 13
+4824:  [3] AVMOpcode(Xget)		Line: 169, Column: 31
+4825:  [8] AVMOpcode(Mul)		Line: 169, Column: 31
+4826:  [3] AVMOpcode(Xset)		Line: 169, Column: 13
+4827:  [5] AVMOpcode(Xget)		Line: 113, Column: 5
+4828:  AVMOpcode(Jump)		Line: 113, Column: 5
+4829:  AVMOpcode(AuxPush)		Line: 174, Column: 1
+4830:  [Tuple(_, _)] AVMOpcode(AuxPush)		Line: 174, Column: 1
+4831:  [0] AVMOpcode(Xset)		Line: 174, Column: 1
+4832:  [1] AVMOpcode(Xset)		Line: 174, Column: 1
+4833:  [0] AVMOpcode(Noop)		Line: 175, Column: 35
+4834:  [1] AVMOpcode(Xget)		Line: 175, Column: 30
+4835:  [0] AVMOpcode(Xget)		Line: 175, Column: 27
+4836:  [CodePoint(Internal(4840))] AVMOpcode(PushStatic)		Line: 175, Column: 12
+4837:  [5] AVMOpcode(Tget)		Line: 175, Column: 12
+4838:  [7] AVMOpcode(Tget)		Line: 175, Column: 12
+4839:  AVMOpcode(Jump)		Line: 175, Column: 12
+4840:  AVMOpcode(AuxPop)		Line: 175, Column: 5
+4841:  AVMOpcode(Pop)		Line: 175, Column: 5
+4842:  AVMOpcode(AuxPop)		Line: 175, Column: 5
+4843:  AVMOpcode(Jump)		Line: 175, Column: 5
+4844:  AVMOpcode(AuxPush)		Line: 183, Column: 1
+4845:  [Tuple(_, _, _)] AVMOpcode(AuxPush)		Line: 183, Column: 1
+4846:  [0] AVMOpcode(Xset)		Line: 183, Column: 1
+4847:  [1] AVMOpcode(Xset)		Line: 183, Column: 1
+4848:  [2] AVMOpcode(Xset)		Line: 183, Column: 1
+4849:  [2] AVMOpcode(Xget)		Line: 188, Column: 52
+4850:  [1] AVMOpcode(Xget)		Line: 188, Column: 43
+4851:  [0] AVMOpcode(Xget)		Line: 188, Column: 35
+4852:  [0] AVMOpcode(Tget)		Line: 188, Column: 35
+4853:  [CodePoint(Internal(4855))] AVMOpcode(Noop)		Line: 188, Column: 12
+4854:  [CodePoint(Internal(4859))] AVMOpcode(Jump)		Line: 188, Column: 12
+4855:  AVMOpcode(AuxPop)		Line: 188, Column: 5
+4856:  AVMOpcode(Pop)		Line: 188, Column: 5
+4857:  AVMOpcode(AuxPop)		Line: 188, Column: 5
+4858:  AVMOpcode(Jump)		Line: 188, Column: 5
+4859:  AVMOpcode(AuxPush)		Line: 191, Column: 1
+4860:  [Tuple(_, _, _, _, _)] AVMOpcode(AuxPush)		Line: 191, Column: 1
+4861:  [0] AVMOpcode(Xset)		Line: 191, Column: 1
+4862:  [1] AVMOpcode(Xset)		Line: 191, Column: 1
+4863:  [2] AVMOpcode(Xset)		Line: 191, Column: 1
+4864:  [0] AVMOpcode(Noop)		Line: 196, Column: 41
+4865:  [0] AVMOpcode(Xget)		Line: 196, Column: 9
+4866:  AVMOpcode(Equal)		Line: 196, Column: 9
+4867:  AVMOpcode(IsZero)		Line: 196, Column: 5
+4868:  [CodePoint(Internal(4874))] AVMOpcode(Cjump)		Line: 196, Column: 5
+4869:  [2] AVMOpcode(Xget)		Line: 197, Column: 16
+4870:  AVMOpcode(AuxPop)		Line: 197, Column: 9
+4871:  AVMOpcode(Pop)		Line: 197, Column: 9
+4872:  AVMOpcode(AuxPop)		Line: 197, Column: 9
+4873:  AVMOpcode(Jump)		Line: 197, Column: 9
+4874:  [0] AVMOpcode(Xget)		Line: 198, Column: 19
+4875:  AVMOpcode(Tlen)		Line: 198, Column: 30
+4876:  [2] AVMOpcode(Equal)		Line: 198, Column: 15
+4877:  AVMOpcode(IsZero)		Line: 198, Column: 7
+4878:  [CodePoint(Internal(4891))] AVMOpcode(Cjump)		Line: 198, Column: 7
+4879:  [2] AVMOpcode(Xget)		Line: 202, Column: 13
+4880:  [0] AVMOpcode(Xget)		Line: 201, Column: 40
+4881:  [1] AVMOpcode(Tget)		Line: 201, Column: 13
+4882:  [0] AVMOpcode(Xget)		Line: 200, Column: 40
+4883:  [0] AVMOpcode(Tget)		Line: 200, Column: 13
+4884:  [CodePoint(Internal(4887))] AVMOpcode(Noop)		Line: 199, Column: 16
+4885:  [1] AVMOpcode(Xget)		Line: 199, Column: 16
+4886:  AVMOpcode(Jump)		Line: 199, Column: 16
+4887:  AVMOpcode(AuxPop)		Line: 199, Column: 9
+4888:  AVMOpcode(Pop)		Line: 199, Column: 9
+4889:  AVMOpcode(AuxPop)		Line: 199, Column: 9
+4890:  AVMOpcode(Jump)		Line: 199, Column: 9
+4891:  [0] AVMOpcode(Noop)		Line: 205, Column: 17
+4892:  [3] AVMOpcode(Xset)		Line: 205, Column: 9
+4893:  [CodePoint(Internal(4896))] AVMOpcode(Noop)		Line: 206, Column: 9
+4894:  [4] AVMOpcode(Xset)		Line: 206, Column: 9
+4895:  [CodePoint(Internal(4909))] AVMOpcode(Jump)		Line: 206, Column: 9
+4896:  [2] AVMOpcode(Xget)		Line: 207, Column: 87
+4897:  [1] AVMOpcode(Xget)		Line: 207, Column: 78
+4898:  [0] AVMOpcode(Xget)		Line: 207, Column: 71
+4899:  [3] AVMOpcode(Xget)		Line: 207, Column: 73
+4900:  AVMOpcode(Tget)		Line: 207, Column: 71
+4901:  [CodePoint(Internal(4905))] AVMOpcode(PushStatic)		Line: 207, Column: 21
+4902:  [6] AVMOpcode(Tget)		Line: 207, Column: 21
+4903:  [0] AVMOpcode(Tget)		Line: 207, Column: 21
+4904:  AVMOpcode(Jump)		Line: 207, Column: 21
+4905:  [2] AVMOpcode(Xset)		Line: 207, Column: 13
+4906:  [3] AVMOpcode(Xget)		Line: 208, Column: 17
+4907:  [1] AVMOpcode(Plus)		Line: 208, Column: 17
+4908:  [3] AVMOpcode(Xset)		Line: 208, Column: 13
+4909:  [3] AVMOpcode(Xget)		Line: 206, Column: 16
+4910:  [8] AVMOpcode(GreaterThan)		Line: 206, Column: 16
+4911:  [4] AVMOpcode(Xget)		Line: 206, Column: 9
+4912:  AVMOpcode(Cjump)		Line: 206, Column: 9
+4913:  [2] AVMOpcode(Xget)		Line: 210, Column: 16
+4914:  AVMOpcode(AuxPop)		Line: 210, Column: 9
+4915:  AVMOpcode(Pop)		Line: 210, Column: 9
+4916:  AVMOpcode(AuxPop)		Line: 210, Column: 9
+4917:  AVMOpcode(Jump)		Line: 210, Column: 9
+4918:  AVMOpcode(AuxPush)		Line: 39, Column: 1
+4919:  [Tuple(_, _, _, _)] AVMOpcode(AuxPush)		Line: 39, Column: 1
+4920:  [0] AVMOpcode(Xset)		Line: 39, Column: 1
+4921:  [1] AVMOpcode(Xset)		Line: 39, Column: 1
+4922:  [1] AVMOpcode(Noop)		Line: 40, Column: 14
+4923:  [2] AVMOpcode(Xset)		Line: 40, Column: 2
+4924:  [CodePoint(Internal(4927))] AVMOpcode(Noop)		Line: 41, Column: 2
+4925:  [3] AVMOpcode(Xset)		Line: 41, Column: 2
+4926:  [CodePoint(Internal(4948))] AVMOpcode(Jump)		Line: 41, Column: 2
+4927:  [2] AVMOpcode(Xget)		Line: 42, Column: 13
+4928:  [8] AVMOpcode(Mul)		Line: 42, Column: 11
+4929:  [2] AVMOpcode(Xset)		Line: 42, Column: 3
+4930:  [1] AVMOpcode(Xget)		Line: 43, Column: 31
+4931:  AVMOpcode(Dup0)		Line: 43, Column: 14
+4932:  AVMOpcode(Dup0)		Line: 43, Column: 14
+4933:  AVMOpcode(Dup0)		Line: 43, Column: 14
+4934:  AVMOpcode(Dup0)		Line: 43, Column: 14
+4935:  AVMOpcode(Dup0)		Line: 43, Column: 14
+4936:  AVMOpcode(Dup0)		Line: 43, Column: 14
+4937:  AVMOpcode(Dup0)		Line: 43, Column: 14
+4938:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(Noop)		Line: 43, Column: 14
+4939:  [0] AVMOpcode(Tset)		Line: 43, Column: 14
+4940:  [1] AVMOpcode(Tset)		Line: 43, Column: 14
+4941:  [2] AVMOpcode(Tset)		Line: 43, Column: 14
+4942:  [3] AVMOpcode(Tset)		Line: 43, Column: 14
+4943:  [4] AVMOpcode(Tset)		Line: 43, Column: 14
+4944:  [5] AVMOpcode(Tset)		Line: 43, Column: 14
+4945:  [6] AVMOpcode(Tset)		Line: 43, Column: 14
+4946:  [7] AVMOpcode(Tset)		Line: 43, Column: 14
+4947:  [1] AVMOpcode(Xset)		Line: 43, Column: 3
+4948:  [0] AVMOpcode(Xget)		Line: 41, Column: 19
+4949:  [2] AVMOpcode(Xget)		Line: 41, Column: 11
+4950:  [8] AVMOpcode(Mul)		Line: 41, Column: 9
+4951:  AVMOpcode(LessThan)		Line: 41, Column: 9
+4952:  [3] AVMOpcode(Xget)		Line: 41, Column: 2
+4953:  AVMOpcode(Cjump)		Line: 41, Column: 2
+4954:  [1] AVMOpcode(Xget)		Line: 48, Column: 48
+4955:  AVMOpcode(Dup0)		Line: 48, Column: 31
+4956:  AVMOpcode(Dup0)		Line: 48, Column: 31
+4957:  AVMOpcode(Dup0)		Line: 48, Column: 31
+4958:  AVMOpcode(Dup0)		Line: 48, Column: 31
+4959:  AVMOpcode(Dup0)		Line: 48, Column: 31
+4960:  AVMOpcode(Dup0)		Line: 48, Column: 31
+4961:  AVMOpcode(Dup0)		Line: 48, Column: 31
+4962:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(Noop)		Line: 48, Column: 31
+4963:  [0] AVMOpcode(Tset)		Line: 48, Column: 31
+4964:  [1] AVMOpcode(Tset)		Line: 48, Column: 31
+4965:  [2] AVMOpcode(Tset)		Line: 48, Column: 31
+4966:  [3] AVMOpcode(Tset)		Line: 48, Column: 31
+4967:  [4] AVMOpcode(Tset)		Line: 48, Column: 31
+4968:  [5] AVMOpcode(Tset)		Line: 48, Column: 31
+4969:  [6] AVMOpcode(Tset)		Line: 48, Column: 31
+4970:  [7] AVMOpcode(Tset)		Line: 48, Column: 31
+4971:  [2] AVMOpcode(Xget)		Line: 47, Column: 12
+4972:  [0] AVMOpcode(Xget)		Line: 46, Column: 9
+4973:  [Tuple(_, _, _)] AVMOpcode(Noop)		Line: 45, Column: 9
+4974:  [0] AVMOpcode(Tset)		Line: 45, Column: 9
+4975:  [1] AVMOpcode(Tset)		Line: 45, Column: 9
+4976:  [2] AVMOpcode(Tset)		Line: 45, Column: 9
+4977:  AVMOpcode(AuxPop)		Line: 45, Column: 2
+4978:  AVMOpcode(Pop)		Line: 45, Column: 2
+4979:  AVMOpcode(AuxPop)		Line: 45, Column: 2
+4980:  AVMOpcode(Jump)		Line: 45, Column: 2
+4981:  AVMOpcode(AuxPush)		Line: 52, Column: 1
+4982:  [Tuple(_, _, _, _, _)] AVMOpcode(AuxPush)		Line: 52, Column: 1
+4983:  [0] AVMOpcode(Xset)		Line: 52, Column: 1
+4984:  [1] AVMOpcode(Xset)		Line: 52, Column: 1
+4985:  [0] AVMOpcode(Xget)		Line: 53, Column: 15
+4986:  [0] AVMOpcode(Tget)		Line: 53, Column: 15
+4987:  [1] AVMOpcode(Xget)		Line: 53, Column: 6
+4988:  AVMOpcode(LessThan)		Line: 53, Column: 6
+4989:  [CodePoint(Internal(4991))] AVMOpcode(Cjump)		Line: 53, Column: 2
+4990:  AVMOpcode(Panic)		Line: 54, Column: 3
+4991:  [0] AVMOpcode(Xget)		Line: 56, Column: 12
+4992:  [2] AVMOpcode(Tget)		Line: 56, Column: 12
+4993:  [2] AVMOpcode(Xset)		Line: 56, Column: 2
+4994:  [0] AVMOpcode(Xget)		Line: 57, Column: 14
+4995:  [1] AVMOpcode(Tget)		Line: 57, Column: 14
+4996:  [3] AVMOpcode(Xset)		Line: 57, Column: 2
+4997:  [CodePoint(Internal(5000))] AVMOpcode(Noop)		Line: 58, Column: 2
+4998:  [4] AVMOpcode(Xset)		Line: 58, Column: 2
+4999:  [CodePoint(Internal(5014))] AVMOpcode(Jump)		Line: 58, Column: 2
+5000:  [2] AVMOpcode(Xget)		Line: 59, Column: 27
+5001:  [3] AVMOpcode(Xget)		Line: 59, Column: 37
+5002:  [1] AVMOpcode(Xget)		Line: 59, Column: 31
+5003:  AVMOpcode(Div)		Line: 59, Column: 31
+5004:  AVMOpcode(Tget)		Line: 59, Column: 27
+5005:  [2] AVMOpcode(Xset)		Line: 59, Column: 3
+5006:  [3] AVMOpcode(Xget)		Line: 60, Column: 19
+5007:  [1] AVMOpcode(Xget)		Line: 60, Column: 11
+5008:  AVMOpcode(Mod)		Line: 60, Column: 11
+5009:  [1] AVMOpcode(Xset)		Line: 60, Column: 3
+5010:  [8] AVMOpcode(Noop)		Line: 61, Column: 19
+5011:  [3] AVMOpcode(Xget)		Line: 61, Column: 11
+5012:  AVMOpcode(Div)		Line: 61, Column: 11
+5013:  [3] AVMOpcode(Xset)		Line: 61, Column: 3
+5014:  [3] AVMOpcode(Xget)		Line: 58, Column: 14
+5015:  [1] AVMOpcode(GreaterThan)		Line: 58, Column: 9
+5016:  AVMOpcode(IsZero)		Line: 58, Column: 9
+5017:  [4] AVMOpcode(Xget)		Line: 58, Column: 2
+5018:  AVMOpcode(Cjump)		Line: 58, Column: 2
+5019:  [2] AVMOpcode(Xget)		Line: 63, Column: 9
+5020:  AVMOpcode(AuxPop)		Line: 63, Column: 2
+5021:  AVMOpcode(Pop)		Line: 63, Column: 2
+5022:  AVMOpcode(AuxPop)		Line: 63, Column: 2
+5023:  AVMOpcode(Jump)		Line: 63, Column: 2
+5024:  AVMOpcode(AuxPush)		Line: 66, Column: 1
+5025:  [Tuple(_, _)] AVMOpcode(AuxPush)		Line: 66, Column: 1
+5026:  [0] AVMOpcode(Xset)		Line: 66, Column: 1
+5027:  [1] AVMOpcode(Xset)		Line: 66, Column: 1
+5028:  [0] AVMOpcode(Xget)		Line: 68, Column: 15
+5029:  [0] AVMOpcode(Tget)		Line: 68, Column: 15
+5030:  [1] AVMOpcode(Xget)		Line: 68, Column: 6
+5031:  AVMOpcode(LessThan)		Line: 68, Column: 6
+5032:  [CodePoint(Internal(5037))] AVMOpcode(Cjump)		Line: 68, Column: 2
+5033:  [Tuple(0)] AVMOpcode(AuxPop)		Line: 69, Column: 3
+5034:  AVMOpcode(Pop)		Line: 69, Column: 3
+5035:  AVMOpcode(AuxPop)		Line: 69, Column: 3
+5036:  AVMOpcode(Jump)		Line: 69, Column: 3
+5037:  [1] AVMOpcode(Xget)		Line: 71, Column: 36
+5038:  [0] AVMOpcode(Xget)		Line: 71, Column: 31
+5039:  [CodePoint(Internal(5043))] AVMOpcode(PushStatic)		Line: 71, Column: 14
+5040:  [6] AVMOpcode(Tget)		Line: 71, Column: 14
+5041:  [1] AVMOpcode(Tget)		Line: 71, Column: 14
+5042:  AVMOpcode(Jump)		Line: 71, Column: 14
+5043:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 71, Column: 9
+5044:  [1] AVMOpcode(Tset)		Line: 71, Column: 9
+5045:  AVMOpcode(AuxPop)		Line: 71, Column: 2
+5046:  AVMOpcode(Pop)		Line: 71, Column: 2
+5047:  AVMOpcode(AuxPop)		Line: 71, Column: 2
+5048:  AVMOpcode(Jump)		Line: 71, Column: 2
+5049:  AVMOpcode(AuxPush)		Line: 74, Column: 1
+5050:  [Tuple(_, _, _, _, _)] AVMOpcode(AuxPush)		Line: 74, Column: 1
+5051:  [0] AVMOpcode(Xset)		Line: 74, Column: 1
+5052:  [1] AVMOpcode(Xset)		Line: 74, Column: 1
+5053:  [0] AVMOpcode(Xget)		Line: 77, Column: 17
+5054:  [0] AVMOpcode(Tget)		Line: 77, Column: 17
+5055:  [1] AVMOpcode(Xget)		Line: 77, Column: 6
+5056:  [1] AVMOpcode(Plus)		Line: 77, Column: 6
+5057:  AVMOpcode(LessThan)		Line: 77, Column: 6
+5058:  [CodePoint(Internal(5060))] AVMOpcode(Cjump)		Line: 77, Column: 2
+5059:  AVMOpcode(Panic)		Line: 78, Column: 3
+5060:  [8] AVMOpcode(Noop)		Line: 80, Column: 15
+5061:  [1] AVMOpcode(Xget)		Line: 80, Column: 7
+5062:  AVMOpcode(Mod)		Line: 80, Column: 7
+5063:  [7] AVMOpcode(Equal)		Line: 80, Column: 6
+5064:  AVMOpcode(IsZero)		Line: 80, Column: 2
+5065:  [CodePoint(Internal(5086))] AVMOpcode(Cjump)		Line: 80, Column: 2
+5066:  [1] AVMOpcode(Xget)		Line: 82, Column: 63
+5067:  [1] AVMOpcode(Plus)		Line: 82, Column: 63
+5068:  [0] AVMOpcode(Xget)		Line: 82, Column: 58
+5069:  [CodePoint(Internal(5073))] AVMOpcode(PushStatic)		Line: 82, Column: 41
+5070:  [6] AVMOpcode(Tget)		Line: 82, Column: 41
+5071:  [1] AVMOpcode(Tget)		Line: 82, Column: 41
+5072:  AVMOpcode(Jump)		Line: 82, Column: 41
+5073:  [1] AVMOpcode(Xget)		Line: 82, Column: 33
+5074:  [0] AVMOpcode(Xget)		Line: 82, Column: 28
+5075:  [CodePoint(Internal(5079))] AVMOpcode(PushStatic)		Line: 82, Column: 11
+5076:  [6] AVMOpcode(Tget)		Line: 82, Column: 11
+5077:  [1] AVMOpcode(Tget)		Line: 82, Column: 11
+5078:  AVMOpcode(Jump)		Line: 82, Column: 11
+5079:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 82, Column: 10
+5080:  [0] AVMOpcode(Tset)		Line: 82, Column: 10
+5081:  [1] AVMOpcode(Tset)		Line: 82, Column: 10
+5082:  AVMOpcode(AuxPop)		Line: 82, Column: 3
+5083:  AVMOpcode(Pop)		Line: 82, Column: 3
+5084:  AVMOpcode(AuxPop)		Line: 82, Column: 3
+5085:  AVMOpcode(Jump)		Line: 82, Column: 3
+5086:  [0] AVMOpcode(Xget)		Line: 84, Column: 13
+5087:  [2] AVMOpcode(Tget)		Line: 84, Column: 13
+5088:  [2] AVMOpcode(Xset)		Line: 84, Column: 3
+5089:  [0] AVMOpcode(Xget)		Line: 85, Column: 15
+5090:  [1] AVMOpcode(Tget)		Line: 85, Column: 15
+5091:  [3] AVMOpcode(Xset)		Line: 85, Column: 3
+5092:  [CodePoint(Internal(5095))] AVMOpcode(Noop)		Line: 86, Column: 3
+5093:  [4] AVMOpcode(Xset)		Line: 86, Column: 3
+5094:  [CodePoint(Internal(5109))] AVMOpcode(Jump)		Line: 86, Column: 3
+5095:  [2] AVMOpcode(Xget)		Line: 87, Column: 28
+5096:  [3] AVMOpcode(Xget)		Line: 87, Column: 38
+5097:  [1] AVMOpcode(Xget)		Line: 87, Column: 32
+5098:  AVMOpcode(Div)		Line: 87, Column: 32
+5099:  AVMOpcode(Tget)		Line: 87, Column: 28
+5100:  [2] AVMOpcode(Xset)		Line: 87, Column: 4
+5101:  [3] AVMOpcode(Xget)		Line: 88, Column: 20
+5102:  [1] AVMOpcode(Xget)		Line: 88, Column: 12
+5103:  AVMOpcode(Mod)		Line: 88, Column: 12
+5104:  [1] AVMOpcode(Xset)		Line: 88, Column: 4
+5105:  [8] AVMOpcode(Noop)		Line: 89, Column: 20
+5106:  [3] AVMOpcode(Xget)		Line: 89, Column: 12
+5107:  AVMOpcode(Div)		Line: 89, Column: 12
+5108:  [3] AVMOpcode(Xset)		Line: 89, Column: 4
+5109:  [3] AVMOpcode(Xget)		Line: 86, Column: 15
+5110:  [8] AVMOpcode(GreaterThan)		Line: 86, Column: 10
+5111:  AVMOpcode(IsZero)		Line: 86, Column: 10
+5112:  [4] AVMOpcode(Xget)		Line: 86, Column: 3
+5113:  AVMOpcode(Cjump)		Line: 86, Column: 3
+5114:  [2] AVMOpcode(Xget)		Line: 91, Column: 23
+5115:  [1] AVMOpcode(Xget)		Line: 91, Column: 27
+5116:  [1] AVMOpcode(Plus)		Line: 91, Column: 27
+5117:  AVMOpcode(Tget)		Line: 91, Column: 23
+5118:  [2] AVMOpcode(Xget)		Line: 91, Column: 11
+5119:  [1] AVMOpcode(Xget)		Line: 91, Column: 15
+5120:  AVMOpcode(Tget)		Line: 91, Column: 11
+5121:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 91, Column: 10
+5122:  [0] AVMOpcode(Tset)		Line: 91, Column: 10
+5123:  [1] AVMOpcode(Tset)		Line: 91, Column: 10
+5124:  AVMOpcode(AuxPop)		Line: 91, Column: 3
+5125:  AVMOpcode(Pop)		Line: 91, Column: 3
+5126:  AVMOpcode(AuxPop)		Line: 91, Column: 3
+5127:  AVMOpcode(Jump)		Line: 91, Column: 3
+5128:  AVMOpcode(AuxPush)		Line: 95, Column: 1
+5129:  [Tuple(_, _)] AVMOpcode(AuxPush)		Line: 95, Column: 1
+5130:  [0] AVMOpcode(Xset)		Line: 95, Column: 1
+5131:  [1] AVMOpcode(Xset)		Line: 95, Column: 1
+5132:  [0] AVMOpcode(Xget)		Line: 97, Column: 17
+5133:  [0] AVMOpcode(Tget)		Line: 97, Column: 17
+5134:  [1] AVMOpcode(Xget)		Line: 97, Column: 6
+5135:  [1] AVMOpcode(Plus)		Line: 97, Column: 6
+5136:  AVMOpcode(LessThan)		Line: 97, Column: 6
+5137:  [CodePoint(Internal(5142))] AVMOpcode(Cjump)		Line: 97, Column: 2
+5138:  [Tuple(0)] AVMOpcode(AuxPop)		Line: 98, Column: 3
+5139:  AVMOpcode(Pop)		Line: 98, Column: 3
+5140:  AVMOpcode(AuxPop)		Line: 98, Column: 3
+5141:  AVMOpcode(Jump)		Line: 98, Column: 3
+5142:  [1] AVMOpcode(Xget)		Line: 100, Column: 47
+5143:  [0] AVMOpcode(Xget)		Line: 100, Column: 42
+5144:  [CodePoint(Internal(5148))] AVMOpcode(PushStatic)		Line: 100, Column: 14
+5145:  [6] AVMOpcode(Tget)		Line: 100, Column: 14
+5146:  [2] AVMOpcode(Tget)		Line: 100, Column: 14
+5147:  AVMOpcode(Jump)		Line: 100, Column: 14
+5148:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 100, Column: 9
+5149:  [1] AVMOpcode(Tset)		Line: 100, Column: 9
+5150:  AVMOpcode(AuxPop)		Line: 100, Column: 2
+5151:  AVMOpcode(Pop)		Line: 100, Column: 2
+5152:  AVMOpcode(AuxPop)		Line: 100, Column: 2
+5153:  AVMOpcode(Jump)		Line: 100, Column: 2
+5154:  AVMOpcode(AuxPush)		Line: 103, Column: 1
+5155:  [Tuple(_, _, _)] AVMOpcode(AuxPush)		Line: 103, Column: 1
+5156:  [0] AVMOpcode(Xset)		Line: 103, Column: 1
+5157:  [1] AVMOpcode(Xset)		Line: 103, Column: 1
+5158:  [2] AVMOpcode(Xset)		Line: 103, Column: 1
+5159:  [0] AVMOpcode(Xget)		Line: 104, Column: 15
+5160:  [0] AVMOpcode(Tget)		Line: 104, Column: 15
+5161:  [1] AVMOpcode(Xget)		Line: 104, Column: 6
+5162:  AVMOpcode(LessThan)		Line: 104, Column: 6
+5163:  [CodePoint(Internal(5165))] AVMOpcode(Cjump)		Line: 104, Column: 2
+5164:  AVMOpcode(Panic)		Line: 105, Column: 3
+5165:  [2] AVMOpcode(Xget)		Line: 107, Column: 74
+5166:  [1] AVMOpcode(Xget)		Line: 107, Column: 67
+5167:  [0] AVMOpcode(Xget)		Line: 107, Column: 54
+5168:  [1] AVMOpcode(Tget)		Line: 107, Column: 54
+5169:  [0] AVMOpcode(Xget)		Line: 107, Column: 40
+5170:  [2] AVMOpcode(Tget)		Line: 107, Column: 40
+5171:  [CodePoint(Internal(5173))] AVMOpcode(Noop)		Line: 107, Column: 30
+5172:  [CodePoint(Internal(5179))] AVMOpcode(Jump)		Line: 107, Column: 30
+5173:  [0] AVMOpcode(Xget)		Line: 107, Column: 9
+5174:  [2] AVMOpcode(Tset)		Line: 107, Column: 9
+5175:  AVMOpcode(AuxPop)		Line: 107, Column: 2
+5176:  AVMOpcode(Pop)		Line: 107, Column: 2
+5177:  AVMOpcode(AuxPop)		Line: 107, Column: 2
+5178:  AVMOpcode(Jump)		Line: 107, Column: 2
+5179:  AVMOpcode(AuxPush)		Line: 117, Column: 1
+5180:  [Tuple(_, _, _, _)] AVMOpcode(AuxPush)		Line: 117, Column: 1
+5181:  [0] AVMOpcode(Xset)		Line: 117, Column: 1
+5182:  [1] AVMOpcode(Xset)		Line: 117, Column: 1
+5183:  [2] AVMOpcode(Xset)		Line: 117, Column: 1
+5184:  [3] AVMOpcode(Xset)		Line: 117, Column: 1
+5185:  [1] AVMOpcode(Xget)		Line: 118, Column: 11
+5186:  [1] AVMOpcode(Equal)		Line: 118, Column: 6
+5187:  AVMOpcode(IsZero)		Line: 118, Column: 2
+5188:  [CodePoint(Internal(5197))] AVMOpcode(Cjump)		Line: 118, Column: 2
+5189:  [3] AVMOpcode(Xget)		Line: 120, Column: 28
+5190:  [0] AVMOpcode(Xget)		Line: 120, Column: 10
+5191:  [2] AVMOpcode(Xget)		Line: 120, Column: 19
+5192:  AVMOpcode(Tset)		Line: 120, Column: 10
+5193:  AVMOpcode(AuxPop)		Line: 120, Column: 3
+5194:  AVMOpcode(Pop)		Line: 120, Column: 3
+5195:  AVMOpcode(AuxPop)		Line: 120, Column: 3
+5196:  AVMOpcode(Jump)		Line: 120, Column: 3
+5197:  [3] AVMOpcode(Xget)		Line: 127, Column: 4
+5198:  [1] AVMOpcode(Xget)		Line: 126, Column: 12
+5199:  [2] AVMOpcode(Xget)		Line: 126, Column: 4
+5200:  AVMOpcode(Mod)		Line: 126, Column: 4
+5201:  [8] AVMOpcode(Noop)		Line: 125, Column: 16
+5202:  [1] AVMOpcode(Xget)		Line: 125, Column: 4
+5203:  AVMOpcode(Div)		Line: 125, Column: 4
+5204:  [0] AVMOpcode(Xget)		Line: 124, Column: 22
+5205:  [1] AVMOpcode(Xget)		Line: 124, Column: 30
+5206:  [2] AVMOpcode(Xget)		Line: 124, Column: 24
+5207:  AVMOpcode(Div)		Line: 124, Column: 24
+5208:  AVMOpcode(Tget)		Line: 124, Column: 22
+5209:  [CodePoint(Internal(5213))] AVMOpcode(PushStatic)		Line: 123, Column: 38
+5210:  [6] AVMOpcode(Tget)		Line: 123, Column: 38
+5211:  [3] AVMOpcode(Tget)		Line: 123, Column: 38
+5212:  AVMOpcode(Jump)		Line: 123, Column: 38
+5213:  [0] AVMOpcode(Xget)		Line: 123, Column: 10
+5214:  [1] AVMOpcode(Xget)		Line: 123, Column: 25
+5215:  [2] AVMOpcode(Xget)		Line: 123, Column: 19
+5216:  AVMOpcode(Div)		Line: 123, Column: 19
+5217:  AVMOpcode(Tset)		Line: 123, Column: 10
+5218:  AVMOpcode(AuxPop)		Line: 123, Column: 3
+5219:  AVMOpcode(Pop)		Line: 123, Column: 3
+5220:  AVMOpcode(AuxPop)		Line: 123, Column: 3
+5221:  AVMOpcode(Jump)		Line: 123, Column: 3
+5222:  AVMOpcode(AuxPush)		Line: 110, Column: 1
+5223:  [Tuple(_, _, _)] AVMOpcode(AuxPush)		Line: 110, Column: 1
+5224:  [0] AVMOpcode(Xset)		Line: 110, Column: 1
+5225:  [1] AVMOpcode(Xset)		Line: 110, Column: 1
+5226:  [2] AVMOpcode(Xset)		Line: 110, Column: 1
+5227:  [0] AVMOpcode(Xget)		Line: 111, Column: 15
+5228:  [0] AVMOpcode(Tget)		Line: 111, Column: 15
+5229:  [1] AVMOpcode(Xget)		Line: 111, Column: 6
+5230:  AVMOpcode(LessThan)		Line: 111, Column: 6
+5231:  [CodePoint(Internal(5236))] AVMOpcode(Cjump)		Line: 111, Column: 2
+5232:  [Tuple(0)] AVMOpcode(AuxPop)		Line: 112, Column: 3
+5233:  AVMOpcode(Pop)		Line: 112, Column: 3
+5234:  AVMOpcode(AuxPop)		Line: 112, Column: 3
+5235:  AVMOpcode(Jump)		Line: 112, Column: 3
+5236:  [2] AVMOpcode(Xget)		Line: 114, Column: 43
+5237:  [1] AVMOpcode(Xget)		Line: 114, Column: 36
+5238:  [0] AVMOpcode(Xget)		Line: 114, Column: 31
+5239:  [CodePoint(Internal(5243))] AVMOpcode(PushStatic)		Line: 114, Column: 14
+5240:  [6] AVMOpcode(Tget)		Line: 114, Column: 14
+5241:  [4] AVMOpcode(Tget)		Line: 114, Column: 14
+5242:  AVMOpcode(Jump)		Line: 114, Column: 14
+5243:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 114, Column: 9
+5244:  [1] AVMOpcode(Tset)		Line: 114, Column: 9
+5245:  AVMOpcode(AuxPop)		Line: 114, Column: 2
+5246:  AVMOpcode(Pop)		Line: 114, Column: 2
+5247:  AVMOpcode(AuxPop)		Line: 114, Column: 2
+5248:  AVMOpcode(Jump)		Line: 114, Column: 2
+5249:  AVMOpcode(AuxPush)		Line: 132, Column: 1
+5250:  [Tuple(_, _, _, _)] AVMOpcode(AuxPush)		Line: 132, Column: 1
+5251:  [0] AVMOpcode(Xset)		Line: 132, Column: 1
+5252:  [1] AVMOpcode(Xset)		Line: 132, Column: 1
+5253:  [2] AVMOpcode(Xset)		Line: 132, Column: 1
+5254:  [0] AVMOpcode(Xget)		Line: 134, Column: 15
+5255:  [0] AVMOpcode(Tget)		Line: 134, Column: 15
+5256:  [1] AVMOpcode(Xget)		Line: 134, Column: 6
+5257:  AVMOpcode(LessThan)		Line: 134, Column: 6
+5258:  [CodePoint(Internal(5260))] AVMOpcode(Cjump)		Line: 134, Column: 2
+5259:  AVMOpcode(Panic)		Line: 135, Column: 3
+5260:  [2] AVMOpcode(Xget)		Line: 137, Column: 53
+5261:  [1] AVMOpcode(Xget)		Line: 137, Column: 46
+5262:  [0] AVMOpcode(Xget)		Line: 137, Column: 35
+5263:  [1] AVMOpcode(Tget)		Line: 137, Column: 35
+5264:  [0] AVMOpcode(Xget)		Line: 137, Column: 23
+5265:  [2] AVMOpcode(Tget)		Line: 137, Column: 23
+5266:  [CodePoint(Internal(5268))] AVMOpcode(Noop)		Line: 137, Column: 12
+5267:  [CodePoint(Internal(5282))] AVMOpcode(Jump)		Line: 137, Column: 12
+5268:  [3] AVMOpcode(Xset)		Line: 137, Column: 2
+5269:  [3] AVMOpcode(Xget)		Line: 140, Column: 3
+5270:  [1] AVMOpcode(Tget)		Line: 140, Column: 3
+5271:  [3] AVMOpcode(Xget)		Line: 139, Column: 22
+5272:  [0] AVMOpcode(Tget)		Line: 139, Column: 22
+5273:  [0] AVMOpcode(Xget)		Line: 139, Column: 3
+5274:  [2] AVMOpcode(Tset)		Line: 139, Column: 3
+5275:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 138, Column: 9
+5276:  [0] AVMOpcode(Tset)		Line: 138, Column: 9
+5277:  [1] AVMOpcode(Tset)		Line: 138, Column: 9
+5278:  AVMOpcode(AuxPop)		Line: 138, Column: 2
+5279:  AVMOpcode(Pop)		Line: 138, Column: 2
+5280:  AVMOpcode(AuxPop)		Line: 138, Column: 2
+5281:  AVMOpcode(Jump)		Line: 138, Column: 2
+5282:  AVMOpcode(AuxPush)		Line: 157, Column: 1
+5283:  [Tuple(_, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 157, Column: 1
+5284:  [0] AVMOpcode(Xset)		Line: 157, Column: 1
+5285:  [1] AVMOpcode(Xset)		Line: 157, Column: 1
+5286:  [2] AVMOpcode(Xset)		Line: 157, Column: 1
+5287:  [3] AVMOpcode(Xset)		Line: 157, Column: 1
+5288:  [1] AVMOpcode(Xget)		Line: 158, Column: 11
+5289:  [1] AVMOpcode(Equal)		Line: 158, Column: 6
+5290:  AVMOpcode(IsZero)		Line: 158, Column: 2
+5291:  [CodePoint(Internal(5306))] AVMOpcode(Cjump)		Line: 158, Column: 2
+5292:  [0] AVMOpcode(Xget)		Line: 161, Column: 9
+5293:  [2] AVMOpcode(Xget)		Line: 161, Column: 11
+5294:  AVMOpcode(Tget)		Line: 161, Column: 9
+5295:  [3] AVMOpcode(Xget)		Line: 160, Column: 28
+5296:  [0] AVMOpcode(Xget)		Line: 160, Column: 10
+5297:  [2] AVMOpcode(Xget)		Line: 160, Column: 19
+5298:  AVMOpcode(Tset)		Line: 160, Column: 10
+5299:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 159, Column: 10
+5300:  [0] AVMOpcode(Tset)		Line: 159, Column: 10
+5301:  [1] AVMOpcode(Tset)		Line: 159, Column: 10
+5302:  AVMOpcode(AuxPop)		Line: 159, Column: 3
+5303:  AVMOpcode(Pop)		Line: 159, Column: 3
+5304:  AVMOpcode(AuxPop)		Line: 159, Column: 3
+5305:  AVMOpcode(Jump)		Line: 159, Column: 3
+5306:  [1] AVMOpcode(Xget)		Line: 164, Column: 24
+5307:  [2] AVMOpcode(Xget)		Line: 164, Column: 18
+5308:  AVMOpcode(Div)		Line: 164, Column: 18
+5309:  [4] AVMOpcode(Xset)		Line: 164, Column: 3
+5310:  [3] AVMOpcode(Xget)		Line: 169, Column: 4
+5311:  [1] AVMOpcode(Xget)		Line: 168, Column: 10
+5312:  [2] AVMOpcode(Xget)		Line: 168, Column: 4
+5313:  AVMOpcode(Mod)		Line: 168, Column: 4
+5314:  [8] AVMOpcode(Noop)		Line: 167, Column: 10
+5315:  [1] AVMOpcode(Xget)		Line: 167, Column: 4
+5316:  AVMOpcode(Div)		Line: 167, Column: 4
+5317:  [0] AVMOpcode(Xget)		Line: 166, Column: 22
+5318:  [4] AVMOpcode(Xget)		Line: 166, Column: 24
+5319:  AVMOpcode(Tget)		Line: 166, Column: 22
+5320:  [CodePoint(Internal(5324))] AVMOpcode(PushStatic)		Line: 165, Column: 13
+5321:  [6] AVMOpcode(Tget)		Line: 165, Column: 13
+5322:  [5] AVMOpcode(Tget)		Line: 165, Column: 13
+5323:  AVMOpcode(Jump)		Line: 165, Column: 13
+5324:  [5] AVMOpcode(Xset)		Line: 165, Column: 3
+5325:  [5] AVMOpcode(Xget)		Line: 171, Column: 48
+5326:  [0] AVMOpcode(Tget)		Line: 171, Column: 48
+5327:  [0] AVMOpcode(Xget)		Line: 171, Column: 27
+5328:  [4] AVMOpcode(Xget)		Line: 171, Column: 36
+5329:  AVMOpcode(Tset)		Line: 171, Column: 27
+5330:  [5] AVMOpcode(Xget)		Line: 171, Column: 10
+5331:  [0] AVMOpcode(Tset)		Line: 171, Column: 10
+5332:  AVMOpcode(AuxPop)		Line: 171, Column: 3
+5333:  AVMOpcode(Pop)		Line: 171, Column: 3
+5334:  AVMOpcode(AuxPop)		Line: 171, Column: 3
+5335:  AVMOpcode(Jump)		Line: 171, Column: 3
+5336:  AVMOpcode(AuxPush)		Line: 144, Column: 1
+5337:  [Tuple(_, _, _, _, _)] AVMOpcode(AuxPush)		Line: 144, Column: 1
+5338:  [0] AVMOpcode(Xset)		Line: 144, Column: 1
+5339:  [1] AVMOpcode(Xset)		Line: 144, Column: 1
+5340:  [2] AVMOpcode(Xset)		Line: 144, Column: 1
+5341:  [0] AVMOpcode(Xget)		Line: 145, Column: 15
+5342:  [0] AVMOpcode(Tget)		Line: 145, Column: 15
+5343:  [1] AVMOpcode(Xget)		Line: 145, Column: 6
+5344:  AVMOpcode(LessThan)		Line: 145, Column: 6
+5345:  [CodePoint(Internal(5350))] AVMOpcode(Cjump)		Line: 145, Column: 2
+5346:  [Tuple(0)] AVMOpcode(AuxPop)		Line: 146, Column: 3
+5347:  AVMOpcode(Pop)		Line: 146, Column: 3
+5348:  AVMOpcode(AuxPop)		Line: 146, Column: 3
+5349:  AVMOpcode(Jump)		Line: 146, Column: 3
+5350:  [2] AVMOpcode(Xget)		Line: 148, Column: 51
+5351:  [1] AVMOpcode(Xget)		Line: 148, Column: 44
+5352:  [0] AVMOpcode(Xget)		Line: 148, Column: 41
+5353:  [CodePoint(Internal(5357))] AVMOpcode(PushStatic)		Line: 148, Column: 23
+5354:  [6] AVMOpcode(Tget)		Line: 148, Column: 23
+5355:  [6] AVMOpcode(Tget)		Line: 148, Column: 23
+5356:  AVMOpcode(Jump)		Line: 148, Column: 23
+5357:  AVMOpcode(Dup0)		Line: 148, Column: 2
+5358:  [0] AVMOpcode(Tget)		Line: 148, Column: 2
+5359:  [3] AVMOpcode(Xset)		Line: 148, Column: 2
+5360:  [1] AVMOpcode(Tget)		Line: 148, Column: 2
+5361:  [4] AVMOpcode(Xset)		Line: 148, Column: 2
+5362:  [4] AVMOpcode(Xget)		Line: 149, Column: 21
+5363:  [3] AVMOpcode(Xget)		Line: 149, Column: 15
+5364:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 149, Column: 14
+5365:  [0] AVMOpcode(Tset)		Line: 149, Column: 14
+5366:  [1] AVMOpcode(Tset)		Line: 149, Column: 14
+5367:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 149, Column: 9
+5368:  [1] AVMOpcode(Tset)		Line: 149, Column: 9
+5369:  AVMOpcode(AuxPop)		Line: 149, Column: 2
+5370:  AVMOpcode(Pop)		Line: 149, Column: 2
+5371:  AVMOpcode(AuxPop)		Line: 149, Column: 2
+5372:  AVMOpcode(Jump)		Line: 149, Column: 2
+5373:  AVMOpcode(AuxPush)		Line: 180, Column: 1
+5374:  [Tuple(_, _, _, _)] AVMOpcode(AuxPush)		Line: 180, Column: 1
+5375:  [0] AVMOpcode(Xset)		Line: 180, Column: 1
+5376:  [1] AVMOpcode(Xset)		Line: 180, Column: 1
+5377:  [2] AVMOpcode(Xset)		Line: 180, Column: 1
+5378:  [0] AVMOpcode(Xget)		Line: 185, Column: 15
+5379:  [0] AVMOpcode(Tget)		Line: 185, Column: 15
+5380:  [1] AVMOpcode(Xget)		Line: 185, Column: 6
+5381:  AVMOpcode(LessThan)		Line: 185, Column: 6
+5382:  [CodePoint(Internal(5384))] AVMOpcode(Cjump)		Line: 185, Column: 2
+5383:  AVMOpcode(Panic)		Line: 186, Column: 3
+5384:  [2] AVMOpcode(Xget)		Line: 188, Column: 51
+5385:  [1] AVMOpcode(Xget)		Line: 188, Column: 44
+5386:  [0] AVMOpcode(Xget)		Line: 188, Column: 33
+5387:  [1] AVMOpcode(Tget)		Line: 188, Column: 33
+5388:  [0] AVMOpcode(Xget)		Line: 188, Column: 21
+5389:  [2] AVMOpcode(Tget)		Line: 188, Column: 21
+5390:  [CodePoint(Internal(5392))] AVMOpcode(Noop)		Line: 188, Column: 12
+5391:  [CodePoint(Internal(5406))] AVMOpcode(Jump)		Line: 188, Column: 12
+5392:  [3] AVMOpcode(Xset)		Line: 188, Column: 2
+5393:  [3] AVMOpcode(Xget)		Line: 191, Column: 3
+5394:  [1] AVMOpcode(Tget)		Line: 191, Column: 3
+5395:  [3] AVMOpcode(Xget)		Line: 190, Column: 22
+5396:  [0] AVMOpcode(Tget)		Line: 190, Column: 22
+5397:  [0] AVMOpcode(Xget)		Line: 190, Column: 3
+5398:  [2] AVMOpcode(Tset)		Line: 190, Column: 3
+5399:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 189, Column: 9
+5400:  [0] AVMOpcode(Tset)		Line: 189, Column: 9
+5401:  [1] AVMOpcode(Tset)		Line: 189, Column: 9
+5402:  AVMOpcode(AuxPop)		Line: 189, Column: 2
+5403:  AVMOpcode(Pop)		Line: 189, Column: 2
+5404:  AVMOpcode(AuxPop)		Line: 189, Column: 2
+5405:  AVMOpcode(Jump)		Line: 189, Column: 2
+5406:  AVMOpcode(AuxPush)		Line: 203, Column: 1
+5407:  [Tuple(_, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 203, Column: 1
+5408:  [0] AVMOpcode(Xset)		Line: 203, Column: 1
+5409:  [1] AVMOpcode(Xset)		Line: 203, Column: 1
+5410:  [2] AVMOpcode(Xset)		Line: 203, Column: 1
+5411:  [3] AVMOpcode(Xset)		Line: 203, Column: 1
+5412:  [1] AVMOpcode(Xget)		Line: 204, Column: 11
+5413:  [1] AVMOpcode(Equal)		Line: 204, Column: 6
+5414:  AVMOpcode(IsZero)		Line: 204, Column: 2
+5415:  [CodePoint(Internal(5442))] AVMOpcode(Cjump)		Line: 204, Column: 2
+5416:  [0] AVMOpcode(Xget)		Line: 205, Column: 63
+5417:  [2] AVMOpcode(Xget)		Line: 205, Column: 65
+5418:  AVMOpcode(Tget)		Line: 205, Column: 63
+5419:  [3] AVMOpcode(Xget)		Line: 205, Column: 50
+5420:  [1] AVMOpcode(Tget)		Line: 205, Column: 50
+5421:  [CodePoint(Internal(5425))] AVMOpcode(Noop)		Line: 205, Column: 40
+5422:  [3] AVMOpcode(Xget)		Line: 205, Column: 40
+5423:  [0] AVMOpcode(Tget)		Line: 205, Column: 40
+5424:  AVMOpcode(Jump)		Line: 205, Column: 40
+5425:  AVMOpcode(Dup0)		Line: 205, Column: 3
+5426:  [0] AVMOpcode(Tget)		Line: 205, Column: 3
+5427:  [4] AVMOpcode(Xset)		Line: 205, Column: 3
+5428:  [1] AVMOpcode(Tget)		Line: 205, Column: 3
+5429:  [5] AVMOpcode(Xset)		Line: 205, Column: 3
+5430:  [5] AVMOpcode(Xget)		Line: 208, Column: 9
+5431:  [4] AVMOpcode(Xget)		Line: 207, Column: 29
+5432:  [0] AVMOpcode(Xget)		Line: 207, Column: 10
+5433:  [2] AVMOpcode(Xget)		Line: 207, Column: 20
+5434:  AVMOpcode(Tset)		Line: 207, Column: 10
+5435:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 206, Column: 10
+5436:  [0] AVMOpcode(Tset)		Line: 206, Column: 10
+5437:  [1] AVMOpcode(Tset)		Line: 206, Column: 10
+5438:  AVMOpcode(AuxPop)		Line: 206, Column: 3
+5439:  AVMOpcode(Pop)		Line: 206, Column: 3
+5440:  AVMOpcode(AuxPop)		Line: 206, Column: 3
+5441:  AVMOpcode(Jump)		Line: 206, Column: 3
+5442:  [1] AVMOpcode(Xget)		Line: 211, Column: 24
+5443:  [2] AVMOpcode(Xget)		Line: 211, Column: 18
+5444:  AVMOpcode(Div)		Line: 211, Column: 18
+5445:  [4] AVMOpcode(Xset)		Line: 211, Column: 3
+5446:  [3] AVMOpcode(Xget)		Line: 216, Column: 4
+5447:  [1] AVMOpcode(Xget)		Line: 215, Column: 10
+5448:  [2] AVMOpcode(Xget)		Line: 215, Column: 4
+5449:  AVMOpcode(Mod)		Line: 215, Column: 4
+5450:  [8] AVMOpcode(Noop)		Line: 214, Column: 10
+5451:  [1] AVMOpcode(Xget)		Line: 214, Column: 4
+5452:  AVMOpcode(Div)		Line: 214, Column: 4
+5453:  [0] AVMOpcode(Xget)		Line: 213, Column: 22
+5454:  [4] AVMOpcode(Xget)		Line: 213, Column: 24
+5455:  AVMOpcode(Tget)		Line: 213, Column: 22
+5456:  [CodePoint(Internal(5460))] AVMOpcode(PushStatic)		Line: 212, Column: 13
+5457:  [6] AVMOpcode(Tget)		Line: 212, Column: 13
+5458:  [7] AVMOpcode(Tget)		Line: 212, Column: 13
+5459:  AVMOpcode(Jump)		Line: 212, Column: 13
+5460:  [5] AVMOpcode(Xset)		Line: 212, Column: 3
+5461:  [5] AVMOpcode(Xget)		Line: 218, Column: 48
+5462:  [0] AVMOpcode(Tget)		Line: 218, Column: 48
+5463:  [0] AVMOpcode(Xget)		Line: 218, Column: 27
+5464:  [4] AVMOpcode(Xget)		Line: 218, Column: 36
+5465:  AVMOpcode(Tset)		Line: 218, Column: 27
+5466:  [5] AVMOpcode(Xget)		Line: 218, Column: 10
+5467:  [0] AVMOpcode(Tset)		Line: 218, Column: 10
+5468:  AVMOpcode(AuxPop)		Line: 218, Column: 3
+5469:  AVMOpcode(Pop)		Line: 218, Column: 3
+5470:  AVMOpcode(AuxPop)		Line: 218, Column: 3
+5471:  AVMOpcode(Jump)		Line: 218, Column: 3
+5472:  AVMOpcode(AuxPush)		Line: 195, Column: 1
+5473:  [Tuple(_, _, _, _, _)] AVMOpcode(AuxPush)		Line: 195, Column: 1
+5474:  [0] AVMOpcode(Xset)		Line: 195, Column: 1
+5475:  [1] AVMOpcode(Xset)		Line: 195, Column: 1
+5476:  [2] AVMOpcode(Xset)		Line: 195, Column: 1
+5477:  [0] AVMOpcode(Xget)		Line: 196, Column: 15
+5478:  [0] AVMOpcode(Tget)		Line: 196, Column: 15
+5479:  [1] AVMOpcode(Xget)		Line: 196, Column: 6
+5480:  AVMOpcode(LessThan)		Line: 196, Column: 6
+5481:  [CodePoint(Internal(5486))] AVMOpcode(Cjump)		Line: 196, Column: 2
+5482:  [Tuple(0)] AVMOpcode(AuxPop)		Line: 197, Column: 3
+5483:  AVMOpcode(Pop)		Line: 197, Column: 3
+5484:  AVMOpcode(AuxPop)		Line: 197, Column: 3
+5485:  AVMOpcode(Jump)		Line: 197, Column: 3
+5486:  [2] AVMOpcode(Xget)		Line: 199, Column: 49
+5487:  [1] AVMOpcode(Xget)		Line: 199, Column: 42
+5488:  [0] AVMOpcode(Xget)		Line: 199, Column: 39
+5489:  [CodePoint(Internal(5493))] AVMOpcode(PushStatic)		Line: 199, Column: 23
+5490:  [7] AVMOpcode(Tget)		Line: 199, Column: 23
+5491:  [0] AVMOpcode(Tget)		Line: 199, Column: 23
+5492:  AVMOpcode(Jump)		Line: 199, Column: 23
+5493:  AVMOpcode(Dup0)		Line: 199, Column: 2
+5494:  [0] AVMOpcode(Tget)		Line: 199, Column: 2
+5495:  [3] AVMOpcode(Xset)		Line: 199, Column: 2
+5496:  [1] AVMOpcode(Tget)		Line: 199, Column: 2
+5497:  [4] AVMOpcode(Xset)		Line: 199, Column: 2
+5498:  [4] AVMOpcode(Xget)		Line: 200, Column: 21
+5499:  [3] AVMOpcode(Xget)		Line: 200, Column: 15
+5500:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 200, Column: 14
+5501:  [0] AVMOpcode(Tset)		Line: 200, Column: 14
+5502:  [1] AVMOpcode(Tset)		Line: 200, Column: 14
+5503:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 200, Column: 9
+5504:  [1] AVMOpcode(Tset)		Line: 200, Column: 9
+5505:  AVMOpcode(AuxPop)		Line: 200, Column: 2
+5506:  AVMOpcode(Pop)		Line: 200, Column: 2
+5507:  AVMOpcode(AuxPop)		Line: 200, Column: 2
+5508:  AVMOpcode(Jump)		Line: 200, Column: 2
+5509:  AVMOpcode(AuxPush)		Line: 222, Column: 1
+5510:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 222, Column: 1
+5511:  [0] AVMOpcode(Xset)		Line: 222, Column: 1
+5512:  [1] AVMOpcode(Xset)		Line: 222, Column: 1
+5513:  [2] AVMOpcode(Xset)		Line: 222, Column: 1
+5514:  [3] AVMOpcode(Xset)		Line: 222, Column: 1
+5515:  [2] AVMOpcode(Xget)		Line: 232, Column: 48
+5516:  [1] AVMOpcode(Xget)		Line: 232, Column: 41
+5517:  [0] AVMOpcode(Xget)		Line: 232, Column: 38
+5518:  [CodePoint(Internal(5522))] AVMOpcode(PushStatic)		Line: 232, Column: 22
+5519:  [7] AVMOpcode(Tget)		Line: 232, Column: 22
+5520:  [0] AVMOpcode(Tget)		Line: 232, Column: 22
+5521:  AVMOpcode(Jump)		Line: 232, Column: 22
+5522:  AVMOpcode(Dup0)		Line: 232, Column: 2
+5523:  [0] AVMOpcode(Tget)		Line: 232, Column: 2
+5524:  [4] AVMOpcode(Xset)		Line: 232, Column: 2
+5525:  [1] AVMOpcode(Tget)		Line: 232, Column: 2
+5526:  [5] AVMOpcode(Xset)		Line: 232, Column: 2
+5527:  [3] AVMOpcode(Xget)		Line: 233, Column: 53
+5528:  [1] AVMOpcode(Xget)		Line: 233, Column: 44
+5529:  [1] AVMOpcode(Plus)		Line: 233, Column: 44
+5530:  [4] AVMOpcode(Xget)		Line: 233, Column: 38
+5531:  [CodePoint(Internal(5535))] AVMOpcode(PushStatic)		Line: 233, Column: 22
+5532:  [7] AVMOpcode(Tget)		Line: 233, Column: 22
+5533:  [0] AVMOpcode(Tget)		Line: 233, Column: 22
+5534:  AVMOpcode(Jump)		Line: 233, Column: 22
+5535:  AVMOpcode(Dup0)		Line: 233, Column: 2
+5536:  [0] AVMOpcode(Tget)		Line: 233, Column: 2
+5537:  [6] AVMOpcode(Xset)		Line: 233, Column: 2
+5538:  [1] AVMOpcode(Tget)		Line: 233, Column: 2
+5539:  [7] AVMOpcode(Xset)		Line: 233, Column: 2
+5540:  [7] AVMOpcode(Xget)		Line: 234, Column: 22
+5541:  [5] AVMOpcode(Xget)		Line: 234, Column: 16
+5542:  [6] AVMOpcode(Xget)		Line: 234, Column: 10
+5543:  [Tuple(_, _, _)] AVMOpcode(Noop)		Line: 234, Column: 9
+5544:  [0] AVMOpcode(Tset)		Line: 234, Column: 9
+5545:  [1] AVMOpcode(Tset)		Line: 234, Column: 9
+5546:  [2] AVMOpcode(Tset)		Line: 234, Column: 9
+5547:  AVMOpcode(AuxPop)		Line: 234, Column: 2
+5548:  AVMOpcode(Pop)		Line: 234, Column: 2
+5549:  AVMOpcode(AuxPop)		Line: 234, Column: 2
+5550:  AVMOpcode(Jump)		Line: 234, Column: 2
+5551:  AVMOpcode(AuxPush)		Line: 237, Column: 1
+5552:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 237, Column: 1
+5553:  [0] AVMOpcode(Xset)		Line: 237, Column: 1
+5554:  [1] AVMOpcode(Xset)		Line: 237, Column: 1
+5555:  [2] AVMOpcode(Xset)		Line: 237, Column: 1
+5556:  [3] AVMOpcode(Xset)		Line: 237, Column: 1
+5557:  [2] AVMOpcode(Xget)		Line: 243, Column: 51
+5558:  [1] AVMOpcode(Xget)		Line: 243, Column: 44
+5559:  [0] AVMOpcode(Xget)		Line: 243, Column: 41
+5560:  [CodePoint(Internal(5564))] AVMOpcode(PushStatic)		Line: 243, Column: 21
+5561:  [7] AVMOpcode(Tget)		Line: 243, Column: 21
+5562:  [1] AVMOpcode(Tget)		Line: 243, Column: 21
+5563:  AVMOpcode(Jump)		Line: 243, Column: 21
+5564:  AVMOpcode(Dup0)		Line: 243, Column: 21
+5565:  [0] AVMOpcode(Tget)		Line: 243, Column: 21
+5566:  [CodePoint(Internal(5571))] AVMOpcode(Cjump)		Line: 243, Column: 21
+5567:  AVMOpcode(AuxPop)		Line: 243, Column: 21
+5568:  AVMOpcode(Pop)		Line: 243, Column: 21
+5569:  AVMOpcode(AuxPop)		Line: 243, Column: 21
+5570:  AVMOpcode(Jump)		Line: 243, Column: 21
+5571:  [1] AVMOpcode(Tget)		Line: 243, Column: 21
+5572:  AVMOpcode(Dup0)		Line: 243, Column: 2
+5573:  [0] AVMOpcode(Tget)		Line: 243, Column: 2
+5574:  [4] AVMOpcode(Xset)		Line: 243, Column: 2
+5575:  [1] AVMOpcode(Tget)		Line: 243, Column: 2
+5576:  [5] AVMOpcode(Xset)		Line: 243, Column: 2
+5577:  [3] AVMOpcode(Xget)		Line: 244, Column: 56
+5578:  [1] AVMOpcode(Xget)		Line: 244, Column: 47
+5579:  [1] AVMOpcode(Plus)		Line: 244, Column: 47
+5580:  [4] AVMOpcode(Xget)		Line: 244, Column: 41
+5581:  [CodePoint(Internal(5585))] AVMOpcode(PushStatic)		Line: 244, Column: 21
+5582:  [7] AVMOpcode(Tget)		Line: 244, Column: 21
+5583:  [1] AVMOpcode(Tget)		Line: 244, Column: 21
+5584:  AVMOpcode(Jump)		Line: 244, Column: 21
+5585:  AVMOpcode(Dup0)		Line: 244, Column: 21
+5586:  [0] AVMOpcode(Tget)		Line: 244, Column: 21
+5587:  [CodePoint(Internal(5592))] AVMOpcode(Cjump)		Line: 244, Column: 21
+5588:  AVMOpcode(AuxPop)		Line: 244, Column: 21
+5589:  AVMOpcode(Pop)		Line: 244, Column: 21
+5590:  AVMOpcode(AuxPop)		Line: 244, Column: 21
+5591:  AVMOpcode(Jump)		Line: 244, Column: 21
+5592:  [1] AVMOpcode(Tget)		Line: 244, Column: 21
+5593:  AVMOpcode(Dup0)		Line: 244, Column: 2
+5594:  [0] AVMOpcode(Tget)		Line: 244, Column: 2
+5595:  [6] AVMOpcode(Xset)		Line: 244, Column: 2
+5596:  [1] AVMOpcode(Tget)		Line: 244, Column: 2
+5597:  [7] AVMOpcode(Xset)		Line: 244, Column: 2
+5598:  [7] AVMOpcode(Xget)		Line: 245, Column: 27
+5599:  [5] AVMOpcode(Xget)		Line: 245, Column: 21
+5600:  [6] AVMOpcode(Xget)		Line: 245, Column: 15
+5601:  [Tuple(_, _, _)] AVMOpcode(Noop)		Line: 245, Column: 14
+5602:  [0] AVMOpcode(Tset)		Line: 245, Column: 14
+5603:  [1] AVMOpcode(Tset)		Line: 245, Column: 14
+5604:  [2] AVMOpcode(Tset)		Line: 245, Column: 14
+5605:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 245, Column: 9
+5606:  [1] AVMOpcode(Tset)		Line: 245, Column: 9
+5607:  AVMOpcode(AuxPop)		Line: 245, Column: 2
+5608:  AVMOpcode(Pop)		Line: 245, Column: 2
+5609:  AVMOpcode(AuxPop)		Line: 245, Column: 2
+5610:  AVMOpcode(Jump)		Line: 245, Column: 2
+5611:  AVMOpcode(AuxPush)		Line: 248, Column: 1
+5612:  [Tuple(_, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 248, Column: 1
+5613:  [0] AVMOpcode(Xset)		Line: 248, Column: 1
+5614:  [1] AVMOpcode(Xset)		Line: 248, Column: 1
+5615:  [2] AVMOpcode(Xset)		Line: 248, Column: 1
+5616:  [0] AVMOpcode(Xget)		Line: 254, Column: 16
+5617:  [0] AVMOpcode(Tget)		Line: 254, Column: 16
+5618:  [3] AVMOpcode(Xset)		Line: 254, Column: 2
+5619:  [1] AVMOpcode(Xget)		Line: 255, Column: 16
+5620:  [3] AVMOpcode(Xget)		Line: 255, Column: 6
+5621:  AVMOpcode(GreaterThan)		Line: 255, Column: 6
+5622:  AVMOpcode(IsZero)		Line: 255, Column: 2
+5623:  [CodePoint(Internal(5627))] AVMOpcode(Cjump)		Line: 255, Column: 2
+5624:  [1] AVMOpcode(Xget)		Line: 256, Column: 13
+5625:  [3] AVMOpcode(Xset)		Line: 256, Column: 3
+5626:  [CodePoint(Internal(5627))] AVMOpcode(Jump)		Line: 255, Column: 2
+5627:  [2] AVMOpcode(Xget)		Line: 258, Column: 38
+5628:  [1] AVMOpcode(Xget)		Line: 258, Column: 29
+5629:  [CodePoint(Internal(5633))] AVMOpcode(PushStatic)		Line: 258, Column: 12
+5630:  [7] AVMOpcode(Tget)		Line: 258, Column: 12
+5631:  [2] AVMOpcode(Tget)		Line: 258, Column: 12
+5632:  AVMOpcode(Jump)		Line: 258, Column: 12
+5633:  [4] AVMOpcode(Xset)		Line: 258, Column: 2
+5634:  [0] AVMOpcode(Noop)		Line: 259, Column: 10
+5635:  [5] AVMOpcode(Xset)		Line: 259, Column: 2
+5636:  [CodePoint(Internal(5639))] AVMOpcode(Noop)		Line: 260, Column: 2
+5637:  [6] AVMOpcode(Xset)		Line: 260, Column: 2
+5638:  [CodePoint(Internal(5655))] AVMOpcode(Jump)		Line: 260, Column: 2
+5639:  [5] AVMOpcode(Xget)		Line: 261, Column: 54
+5640:  [0] AVMOpcode(Xget)		Line: 261, Column: 51
+5641:  [CodePoint(Internal(5645))] AVMOpcode(PushStatic)		Line: 261, Column: 34
+5642:  [6] AVMOpcode(Tget)		Line: 261, Column: 34
+5643:  [1] AVMOpcode(Tget)		Line: 261, Column: 34
+5644:  AVMOpcode(Jump)		Line: 261, Column: 34
+5645:  [5] AVMOpcode(Xget)		Line: 261, Column: 31
+5646:  [4] AVMOpcode(Xget)		Line: 261, Column: 26
+5647:  [CodePoint(Internal(5651))] AVMOpcode(PushStatic)		Line: 261, Column: 9
+5648:  [6] AVMOpcode(Tget)		Line: 261, Column: 9
+5649:  [4] AVMOpcode(Tget)		Line: 261, Column: 9
+5650:  AVMOpcode(Jump)		Line: 261, Column: 9
+5651:  [4] AVMOpcode(Xset)		Line: 261, Column: 3
+5652:  [5] AVMOpcode(Xget)		Line: 262, Column: 7
+5653:  [1] AVMOpcode(Plus)		Line: 262, Column: 7
+5654:  [5] AVMOpcode(Xset)		Line: 262, Column: 3
+5655:  [3] AVMOpcode(Xget)		Line: 260, Column: 13
+5656:  [5] AVMOpcode(Xget)		Line: 260, Column: 9
+5657:  AVMOpcode(LessThan)		Line: 260, Column: 9
+5658:  [6] AVMOpcode(Xget)		Line: 260, Column: 2
+5659:  AVMOpcode(Cjump)		Line: 260, Column: 2
+5660:  [4] AVMOpcode(Xget)		Line: 264, Column: 9
+5661:  AVMOpcode(AuxPop)		Line: 264, Column: 2
+5662:  AVMOpcode(Pop)		Line: 264, Column: 2
+5663:  AVMOpcode(AuxPop)		Line: 264, Column: 2
+5664:  AVMOpcode(Jump)		Line: 264, Column: 2
+5665:  AVMOpcode(AuxPush)		Line: 43, Column: 1
+5666:  [_] AVMOpcode(AuxPush)		Line: 43, Column: 1
+5667:  [Tuple(0)] AVMOpcode(AuxPop)		Line: 44, Column: 5
+5668:  AVMOpcode(Pop)		Line: 44, Column: 5
+5669:  AVMOpcode(AuxPop)		Line: 44, Column: 5
+5670:  AVMOpcode(Jump)		Line: 44, Column: 5
+5671:  AVMOpcode(AuxPush)		Line: 47, Column: 1
+5672:  [Tuple(_, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 47, Column: 1
+5673:  [0] AVMOpcode(Xset)		Line: 47, Column: 1
+5674:  [1] AVMOpcode(Xset)		Line: 47, Column: 1
+5675:  [1] AVMOpcode(Xget)		Line: 48, Column: 32
+5676:  AVMOpcode(Hash)		Line: 48, Column: 27
+5677:  [2] AVMOpcode(Xset)		Line: 48, Column: 5
+5678:  [CodePoint(Internal(5680))] AVMOpcode(Noop)		Line: 49, Column: 5
+5679:  [3] AVMOpcode(Xset)		Line: 49, Column: 5
+5680:  [0] AVMOpcode(Xget)		Line: 50, Column: 20
+5681:  AVMOpcode(Dup0)		Line: 50, Column: 20
+5682:  [0] AVMOpcode(Tget)		Line: 50, Column: 20
+5683:  [CodePoint(Internal(5688))] AVMOpcode(Cjump)		Line: 50, Column: 20
+5684:  AVMOpcode(AuxPop)		Line: 50, Column: 20
+5685:  AVMOpcode(Pop)		Line: 50, Column: 20
+5686:  AVMOpcode(AuxPop)		Line: 50, Column: 20
+5687:  AVMOpcode(Jump)		Line: 50, Column: 20
+5688:  [1] AVMOpcode(Tget)		Line: 50, Column: 20
+5689:  [4] AVMOpcode(Xset)		Line: 50, Column: 9
+5690:  [4] AVMOpcode(Xget)		Line: 51, Column: 31
+5691:  [0] AVMOpcode(Tget)		Line: 51, Column: 31
+5692:  AVMOpcode(Dup0)		Line: 51, Column: 9
+5693:  [0] AVMOpcode(Tget)		Line: 51, Column: 9
+5694:  AVMOpcode(IsZero)		Line: 51, Column: 9
+5695:  [CodePoint(Internal(5713))] AVMOpcode(Cjump)		Line: 51, Column: 9
+5696:  [1] AVMOpcode(Tget)		Line: 51, Column: 9
+5697:  [5] AVMOpcode(Xset)		Line: 51, Column: 9
+5698:  [5] AVMOpcode(Xget)		Line: 52, Column: 31
+5699:  [0] AVMOpcode(Tget)		Line: 52, Column: 31
+5700:  [2] AVMOpcode(Xget)		Line: 52, Column: 17
+5701:  AVMOpcode(Equal)		Line: 52, Column: 17
+5702:  AVMOpcode(IsZero)		Line: 52, Column: 13
+5703:  [CodePoint(Internal(5712))] AVMOpcode(Cjump)		Line: 52, Column: 13
+5704:  [5] AVMOpcode(Xget)		Line: 53, Column: 29
+5705:  [2] AVMOpcode(Tget)		Line: 53, Column: 29
+5706:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 53, Column: 24
+5707:  [1] AVMOpcode(Tset)		Line: 53, Column: 24
+5708:  AVMOpcode(AuxPop)		Line: 53, Column: 17
+5709:  AVMOpcode(Pop)		Line: 53, Column: 17
+5710:  AVMOpcode(AuxPop)		Line: 53, Column: 17
+5711:  AVMOpcode(Jump)		Line: 53, Column: 17
+5712:  [CodePoint(Internal(5714))] AVMOpcode(Jump)		Line: 51, Column: 9
+5713:  AVMOpcode(Pop)		Line: 51, Column: 9
+5714:  [4] AVMOpcode(Xget)		Line: 56, Column: 35
+5715:  [1] AVMOpcode(Tget)		Line: 56, Column: 35
+5716:  [8] AVMOpcode(Noop)		Line: 56, Column: 62
+5717:  [2] AVMOpcode(Xget)		Line: 56, Column: 49
+5718:  AVMOpcode(Mod)		Line: 56, Column: 49
+5719:  AVMOpcode(Tget)		Line: 56, Column: 35
+5720:  [0] AVMOpcode(Xset)		Line: 56, Column: 9
+5721:  [8] AVMOpcode(Noop)		Line: 57, Column: 35
+5722:  [2] AVMOpcode(Xget)		Line: 57, Column: 22
+5723:  AVMOpcode(Div)		Line: 57, Column: 22
+5724:  [2] AVMOpcode(Xset)		Line: 57, Column: 9
+5725:  [3] AVMOpcode(Xget)		Line: 49, Column: 5
+5726:  AVMOpcode(Jump)		Line: 49, Column: 5
+5727:  AVMOpcode(AuxPush)		Line: 61, Column: 1
+5728:  [Tuple(_, _)] AVMOpcode(AuxPush)		Line: 61, Column: 1
+5729:  [0] AVMOpcode(Xset)		Line: 61, Column: 1
+5730:  [1] AVMOpcode(Xset)		Line: 61, Column: 1
+5731:  [Tuple(0)] AVMOpcode(Noop)		Line: 62, Column: 40
+5732:  [1] AVMOpcode(Xget)		Line: 62, Column: 32
+5733:  [0] AVMOpcode(Xget)		Line: 62, Column: 27
+5734:  [CodePoint(Internal(5738))] AVMOpcode(PushStatic)		Line: 62, Column: 12
+5735:  [7] AVMOpcode(Tget)		Line: 62, Column: 12
+5736:  [3] AVMOpcode(Tget)		Line: 62, Column: 12
+5737:  AVMOpcode(Jump)		Line: 62, Column: 12
+5738:  AVMOpcode(Equal)		Line: 62, Column: 12
+5739:  AVMOpcode(IsZero)		Line: 62, Column: 12
+5740:  AVMOpcode(AuxPop)		Line: 62, Column: 5
+5741:  AVMOpcode(Pop)		Line: 62, Column: 5
+5742:  AVMOpcode(AuxPop)		Line: 62, Column: 5
+5743:  AVMOpcode(Jump)		Line: 62, Column: 5
+5744:  AVMOpcode(AuxPush)		Line: 65, Column: 1
+5745:  [Tuple(_, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 65, Column: 1
+5746:  [0] AVMOpcode(Xset)		Line: 65, Column: 1
+5747:  [1] AVMOpcode(Xset)		Line: 65, Column: 1
+5748:  [2] AVMOpcode(Xset)		Line: 65, Column: 1
+5749:  [2] AVMOpcode(Xget)		Line: 70, Column: 9
+5750:  [1] AVMOpcode(Xget)		Line: 69, Column: 9
+5751:  [1] AVMOpcode(Xget)		Line: 68, Column: 19
+5752:  AVMOpcode(Hash)		Line: 68, Column: 14
+5753:  [0] AVMOpcode(Xget)		Line: 67, Column: 9
+5754:  [CodePoint(Internal(5756))] AVMOpcode(Noop)		Line: 66, Column: 24
+5755:  [CodePoint(Internal(5780))] AVMOpcode(Jump)		Line: 66, Column: 24
+5756:  AVMOpcode(Dup0)		Line: 66, Column: 5
+5757:  [0] AVMOpcode(Tget)		Line: 66, Column: 5
+5758:  AVMOpcode(IsZero)		Line: 66, Column: 5
+5759:  [CodePoint(Internal(5774))] AVMOpcode(Cjump)		Line: 66, Column: 5
+5760:  [1] AVMOpcode(Tget)		Line: 66, Column: 5
+5761:  [3] AVMOpcode(Xset)		Line: 66, Column: 5
+5762:  [3] AVMOpcode(Xget)		Line: 72, Column: 27
+5763:  AVMOpcode(Dup0)		Line: 72, Column: 9
+5764:  [0] AVMOpcode(Tget)		Line: 72, Column: 9
+5765:  [4] AVMOpcode(Xset)		Line: 72, Column: 9
+5766:  [1] AVMOpcode(Tget)		Line: 72, Column: 9
+5767:  [5] AVMOpcode(Xset)		Line: 72, Column: 9
+5768:  [4] AVMOpcode(Xget)		Line: 73, Column: 16
+5769:  AVMOpcode(AuxPop)		Line: 73, Column: 9
+5770:  AVMOpcode(Pop)		Line: 73, Column: 9
+5771:  AVMOpcode(AuxPop)		Line: 73, Column: 9
+5772:  AVMOpcode(Jump)		Line: 73, Column: 9
+5773:  [CodePoint(Internal(5780))] AVMOpcode(Jump)		Line: 66, Column: 5
+5774:  AVMOpcode(Pop)		Line: 66, Column: 5
+5775:  [0] AVMOpcode(Xget)		Line: 75, Column: 16
+5776:  AVMOpcode(AuxPop)		Line: 75, Column: 9
+5777:  AVMOpcode(Pop)		Line: 75, Column: 9
+5778:  AVMOpcode(AuxPop)		Line: 75, Column: 9
+5779:  AVMOpcode(Jump)		Line: 75, Column: 9
+5780:  AVMOpcode(AuxPush)		Line: 79, Column: 1
+5781:  [Tuple(_, _, _, _, _, _, _, Tuple(_, _, _))] AVMOpcode(AuxPush)		Line: 79, Column: 1
+5782:  [0] AVMOpcode(Xset)		Line: 79, Column: 1
+5783:  [1] AVMOpcode(Xset)		Line: 79, Column: 1
+5784:  [2] AVMOpcode(Xset)		Line: 79, Column: 1
+5785:  [3] AVMOpcode(Xset)		Line: 79, Column: 1
+5786:  [0] AVMOpcode(Xget)		Line: 87, Column: 25
+5787:  AVMOpcode(Dup0)		Line: 87, Column: 5
+5788:  [0] AVMOpcode(Tget)		Line: 87, Column: 5
+5789:  AVMOpcode(IsZero)		Line: 87, Column: 5
+5790:  [CodePoint(Internal(5973))] AVMOpcode(Cjump)		Line: 87, Column: 5
+5791:  [1] AVMOpcode(Tget)		Line: 87, Column: 5
+5792:  [4] AVMOpcode(Xset)		Line: 87, Column: 5
+5793:  [4] AVMOpcode(Xget)		Line: 88, Column: 31
+5794:  [0] AVMOpcode(Tget)		Line: 88, Column: 31
+5795:  AVMOpcode(Dup0)		Line: 88, Column: 9
+5796:  [0] AVMOpcode(Tget)		Line: 88, Column: 9
+5797:  AVMOpcode(IsZero)		Line: 88, Column: 9
+5798:  [CodePoint(Internal(5893))] AVMOpcode(Cjump)		Line: 88, Column: 9
+5799:  [1] AVMOpcode(Tget)		Line: 88, Column: 9
+5800:  [5] AVMOpcode(Xset)		Line: 88, Column: 9
+5801:  [1] AVMOpcode(Xget)		Line: 89, Column: 38
+5802:  [5] AVMOpcode(Xget)		Line: 89, Column: 17
+5803:  [0] AVMOpcode(Tget)		Line: 89, Column: 17
+5804:  AVMOpcode(Equal)		Line: 89, Column: 17
+5805:  AVMOpcode(IsZero)		Line: 89, Column: 13
+5806:  [CodePoint(Internal(5826))] AVMOpcode(Cjump)		Line: 89, Column: 13
+5807:  [0] AVMOpcode(Noop)		Line: 95, Column: 20
+5808:  [3] AVMOpcode(Xget)		Line: 93, Column: 59
+5809:  [5] AVMOpcode(Xget)		Line: 93, Column: 38
+5810:  [2] AVMOpcode(Tset)		Line: 93, Column: 38
+5811:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 93, Column: 33
+5812:  [1] AVMOpcode(Tset)		Line: 93, Column: 33
+5813:  [4] AVMOpcode(Xget)		Line: 92, Column: 21
+5814:  [0] AVMOpcode(Tset)		Line: 92, Column: 21
+5815:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 91, Column: 30
+5816:  [1] AVMOpcode(Tset)		Line: 91, Column: 30
+5817:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 91, Column: 29
+5818:  [0] AVMOpcode(Tset)		Line: 91, Column: 29
+5819:  [1] AVMOpcode(Tset)		Line: 91, Column: 29
+5820:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 91, Column: 24
+5821:  [1] AVMOpcode(Tset)		Line: 91, Column: 24
+5822:  AVMOpcode(AuxPop)		Line: 91, Column: 17
+5823:  AVMOpcode(Pop)		Line: 91, Column: 17
+5824:  AVMOpcode(AuxPop)		Line: 91, Column: 17
+5825:  AVMOpcode(Jump)		Line: 91, Column: 17
+5826:  [8] AVMOpcode(Noop)		Line: 98, Column: 41
+5827:  [1] AVMOpcode(Xget)		Line: 98, Column: 28
+5828:  AVMOpcode(Mod)		Line: 98, Column: 28
+5829:  [6] AVMOpcode(Xset)		Line: 98, Column: 17
+5830:  [4] AVMOpcode(Xget)		Line: 99, Column: 50
+5831:  [1] AVMOpcode(Tget)		Line: 99, Column: 50
+5832:  [6] AVMOpcode(Xget)		Line: 99, Column: 64
+5833:  AVMOpcode(Tget)		Line: 99, Column: 50
+5834:  [7] AVMOpcode(Xget)		Line: 99, Column: 17
+5835:  [0] AVMOpcode(Tset)		Line: 99, Column: 17
+5836:  [7] AVMOpcode(Xset)		Line: 99, Column: 17
+5837:  [3] AVMOpcode(Xget)		Line: 104, Column: 21
+5838:  [2] AVMOpcode(Xget)		Line: 103, Column: 21
+5839:  [8] AVMOpcode(Noop)		Line: 102, Column: 34
+5840:  [1] AVMOpcode(Xget)		Line: 102, Column: 21
+5841:  AVMOpcode(Div)		Line: 102, Column: 21
+5842:  [7] AVMOpcode(Xget)		Line: 101, Column: 21
+5843:  [0] AVMOpcode(Tget)		Line: 101, Column: 21
+5844:  [CodePoint(Internal(5848))] AVMOpcode(PushStatic)		Line: 100, Column: 42
+5845:  [7] AVMOpcode(Tget)		Line: 100, Column: 42
+5846:  [4] AVMOpcode(Tget)		Line: 100, Column: 42
+5847:  AVMOpcode(Jump)		Line: 100, Column: 42
+5848:  AVMOpcode(Dup0)		Line: 100, Column: 42
+5849:  [0] AVMOpcode(Tget)		Line: 100, Column: 42
+5850:  [CodePoint(Internal(5855))] AVMOpcode(Cjump)		Line: 100, Column: 42
+5851:  AVMOpcode(AuxPop)		Line: 100, Column: 42
+5852:  AVMOpcode(Pop)		Line: 100, Column: 42
+5853:  AVMOpcode(AuxPop)		Line: 100, Column: 42
+5854:  AVMOpcode(Jump)		Line: 100, Column: 42
+5855:  [1] AVMOpcode(Tget)		Line: 100, Column: 42
+5856:  AVMOpcode(Dup0)		Line: 100, Column: 17
+5857:  [0] AVMOpcode(Tget)		Line: 100, Column: 17
+5858:  [7] AVMOpcode(Xget)		Line: 100, Column: 17
+5859:  [1] AVMOpcode(Tset)		Line: 100, Column: 17
+5860:  [7] AVMOpcode(Xset)		Line: 100, Column: 17
+5861:  [1] AVMOpcode(Tget)		Line: 100, Column: 17
+5862:  [7] AVMOpcode(Xget)		Line: 100, Column: 17
+5863:  [2] AVMOpcode(Tset)		Line: 100, Column: 17
+5864:  [7] AVMOpcode(Xset)		Line: 100, Column: 17
+5865:  [7] AVMOpcode(Xget)		Line: 114, Column: 20
+5866:  [2] AVMOpcode(Tget)		Line: 114, Column: 20
+5867:  [7] AVMOpcode(Xget)		Line: 112, Column: 53
+5868:  [2] AVMOpcode(Tget)		Line: 112, Column: 53
+5869:  [4] AVMOpcode(Xget)		Line: 112, Column: 40
+5870:  [2] AVMOpcode(Tget)		Line: 112, Column: 40
+5871:  AVMOpcode(Plus)		Line: 112, Column: 36
+5872:  [7] AVMOpcode(Xget)		Line: 109, Column: 38
+5873:  [1] AVMOpcode(Tget)		Line: 109, Column: 38
+5874:  [4] AVMOpcode(Xget)		Line: 108, Column: 35
+5875:  [1] AVMOpcode(Tget)		Line: 108, Column: 35
+5876:  [6] AVMOpcode(Xget)		Line: 109, Column: 30
+5877:  AVMOpcode(Tset)		Line: 108, Column: 35
+5878:  [4] AVMOpcode(Xget)		Line: 107, Column: 21
+5879:  [1] AVMOpcode(Tset)		Line: 107, Column: 21
+5880:  [2] AVMOpcode(Tset)		Line: 107, Column: 21
+5881:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 106, Column: 30
+5882:  [1] AVMOpcode(Tset)		Line: 106, Column: 30
+5883:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 106, Column: 29
+5884:  [0] AVMOpcode(Tset)		Line: 106, Column: 29
+5885:  [1] AVMOpcode(Tset)		Line: 106, Column: 29
+5886:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 106, Column: 24
+5887:  [1] AVMOpcode(Tset)		Line: 106, Column: 24
+5888:  AVMOpcode(AuxPop)		Line: 106, Column: 17
+5889:  AVMOpcode(Pop)		Line: 106, Column: 17
+5890:  AVMOpcode(AuxPop)		Line: 106, Column: 17
+5891:  AVMOpcode(Jump)		Line: 106, Column: 17
+5892:  [CodePoint(Internal(5972))] AVMOpcode(Jump)		Line: 88, Column: 9
+5893:  AVMOpcode(Pop)		Line: 88, Column: 9
+5894:  [8] AVMOpcode(Noop)		Line: 122, Column: 37
+5895:  [1] AVMOpcode(Xget)		Line: 122, Column: 24
+5896:  AVMOpcode(Mod)		Line: 122, Column: 24
+5897:  [5] AVMOpcode(Xset)		Line: 122, Column: 13
+5898:  [1] AVMOpcode(Noop)		Line: 123, Column: 28
+5899:  [6] AVMOpcode(Xset)		Line: 123, Column: 13
+5900:  [8] AVMOpcode(Noop)		Line: 126, Column: 30
+5901:  [1] AVMOpcode(Xget)		Line: 126, Column: 17
+5902:  AVMOpcode(Div)		Line: 126, Column: 17
+5903:  [4] AVMOpcode(Xget)		Line: 125, Column: 37
+5904:  [1] AVMOpcode(Tget)		Line: 125, Column: 37
+5905:  [5] AVMOpcode(Xget)		Line: 125, Column: 51
+5906:  AVMOpcode(Tget)		Line: 125, Column: 37
+5907:  [CodePoint(Internal(5909))] AVMOpcode(Noop)		Line: 124, Column: 32
+5908:  [CodePoint(Internal(6016))] AVMOpcode(Jump)		Line: 124, Column: 32
+5909:  AVMOpcode(Dup0)		Line: 124, Column: 13
+5910:  [0] AVMOpcode(Tget)		Line: 124, Column: 13
+5911:  AVMOpcode(IsZero)		Line: 124, Column: 13
+5912:  [CodePoint(Internal(5943))] AVMOpcode(Cjump)		Line: 124, Column: 13
+5913:  [1] AVMOpcode(Tget)		Line: 124, Column: 13
+5914:  [7] AVMOpcode(Xget)		Line: 124, Column: 13
+5915:  [0] AVMOpcode(Tset)		Line: 124, Column: 13
+5916:  [7] AVMOpcode(Xset)		Line: 124, Column: 13
+5917:  [7] AVMOpcode(Xget)		Line: 128, Column: 47
+5918:  [0] AVMOpcode(Tget)		Line: 128, Column: 47
+5919:  AVMOpcode(Dup0)		Line: 128, Column: 17
+5920:  [0] AVMOpcode(Tget)		Line: 128, Column: 17
+5921:  [7] AVMOpcode(Xget)		Line: 128, Column: 17
+5922:  [1] AVMOpcode(Tset)		Line: 128, Column: 17
+5923:  [7] AVMOpcode(Xset)		Line: 128, Column: 17
+5924:  [1] AVMOpcode(Tget)		Line: 128, Column: 17
+5925:  [7] AVMOpcode(Xget)		Line: 128, Column: 17
+5926:  [2] AVMOpcode(Tset)		Line: 128, Column: 17
+5927:  [7] AVMOpcode(Xset)		Line: 128, Column: 17
+5928:  [7] AVMOpcode(Xget)		Line: 129, Column: 39
+5929:  [2] AVMOpcode(Tget)		Line: 129, Column: 39
+5930:  [6] AVMOpcode(Xget)		Line: 129, Column: 28
+5931:  AVMOpcode(Plus)		Line: 129, Column: 28
+5932:  [6] AVMOpcode(Xset)		Line: 129, Column: 17
+5933:  [7] AVMOpcode(Xget)		Line: 132, Column: 34
+5934:  [1] AVMOpcode(Tget)		Line: 132, Column: 34
+5935:  [4] AVMOpcode(Xget)		Line: 131, Column: 31
+5936:  [1] AVMOpcode(Tget)		Line: 131, Column: 31
+5937:  [5] AVMOpcode(Xget)		Line: 132, Column: 26
+5938:  AVMOpcode(Tset)		Line: 131, Column: 31
+5939:  [4] AVMOpcode(Xget)		Line: 130, Column: 24
+5940:  [1] AVMOpcode(Tset)		Line: 130, Column: 24
+5941:  [4] AVMOpcode(Xset)		Line: 130, Column: 17
+5942:  [CodePoint(Internal(5944))] AVMOpcode(Jump)		Line: 124, Column: 13
+5943:  AVMOpcode(Pop)		Line: 124, Column: 13
+5944:  [6] AVMOpcode(Xget)		Line: 148, Column: 16
+5945:  [6] AVMOpcode(Xget)		Line: 146, Column: 49
+5946:  [4] AVMOpcode(Xget)		Line: 146, Column: 36
+5947:  [2] AVMOpcode(Tget)		Line: 146, Column: 36
+5948:  AVMOpcode(Plus)		Line: 146, Column: 32
+5949:  [3] AVMOpcode(Xget)		Line: 143, Column: 32
+5950:  [2] AVMOpcode(Xget)		Line: 142, Column: 30
+5951:  [1] AVMOpcode(Xget)		Line: 141, Column: 37
+5952:  [Tuple(_, _, _)] AVMOpcode(Noop)		Line: 140, Column: 34
+5953:  [0] AVMOpcode(Tset)		Line: 140, Column: 34
+5954:  [1] AVMOpcode(Tset)		Line: 140, Column: 34
+5955:  [2] AVMOpcode(Tset)		Line: 140, Column: 34
+5956:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 140, Column: 29
+5957:  [1] AVMOpcode(Tset)		Line: 140, Column: 29
+5958:  [4] AVMOpcode(Xget)		Line: 139, Column: 17
+5959:  [0] AVMOpcode(Tset)		Line: 139, Column: 17
+5960:  [2] AVMOpcode(Tset)		Line: 139, Column: 17
+5961:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 138, Column: 26
+5962:  [1] AVMOpcode(Tset)		Line: 138, Column: 26
+5963:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 138, Column: 25
+5964:  [0] AVMOpcode(Tset)		Line: 138, Column: 25
+5965:  [1] AVMOpcode(Tset)		Line: 138, Column: 25
+5966:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 138, Column: 20
+5967:  [1] AVMOpcode(Tset)		Line: 138, Column: 20
+5968:  AVMOpcode(AuxPop)		Line: 138, Column: 13
+5969:  AVMOpcode(Pop)		Line: 138, Column: 13
+5970:  AVMOpcode(AuxPop)		Line: 138, Column: 13
+5971:  AVMOpcode(Jump)		Line: 138, Column: 13
+5972:  [CodePoint(Internal(6016))] AVMOpcode(Jump)		Line: 87, Column: 5
+5973:  AVMOpcode(Pop)		Line: 87, Column: 5
+5974:  [1] AVMOpcode(Noop)		Line: 162, Column: 12
+5975:  [1] AVMOpcode(Noop)		Line: 160, Column: 23
+5976:  [Tuple(0)] AVMOpcode(Dup0)		Line: 159, Column: 27
+5977:  AVMOpcode(Dup0)		Line: 159, Column: 27
+5978:  AVMOpcode(Dup0)		Line: 159, Column: 27
+5979:  AVMOpcode(Dup0)		Line: 159, Column: 27
+5980:  AVMOpcode(Dup0)		Line: 159, Column: 27
+5981:  AVMOpcode(Dup0)		Line: 159, Column: 27
+5982:  AVMOpcode(Dup0)		Line: 159, Column: 27
+5983:  [Tuple(_, _, _, _, _, _, _, _)] AVMOpcode(Noop)		Line: 159, Column: 27
+5984:  [0] AVMOpcode(Tset)		Line: 159, Column: 27
+5985:  [1] AVMOpcode(Tset)		Line: 159, Column: 27
+5986:  [2] AVMOpcode(Tset)		Line: 159, Column: 27
+5987:  [3] AVMOpcode(Tset)		Line: 159, Column: 27
+5988:  [4] AVMOpcode(Tset)		Line: 159, Column: 27
+5989:  [5] AVMOpcode(Tset)		Line: 159, Column: 27
+5990:  [6] AVMOpcode(Tset)		Line: 159, Column: 27
+5991:  [7] AVMOpcode(Tset)		Line: 159, Column: 27
+5992:  [3] AVMOpcode(Xget)		Line: 157, Column: 28
+5993:  [2] AVMOpcode(Xget)		Line: 156, Column: 26
+5994:  [1] AVMOpcode(Xget)		Line: 155, Column: 33
+5995:  [Tuple(_, _, _)] AVMOpcode(Noop)		Line: 154, Column: 30
+5996:  [0] AVMOpcode(Tset)		Line: 154, Column: 30
+5997:  [1] AVMOpcode(Tset)		Line: 154, Column: 30
+5998:  [2] AVMOpcode(Tset)		Line: 154, Column: 30
+5999:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 154, Column: 25
+6000:  [1] AVMOpcode(Tset)		Line: 154, Column: 25
+6001:  [Tuple(_, _, _)] AVMOpcode(Noop)		Line: 153, Column: 13
+6002:  [0] AVMOpcode(Tset)		Line: 153, Column: 13
+6003:  [1] AVMOpcode(Tset)		Line: 153, Column: 13
+6004:  [2] AVMOpcode(Tset)		Line: 153, Column: 13
+6005:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 152, Column: 22
+6006:  [1] AVMOpcode(Tset)		Line: 152, Column: 22
+6007:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 152, Column: 21
+6008:  [0] AVMOpcode(Tset)		Line: 152, Column: 21
+6009:  [1] AVMOpcode(Tset)		Line: 152, Column: 21
+6010:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 152, Column: 16
+6011:  [1] AVMOpcode(Tset)		Line: 152, Column: 16
+6012:  AVMOpcode(AuxPop)		Line: 152, Column: 9
+6013:  AVMOpcode(Pop)		Line: 152, Column: 9
+6014:  AVMOpcode(AuxPop)		Line: 152, Column: 9
+6015:  AVMOpcode(Jump)		Line: 152, Column: 9
+6016:  AVMOpcode(AuxPush)		Line: 175, Column: 1
+6017:  [Tuple(_, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 175, Column: 1
+6018:  [0] AVMOpcode(Xset)		Line: 175, Column: 1
+6019:  [1] AVMOpcode(Xset)		Line: 175, Column: 1
+6020:  [0] AVMOpcode(Xget)		Line: 178, Column: 16
+6021:  AVMOpcode(Dup0)		Line: 178, Column: 16
+6022:  [0] AVMOpcode(Tget)		Line: 178, Column: 16
+6023:  [CodePoint(Internal(6028))] AVMOpcode(Cjump)		Line: 178, Column: 16
+6024:  AVMOpcode(AuxPop)		Line: 178, Column: 16
+6025:  AVMOpcode(Pop)		Line: 178, Column: 16
+6026:  AVMOpcode(AuxPop)		Line: 178, Column: 16
+6027:  AVMOpcode(Jump)		Line: 178, Column: 16
+6028:  [1] AVMOpcode(Tget)		Line: 178, Column: 16
+6029:  [2] AVMOpcode(Xset)		Line: 178, Column: 5
+6030:  [2] AVMOpcode(Xget)		Line: 179, Column: 27
+6031:  [0] AVMOpcode(Tget)		Line: 179, Column: 27
+6032:  AVMOpcode(Dup0)		Line: 179, Column: 5
+6033:  [0] AVMOpcode(Tget)		Line: 179, Column: 5
+6034:  AVMOpcode(IsZero)		Line: 179, Column: 5
+6035:  [CodePoint(Internal(6065))] AVMOpcode(Cjump)		Line: 179, Column: 5
+6036:  [1] AVMOpcode(Tget)		Line: 179, Column: 5
+6037:  [3] AVMOpcode(Xset)		Line: 179, Column: 5
+6038:  [1] AVMOpcode(Xget)		Line: 180, Column: 34
+6039:  [3] AVMOpcode(Xget)		Line: 180, Column: 13
+6040:  [0] AVMOpcode(Tget)		Line: 180, Column: 13
+6041:  AVMOpcode(Equal)		Line: 180, Column: 13
+6042:  AVMOpcode(IsZero)		Line: 180, Column: 9
+6043:  [CodePoint(Internal(6064))] AVMOpcode(Cjump)		Line: 180, Column: 9
+6044:  [0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff] AVMOpcode(Noop)		Line: 188, Column: 22
+6045:  [1] AVMOpcode(Noop)		Line: 186, Column: 65
+6046:  [2] AVMOpcode(Xget)		Line: 186, Column: 52
+6047:  [2] AVMOpcode(Tget)		Line: 186, Column: 52
+6048:  AVMOpcode(Minus)		Line: 186, Column: 48
+6049:  [Tuple(0)] AVMOpcode(Noop)		Line: 185, Column: 45
+6050:  [2] AVMOpcode(Xget)		Line: 185, Column: 25
+6051:  [0] AVMOpcode(Tset)		Line: 185, Column: 25
+6052:  [2] AVMOpcode(Tset)		Line: 185, Column: 25
+6053:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 184, Column: 21
+6054:  [1] AVMOpcode(Tset)		Line: 184, Column: 21
+6055:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 183, Column: 17
+6056:  [0] AVMOpcode(Tset)		Line: 183, Column: 17
+6057:  [1] AVMOpcode(Tset)		Line: 183, Column: 17
+6058:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 182, Column: 20
+6059:  [1] AVMOpcode(Tset)		Line: 182, Column: 20
+6060:  AVMOpcode(AuxPop)		Line: 182, Column: 13
+6061:  AVMOpcode(Pop)		Line: 182, Column: 13
+6062:  AVMOpcode(AuxPop)		Line: 182, Column: 13
+6063:  AVMOpcode(Jump)		Line: 182, Column: 13
+6064:  [CodePoint(Internal(6066))] AVMOpcode(Jump)		Line: 179, Column: 5
+6065:  AVMOpcode(Pop)		Line: 179, Column: 5
+6066:  [8] AVMOpcode(Noop)		Line: 195, Column: 29
+6067:  [1] AVMOpcode(Xget)		Line: 195, Column: 16
+6068:  AVMOpcode(Mod)		Line: 195, Column: 16
+6069:  [4] AVMOpcode(Xset)		Line: 195, Column: 5
+6070:  [8] AVMOpcode(Noop)		Line: 198, Column: 22
+6071:  [1] AVMOpcode(Xget)		Line: 198, Column: 9
+6072:  AVMOpcode(Div)		Line: 198, Column: 9
+6073:  [2] AVMOpcode(Xget)		Line: 197, Column: 29
+6074:  [1] AVMOpcode(Tget)		Line: 197, Column: 29
+6075:  [4] AVMOpcode(Xget)		Line: 197, Column: 43
+6076:  AVMOpcode(Tget)		Line: 197, Column: 29
+6077:  [CodePoint(Internal(6081))] AVMOpcode(PushStatic)		Line: 196, Column: 30
+6078:  [7] AVMOpcode(Tget)		Line: 196, Column: 30
+6079:  [5] AVMOpcode(Tget)		Line: 196, Column: 30
+6080:  AVMOpcode(Jump)		Line: 196, Column: 30
+6081:  AVMOpcode(Dup0)		Line: 196, Column: 30
+6082:  [0] AVMOpcode(Tget)		Line: 196, Column: 30
+6083:  [CodePoint(Internal(6088))] AVMOpcode(Cjump)		Line: 196, Column: 30
+6084:  AVMOpcode(AuxPop)		Line: 196, Column: 30
+6085:  AVMOpcode(Pop)		Line: 196, Column: 30
+6086:  AVMOpcode(AuxPop)		Line: 196, Column: 30
+6087:  AVMOpcode(Jump)		Line: 196, Column: 30
+6088:  [1] AVMOpcode(Tget)		Line: 196, Column: 30
+6089:  AVMOpcode(Dup0)		Line: 196, Column: 5
+6090:  [0] AVMOpcode(Tget)		Line: 196, Column: 5
+6091:  [5] AVMOpcode(Xset)		Line: 196, Column: 5
+6092:  [1] AVMOpcode(Tget)		Line: 196, Column: 5
+6093:  [6] AVMOpcode(Xset)		Line: 196, Column: 5
+6094:  [6] AVMOpcode(Xget)		Line: 208, Column: 8
+6095:  [6] AVMOpcode(Xget)		Line: 206, Column: 41
+6096:  [2] AVMOpcode(Xget)		Line: 206, Column: 28
+6097:  [2] AVMOpcode(Tget)		Line: 206, Column: 28
+6098:  AVMOpcode(Plus)		Line: 206, Column: 24
+6099:  [5] AVMOpcode(Xget)		Line: 203, Column: 26
+6100:  [2] AVMOpcode(Xget)		Line: 202, Column: 23
+6101:  [1] AVMOpcode(Tget)		Line: 202, Column: 23
+6102:  [4] AVMOpcode(Xget)		Line: 203, Column: 18
+6103:  AVMOpcode(Tset)		Line: 202, Column: 23
+6104:  [2] AVMOpcode(Xget)		Line: 201, Column: 9
+6105:  [1] AVMOpcode(Tset)		Line: 201, Column: 9
+6106:  [2] AVMOpcode(Tset)		Line: 201, Column: 9
+6107:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 200, Column: 18
+6108:  [1] AVMOpcode(Tset)		Line: 200, Column: 18
+6109:  [Tuple(_, _)] AVMOpcode(Noop)		Line: 200, Column: 17
+6110:  [0] AVMOpcode(Tset)		Line: 200, Column: 17
+6111:  [1] AVMOpcode(Tset)		Line: 200, Column: 17
+6112:  [Tuple(1, _)] AVMOpcode(Noop)		Line: 200, Column: 12
+6113:  [1] AVMOpcode(Tset)		Line: 200, Column: 12
+6114:  AVMOpcode(AuxPop)		Line: 200, Column: 5
+6115:  AVMOpcode(Pop)		Line: 200, Column: 5
+6116:  AVMOpcode(AuxPop)		Line: 200, Column: 5
+6117:  AVMOpcode(Jump)		Line: 200, Column: 5
+6118:  AVMOpcode(AuxPush)		Line: 166, Column: 1
+6119:  [Tuple(_, _, _, _, _)] AVMOpcode(AuxPush)		Line: 166, Column: 1
+6120:  [0] AVMOpcode(Xset)		Line: 166, Column: 1
+6121:  [1] AVMOpcode(Xset)		Line: 166, Column: 1
+6122:  [1] AVMOpcode(Xget)		Line: 167, Column: 58
+6123:  AVMOpcode(Hash)		Line: 167, Column: 53
+6124:  [0] AVMOpcode(Xget)		Line: 167, Column: 43
+6125:  [CodePoint(Internal(6129))] AVMOpcode(PushStatic)		Line: 167, Column: 24
+6126:  [7] AVMOpcode(Tget)		Line: 167, Column: 24
+6127:  [5] AVMOpcode(Tget)		Line: 167, Column: 24
+6128:  AVMOpcode(Jump)		Line: 167, Column: 24
+6129:  AVMOpcode(Dup0)		Line: 167, Column: 5
+6130:  [0] AVMOpcode(Tget)		Line: 167, Column: 5
+6131:  AVMOpcode(IsZero)		Line: 167, Column: 5
+6132:  [CodePoint(Internal(6147))] AVMOpcode(Cjump)		Line: 167, Column: 5
+6133:  [1] AVMOpcode(Tget)		Line: 167, Column: 5
+6134:  [2] AVMOpcode(Xset)		Line: 167, Column: 5
+6135:  [2] AVMOpcode(Xget)		Line: 168, Column: 27
+6136:  AVMOpcode(Dup0)		Line: 168, Column: 9
+6137:  [0] AVMOpcode(Tget)		Line: 168, Column: 9
+6138:  [3] AVMOpcode(Xset)		Line: 168, Column: 9
+6139:  [1] AVMOpcode(Tget)		Line: 168, Column: 9
+6140:  [4] AVMOpcode(Xset)		Line: 168, Column: 9
+6141:  [3] AVMOpcode(Xget)		Line: 169, Column: 16
+6142:  AVMOpcode(AuxPop)		Line: 169, Column: 9
+6143:  AVMOpcode(Pop)		Line: 169, Column: 9
+6144:  AVMOpcode(AuxPop)		Line: 169, Column: 9
+6145:  AVMOpcode(Jump)		Line: 169, Column: 9
+6146:  [CodePoint(Internal(6153))] AVMOpcode(Jump)		Line: 167, Column: 5
+6147:  AVMOpcode(Pop)		Line: 167, Column: 5
+6148:  [0] AVMOpcode(Xget)		Line: 171, Column: 16
+6149:  AVMOpcode(AuxPop)		Line: 171, Column: 9
+6150:  AVMOpcode(Pop)		Line: 171, Column: 9
+6151:  AVMOpcode(AuxPop)		Line: 171, Column: 9
+6152:  AVMOpcode(Jump)		Line: 171, Column: 9
+6153:  AVMOpcode(AuxPush)		Line: 211, Column: 1
+6154:  [Tuple(_, _, _, _, _, _, _)] AVMOpcode(AuxPush)		Line: 211, Column: 1
+6155:  [0] AVMOpcode(Xset)		Line: 211, Column: 1
+6156:  [1] AVMOpcode(Xset)		Line: 211, Column: 1
+6157:  [2] AVMOpcode(Xset)		Line: 211, Column: 1
+6158:  [0] AVMOpcode(Xget)		Line: 219, Column: 25
+6159:  AVMOpcode(Dup0)		Line: 219, Column: 5
+6160:  [0] AVMOpcode(Tget)		Line: 219, Column: 5
+6161:  AVMOpcode(IsZero)		Line: 219, Column: 5
+6162:  [CodePoint(Internal(6208))] AVMOpcode(Cjump)		Line: 219, Column: 5
+6163:  [1] AVMOpcode(Tget)		Line: 219, Column: 5
+6164:  [3] AVMOpcode(Xset)		Line: 219, Column: 5
+6165:  [3] AVMOpcode(Xget)		Line: 220, Column: 31
+6166:  [0] AVMOpcode(Tget)		Line: 220, Column: 31
+6167:  AVMOpcode(Dup0)		Line: 220, Column: 9
+6168:  [0] AVMOpcode(Tget)		Line: 220, Column: 9
+6169:  AVMOpcode(IsZero)		Line: 220, Column: 9
+6170:  [CodePoint(Internal(6183))] AVMOpcode(Cjump)		Line: 220, Column: 9
+6171:  [1] AVMOpcode(Tget)		Line: 220, Column: 9
+6172:  [4] AVMOpcode(Xset)		Line: 220, Column: 9
+6173:  [2] AVMOpcode(Xget)		Line: 221, Column: 56
+6174:  [4] AVMOpcode(Xget)		Line: 221, Column: 42
+6175:  [2] AVMOpcode(Tget)		Line: 221, Column: 42
+6176:  [4] AVMOpcode(Xget)		Line: 221, Column: 30
+6177:  [1] AVMOpcode(Tget)		Line: 221, Column: 30
+6178:  [CodePoint(Internal(6181))] AVMOpcode(Noop)		Line: 221, Column: 21
+6179:  [1] AVMOpcode(Xget)		Line: 221, Column: 21
+6180:  AVMOpcode(Jump)		Line: 221, Column: 21
+6181:  [2] AVMOpcode(Xset)		Line: 221, Column: 13
+6182:  [CodePoint(Internal(6184))] AVMOpcode(Jump)		Line: 220, Column: 9
+6183:  AVMOpcode(Pop)		Line: 220, Column: 9
+6184:  [0] AVMOpcode(Noop)		Line: 223, Column: 17
+6185:  [5] AVMOpcode(Xset)		Line: 223, Column: 9
+6186:  [CodePoint(Internal(6189))] AVMOpcode(Noop)		Line: 224, Column: 9
+6187:  [6] AVMOpcode(Xset)		Line: 224, Column: 9
+6188:  [CodePoint(Internal(6203))] AVMOpcode(Jump)		Line: 224, Column: 9
+6189:  [2] AVMOpcode(Xget)		Line: 228, Column: 17
+6190:  [1] AVMOpcode(Xget)		Line: 227, Column: 17
+6191:  [3] AVMOpcode(Xget)		Line: 226, Column: 37
+6192:  [1] AVMOpcode(Tget)		Line: 226, Column: 37
+6193:  [5] AVMOpcode(Xget)		Line: 226, Column: 51
+6194:  AVMOpcode(Tget)		Line: 226, Column: 37
+6195:  [CodePoint(Internal(6199))] AVMOpcode(PushStatic)		Line: 225, Column: 21
+6196:  [7] AVMOpcode(Tget)		Line: 225, Column: 21
+6197:  [6] AVMOpcode(Tget)		Line: 225, Column: 21
+6198:  AVMOpcode(Jump)		Line: 225, Column: 21
+6199:  [2] AVMOpcode(Xset)		Line: 225, Column: 13
+6200:  [5] AVMOpcode(Xget)		Line: 230, Column: 17
+6201:  [1] AVMOpcode(Plus)		Line: 230, Column: 17
+6202:  [5] AVMOpcode(Xset)		Line: 230, Column: 13
+6203:  [5] AVMOpcode(Xget)		Line: 224, Column: 16
+6204:  [8] AVMOpcode(GreaterThan)		Line: 224, Column: 16
+6205:  [6] AVMOpcode(Xget)		Line: 224, Column: 9
+6206:  AVMOpcode(Cjump)		Line: 224, Column: 9
+6207:  [CodePoint(Internal(6209))] AVMOpcode(Jump)		Line: 219, Column: 5
+6208:  AVMOpcode(Pop)		Line: 219, Column: 5
+6209:  [2] AVMOpcode(Xget)		Line: 234, Column: 12
+6210:  AVMOpcode(AuxPop)		Line: 234, Column: 5
+6211:  AVMOpcode(Pop)		Line: 234, Column: 5
+6212:  AVMOpcode(AuxPop)		Line: 234, Column: 5
+6213:  AVMOpcode(Jump)		Line: 234, Column: 5
+6214:  AVMOpcode(AuxPush)		Line: 237, Column: 1
+6215:  [Tuple(_, _)] AVMOpcode(AuxPush)		Line: 237, Column: 1
+6216:  [0] AVMOpcode(Xset)		Line: 237, Column: 1
+6217:  [0] AVMOpcode(Xget)		Line: 238, Column: 25
+6218:  AVMOpcode(Dup0)		Line: 238, Column: 5
+6219:  [0] AVMOpcode(Tget)		Line: 238, Column: 5
+6220:  AVMOpcode(IsZero)		Line: 238, Column: 5
+6221:  [CodePoint(Internal(6231))] AVMOpcode(Cjump)		Line: 238, Column: 5
+6222:  [1] AVMOpcode(Tget)		Line: 238, Column: 5
+6223:  [1] AVMOpcode(Xset)		Line: 238, Column: 5
+6224:  [1] AVMOpcode(Xget)		Line: 239, Column: 16
+6225:  [2] AVMOpcode(Tget)		Line: 239, Column: 16
+6226:  AVMOpcode(AuxPop)		Line: 239, Column: 9
+6227:  AVMOpcode(Pop)		Line: 239, Column: 9
+6228:  AVMOpcode(AuxPop)		Line: 239, Column: 9
+6229:  AVMOpcode(Jump)		Line: 239, Column: 9
+6230:  [CodePoint(Internal(6236))] AVMOpcode(Jump)		Line: 238, Column: 5
+6231:  AVMOpcode(Pop)		Line: 238, Column: 5
+6232:  [0] AVMOpcode(AuxPop)		Line: 241, Column: 9
+6233:  AVMOpcode(Pop)		Line: 241, Column: 9
+6234:  AVMOpcode(AuxPop)		Line: 241, Column: 9
+6235:  AVMOpcode(Jump)		Line: 241, Column: 9

--- a/stdlib/bytearray.mini
+++ b/stdlib/bytearray.mini
@@ -76,16 +76,20 @@ public func marshalledBytes_hash(mb: MarshalledBytes) -> bytes32 {
 public func bytearray_unmarshalBytes(inBytes: MarshalledBytes) -> ByteArray {
     // unmarshal bytes from the bytestack data structure that we receive from L1
     let nbytes = inBytes.nbytes;
-    let ba = bytearray_new(nbytes);
+    let eia = expandingIntArray_new();
     let nwords = (nbytes+31)/32;
 
     let words = inBytes.contents;
     while (nwords > 0) {
         nwords = nwords-1;
-        ba = bytearray_set256(ba, 32*nwords, words.first);
+        eia = expandingIntArray_set(eia, nwords, words.first);
         words = unsafecast<MarshalledBytesCell>(words.rest);
     }
-    return ba with { size: nbytes };
+    return struct {
+        size: inBytes.nbytes,
+        sliceOffset: 0,
+        contents: eia,
+    };
 }
 
 public func bytearray_marshalFull(ba: ByteArray) -> MarshalledBytes {
@@ -143,7 +147,7 @@ public func bytearray_get64(ba: ByteArray, offset: uint) -> uint {
         }
         return ret;
     } else {
-        let res = bytearray_get256(ba, offset);
+        let res = bytearray_get256(ba, offset-ba.sliceOffset);
         let ret = res / 0x1000000000000000000000000000000000000000000000000;
         if (bytesToTrim > 0) {
             ret = ret & ~((asm(256, bytesToTrim) uint { exp }) - 1);
@@ -154,6 +158,9 @@ public func bytearray_get64(ba: ByteArray, offset: uint) -> uint {
 
 // bytearray_get256 reads a chunk of 32 bytes from a ByteArray
 public func bytearray_get256(ba: ByteArray, offset: uint) -> uint {
+    if (offset >= ba.size) {
+        return 0;
+    }
     let bytesToTrim = 0;
     if (offset+32 > ba.size) {
         bytesToTrim = offset+32 - ba.size;
@@ -441,7 +448,7 @@ func ear_op2(
             closure
         );
         return (
-            tree with { [index] = newSlotContents },
+            tree with { [slot] = newSlotContents },
             retVal,
         );
     }
@@ -463,7 +470,7 @@ func expandingIntArray_grow(arr: ExpandingIntArray) -> ExpandingIntArray {
     let newContents = unsafecast<[8]any>((0,0,0,0,0,0,0,0));
     let newChunk = 1;
     while (newChunk <= arr.chunk) {
-        newContents = unsafecast<[8]any>(newfixedarray(8, newContents));
+        newContents = unsafecast<[8]any>((newContents, newContents, newContents, newContents, newContents, newContents, newContents, newContents));
         newChunk = newChunk * 8;
     }
     newContents = newContents with { [0] = arr.contents };

--- a/stdlib/bytearray.mini
+++ b/stdlib/bytearray.mini
@@ -14,31 +14,11 @@
 // limitations under the License.
 //
 
-import func array_resize(a: []uint, newSize: uint, baseVal: uint) -> []uint;
-import func builtin_arrayGet(a: []uint, index: uint) -> uint;
-import func builtin_arrayGetConsecutive(a: []uint, index: uint) -> (uint, uint);
-import func builtin_arrayOp(
-    a: []uint, 
-    index: uint, 
-    closure: opClosure
-) -> ([]uint, uint);
-import func builtin_arrayOpConsecutive(
-    a: []uint, 
-    index: uint, 
-    closure1: opClosure, 
-    closure2: opClosure
-    ) -> ([]uint, uint, uint);
-
-type opClosure = struct {
-	f: func((uint, uint), uint) -> (uint, uint),  // (closure.val, oldVal) -> (newVal, return)
-	val: (uint, uint),
-}
 
 type ByteArray = struct { 
     size: uint,
     sliceOffset: uint,
-    arrayCapacityBytes: uint,
-    contents: []uint,
+    contents: ExpandingIntArray,
 }
 
 // bytearray_new makes a new ByteArray
@@ -46,16 +26,11 @@ type ByteArray = struct {
 //        reads beyond the end will return zero,
 //        size will expand to fit all writes,
 //        and the capacity arg is a hint about how big it will get
-public func bytearray_new(capacity: uint) -> ByteArray {
-    let roundedUpCapacity = 8*32;
-    while (roundedUpCapacity < capacity) {
-        roundedUpCapacity = 8*roundedUpCapacity;
-    }
+public func bytearray_new(ignored: uint) -> ByteArray {
     return struct {
         size: 0,
         sliceOffset: 0,
-        arrayCapacityBytes: roundedUpCapacity,
-        contents: newarray<uint>(roundedUpCapacity/32),
+        contents: expandingIntArray_new(),
     };
 }
 
@@ -101,16 +76,16 @@ public func marshalledBytes_hash(mb: MarshalledBytes) -> bytes32 {
 public func bytearray_unmarshalBytes(inBytes: MarshalledBytes) -> ByteArray {
     // unmarshal bytes from the bytestack data structure that we receive from L1
     let nbytes = inBytes.nbytes;
-    let ba = bytearray_new(nbytes) with { size: nbytes };
+    let ba = bytearray_new(nbytes);
     let nwords = (nbytes+31)/32;
 
     let words = inBytes.contents;
     while (nwords > 0) {
         nwords = nwords-1;
-        ba = ba with { contents: ba.contents with { [nwords] = words.first } };
+        ba = bytearray_set256(ba, 32*nwords, words.first);
         words = unsafecast<MarshalledBytesCell>(words.rest);
     }
-    return ba;
+    return ba with { size: nbytes };
 }
 
 public func bytearray_marshalFull(ba: ByteArray) -> MarshalledBytes {
@@ -142,29 +117,11 @@ public func bytearray_getByte(ba: ByteArray, offset: uint) -> uint {
         return 0;
     }
     offset = offset + ba.sliceOffset;
-    let slot = ba.contents[offset/32];
-    let byteno = 31-(offset%32);
-    return (slot / (asm (2, 8*byteno) uint { exp })) & 0xff;
+    let word = expandingIntArray_get(ba.contents, offset/32);
+    return (word / (asm (256, 31-(offset & 0x1f)) uint { exp })) & 0xff;
 }
 
-// bytearray_setbyte writes one byte to a ByteArray, returns the resulting ByteArray
-public func bytearray_setByte(ba: ByteArray, offset: uint, val: uint) -> ByteArray {
-    if (offset >= ba.size) {
-        ba = ba with { size: offset+1 };
-    }
-    offset = offset + ba.sliceOffset;
-    if (offset >= ba.arrayCapacityBytes) {
-        ba = bytearray_expandToFit(ba, offset+1);
-    }
-    let (newContents, _) = builtin_arrayOp(
-        ba.contents, 
-        offset/32, 
-        struct { f: basb_closure_func, val: (31-(offset%32), val,), }
-    );
-    return ba with { contents: newContents };
-}
-
-// bytearray_get64 reads a chunk of 8 bytes from a ByteArray 
+// bytearray_get64 reads a chunk of 8 bytes from a ByteArray
 public func bytearray_get64(ba: ByteArray, offset: uint) -> uint {
     if (offset >= ba.size) {
         return 0;
@@ -174,13 +131,13 @@ public func bytearray_get64(ba: ByteArray, offset: uint) -> uint {
         bytesToTrim = offset+8 - ba.size;
     }
     // the access might extend beyond size, but access to the underlying array will be in-bounds
-    // on the true side of the if, any overage is within an existing word of the underlying array
-    // on the false side of the if, bytearray_get256 will avoid out-of-bounds accesses
+    //    on the true side of the if, any overage is within an existing word of the underlying array
+    //    on the false side of the if, bytearray_get256 will avoid out-of-bounds accesses
     offset = offset + ba.sliceOffset;
     let alignment = offset % 32;
     if (alignment <= 24) {
-        let res = ba.contents[offset/32];
-        let ret = (res / asm(2, 192-8*alignment) uint { exp }) & 0xffffffffffffffff;
+        let word = expandingIntArray_get(ba.contents, offset/32);
+        let ret = (word / asm(256, 24-alignment) uint { exp }) & 0xffffffffffffffff;
         if (bytesToTrim > 0) {
             ret = ret & ~((asm(256, bytesToTrim) uint { exp }) - 1);
         }
@@ -195,32 +152,6 @@ public func bytearray_get64(ba: ByteArray, offset: uint) -> uint {
     }
 }
 
-// bytearray_set64 writes an 8-byte chunk to a ByteArray, returning the resulting ByteArray
-public func bytearray_set64(ba: ByteArray, offset: uint, value: uint) -> ByteArray {
-    if (offset+8 > ba.size) {
-        ba = bytearray_expandToFit(ba, offset+8);
-    }
-    offset = offset + ba.sliceOffset;
-    let lowWordIndex = offset / 32;
-    let alignment = offset % 32;
-    if (alignment <= 24) {
-        let res = builtin_arrayOp(
-            ba.contents,
-            lowWordIndex,
-            struct{ f: bas64_single_closure_func, val: (alignment, value,), }
-        );
-        return ba with { contents: res.0 };
-    } else {
-        let res = builtin_arrayOpConsecutive(
-            ba.contents,
-            lowWordIndex,
-            struct { f: bas64_low_closure_func, val: (alignment, value,), },
-            struct { f: basmulti_hi_closure_func, val: (alignment, value,), }
-        );
-        return ba with { contents: res.0 };
-    }
-}
-
 // bytearray_get256 reads a chunk of 32 bytes from a ByteArray
 public func bytearray_get256(ba: ByteArray, offset: uint) -> uint {
     let bytesToTrim = 0;
@@ -231,37 +162,15 @@ public func bytearray_get256(ba: ByteArray, offset: uint) -> uint {
     let lowWordIndex = offset / 32;
     let alignment = offset % 32;
     if (alignment == 0) {
-        if (offset+32 > ba.arrayCapacityBytes) {
-            // because arrayCapacityBytes is a multiple of 32 in this case, access is entirely beyond size
-            return 0;
-        }
-        let ret = ba.contents[lowWordIndex];
+        let ret = expandingIntArray_get(ba.contents, lowWordIndex);
         if (bytesToTrim > 0) {
             ret = ret & ~((asm(256, bytesToTrim) uint { exp }) - 1);
         }
         return ret;
     } else {
-        let lowWord = 0;  // word from lower-numbered array slot
-        let hiWord = 0;   // word from higher-numbered array slot
-
-        if (offset+32 > ba.arrayCapacityBytes) {
-            // read contents, but only if they exist; otherwise let xxxWord remain 0
-            let offsetBase = offset & ~0x1f;
-            let offsetBaseDiv32 = offsetBase / 32;
-            if (offsetBase < ba.arrayCapacityBytes) {
-                lowWord = ba.contents[offsetBaseDiv32];
-                if (offsetBase+32 < ba.arrayCapacityBytes) {
-                    hiWord = ba.contents[1+offsetBaseDiv32];
-                }
-            }
-        } else {
-            let words = builtin_arrayGetConsecutive(ba.contents, lowWordIndex);
-            lowWord = words.0;
-            hiWord = words.1;
-        }
-
-        let shiftFactor = asm(2, 8*alignment) uint { exp };
-        let invShiftFactor = asm(2, 256-8*alignment) uint { exp };
+        let (lowWord, hiWord) = expandingIntArray_getConsecutive(ba.contents, lowWordIndex);
+        let shiftFactor = asm(256, alignment) uint { exp };
+        let invShiftFactor = asm(256, 32-alignment) uint { exp };
         let ret = (hiWord/invShiftFactor) | (lowWord*shiftFactor);
         if (bytesToTrim > 0) {
             ret = ret & ~((asm(256, bytesToTrim) uint { exp }) - 1);
@@ -270,26 +179,84 @@ public func bytearray_get256(ba: ByteArray, offset: uint) -> uint {
     }
 }
 
+// bytearray_setbyte writes one byte to a ByteArray, returns the resulting ByteArray
+public func bytearray_setByte(ba: ByteArray, offset: uint, val: uint) -> ByteArray {
+    if (offset >= ba.size) {
+        ba = ba with { size: offset+1 };
+    }
+    offset = offset + ba.sliceOffset;
+    let (newContents, _) = expandingIntArray_op(
+        ba.contents, 
+        offset/32, 
+        struct {
+            f: unsafecast<opClosureFunc>(basb_closure_func),
+            val: (31-(offset%32), val,),
+        }
+    );
+    return ba with { contents: newContents };
+}
+
+// bytearray_set64 writes an 8-byte chunk to a ByteArray, returning the resulting ByteArray
+public func bytearray_set64(ba: ByteArray, offset: uint, value: uint) -> ByteArray {
+    if (offset+8 > ba.size) {
+        ba = ba with { size: offset+8 };
+    }
+    offset = offset + ba.sliceOffset;
+    let lowWordIndex = offset / 32;
+    let alignment = offset % 32;
+    if (alignment <= 24) {
+        let (newContents, _) = expandingIntArray_op(
+            ba.contents,
+            lowWordIndex,
+            struct{
+                f: unsafecast<opClosureFunc>(bas64_single_closure_func),
+                val: (alignment, value,),
+            }
+        );
+        return ba with { contents: newContents };
+    } else {
+        let (newContents, _0, _1) = expandingIntArray_opConsecutive(
+            ba.contents,
+            lowWordIndex,
+            struct {
+                f: unsafecast<opClosureFunc>(bas64_low_closure_func),
+                val: (alignment, value,),
+            },
+            struct {
+                f: unsafecast<opClosureFunc>(basmulti_hi_closure_func),
+                val: (alignment, value,),
+            }
+        );
+        return ba with { contents: newContents };
+    }
+}
+
 // bytearray_set256 writes a 32-byte chunk to a ByteArray, returning the resulting ByteArray
 public func bytearray_set256(ba: ByteArray, offset: uint, value: uint) -> ByteArray {
     if (offset+32 > ba.size) {
-        ba = bytearray_expandToFit(ba, offset+32);
+        ba = ba with { size: offset+32 };
     }
     offset = offset + ba.sliceOffset;
     let lowWordIndex = offset / 32;
     let alignment = offset % 32;
     if (alignment == 0) {
         return ba with {
-            contents: ba.contents with { [lowWordIndex] = value }
+            contents: expandingIntArray_set(ba.contents, lowWordIndex, value)
         };
     } else {
-        let res = builtin_arrayOpConsecutive(
+        let (newContents, _0, _1) = expandingIntArray_opConsecutive(
             ba.contents,
             lowWordIndex,
-            struct { f: bas256_low_closure_func, val: (alignment, value,), },
-            struct { f: basmulti_hi_closure_func, val: (alignment, value,), }
+            struct {
+                f: unsafecast<opClosureFunc>(bas256_low_closure_func),
+                val: (alignment, value,),
+            },
+            struct {
+                f: unsafecast<opClosureFunc>(basmulti_hi_closure_func),
+                val: (alignment, value,),
+            }
         );
-        return ba with { contents: res.0 };
+        return ba with { contents: newContents };
     }
 }
 
@@ -326,25 +293,6 @@ public func bytearray_extract(from: ByteArray, offset: uint, nbytes: uint) -> By
     } with {
         sliceOffset: offset + from.sliceOffset
     };
-}
-
-func bytearray_expandToFit(ba: ByteArray, neededCapacity: uint) -> ByteArray {
-    if (ba.size < neededCapacity) {
-        ba = ba with { size: neededCapacity };
-        neededCapacity = neededCapacity + ba.sliceOffset;
-        if (ba.arrayCapacityBytes < neededCapacity) {
-            let newCapacity = ba.arrayCapacityBytes*8;
-            while (newCapacity < neededCapacity) {
-                    newCapacity = 8*newCapacity;
-            }
-            return ba with { arrayCapacityBytes: newCapacity }
-                      with { contents: array_resize(ba.contents, newCapacity/32, 0) };
-        } else {
-            return ba;
-        }
-    } else {
-        return ba;
-    }
 }
 
 func basb_closure_func(args: (uint, uint), oldval: uint) -> (uint, uint) { // returns (newval, junk)
@@ -393,4 +341,135 @@ func bas256_low_closure_func(args: (uint, uint), oldval: uint) -> (uint, uint) {
     let invFactor = asm(2, 8*revAlignment) uint { exp };
     let newVal = (value/factor) | (oldval & (invFactor * ~0));
     return (newVal, 0,);
+}
+
+type ExpandingIntArray = struct {
+    size: uint,
+    chunk: uint,
+    contents: [8]any,
+}
+
+func expandingIntArray_new() -> ExpandingIntArray {
+    return struct {
+        size: 8,
+        chunk: 1,
+        contents: unsafecast<[8]any>((0,0,0,0,0,0,0,0)),
+    };
+}
+
+func expandingIntArray_get(arr: ExpandingIntArray, index: uint) -> uint {
+    if (index >= arr.size) {
+        return 0;
+    }
+    let chunk = arr.chunk;
+    let tree = arr.contents;
+    while (chunk > 1) {
+        tree = unsafecast<[8]any>(tree[index / chunk]);
+        index = index % chunk;
+        chunk = chunk / 8;
+    }
+    return unsafecast<uint>(tree[index]);
+}
+
+func expandingIntArray_getConsecutive(arr: ExpandingIntArray, index: uint) -> (uint, uint) {
+    // TODO: make this more efficient
+    return (
+        expandingIntArray_get(arr, index),
+        expandingIntArray_get(arr, index+1),
+    );
+}
+
+func expandingIntArray_set(arr: ExpandingIntArray, index: uint, value: uint) -> ExpandingIntArray {
+    while (index >= arr.size) {
+        arr = expandingIntArray_grow(arr);
+    }
+    return arr with {
+        contents: ear_set2(arr.contents, arr.chunk, index, value)
+    };
+}
+
+func ear_set2(tree: [8]any, chunk: uint, index: uint, value: uint) -> [8]any {
+    if (chunk == 1) {
+        return tree with { [index] = value };
+    }
+    let slot = index/chunk;
+    return tree with {
+        [slot] = ear_set2(unsafecast<[8]any>(tree[slot]), chunk/8, index%chunk, value)
+    };
+}
+
+type opClosureFunc = func(any, uint) -> (uint, any)
+
+type opClosure = struct {
+	f: opClosureFunc,
+	val: any,
+} // usage: (newSlotContents, returnValue) = closure.f(closure.val, oldSlotContents)
+
+func expandingIntArray_op(
+    arr: ExpandingIntArray,
+    index: uint,
+    closure: opClosure
+) -> (ExpandingIntArray, any) {
+    while (index >= arr.size) {
+        arr = expandingIntArray_grow(arr);
+    }
+    let (tree, retVal) = ear_op2(arr.contents, arr.chunk, index, closure);
+    return (
+        arr with { contents: tree },
+        retVal,
+    );
+}
+
+func ear_op2(
+    tree: [8]any,
+    chunk: uint,
+    index: uint,
+    closure: opClosure
+) -> ([8]any, any) {
+    if (chunk == 1) {
+        let (newSlotContents, retVal) = closure.f(closure.val, unsafecast<uint>(tree[index]));
+        return (
+            tree with { [index] = newSlotContents },
+            retVal,
+        );
+    } else {
+        let slot = index / chunk;
+        let (newSlotContents, retVal) = ear_op2(
+            unsafecast<[8]any>(tree[slot]),
+            chunk/8,
+            index%chunk,
+            closure
+        );
+        return (
+            tree with { [index] = newSlotContents },
+            retVal,
+        );
+    }
+}
+
+func expandingIntArray_opConsecutive(
+    arr: ExpandingIntArray,
+    index: uint,
+    loClosure: opClosure,
+    hiClosure: opClosure
+) -> (ExpandingIntArray, any, any) {
+    // TODO: make this more efficient
+    let (arr1, val1) = expandingIntArray_op(arr, index, loClosure);
+    let (arr2, val2) = expandingIntArray_op(arr1, index+1, hiClosure);
+    return (arr2, val1, val2);
+}
+
+func expandingIntArray_grow(arr: ExpandingIntArray) -> ExpandingIntArray {
+    let newContents = unsafecast<[8]any>((0,0,0,0,0,0,0,0));
+    let newChunk = 1;
+    while (newChunk <= arr.chunk) {
+        newContents = unsafecast<[8]any>(newfixedarray(8, newContents));
+        newChunk = newChunk * 8;
+    }
+    newContents = newContents with { [0] = arr.contents };
+    return struct {
+        size: 8*newChunk,
+        chunk: newChunk,
+        contents: newContents,
+    };
 }

--- a/stdlib/bytearray.mini
+++ b/stdlib/bytearray.mini
@@ -408,23 +408,42 @@ func ear_get_2(tree: [8]any, chunk: uint, index: uint) -> uint {
     return unsafecast<uint>(tree[index]);
 }
 
+type Unwinder = struct {
+    tree: [8]any,
+    slot: uint,
+    next: option<any>,  // really option<Unwinder>, but compiler doesn't allow recursive types
+}
+
 func expandingIntArray_set(arr: ExpandingIntArray, index: uint, value: uint) -> ExpandingIntArray {
     while (index >= arr.size) {
         arr = expandingIntArray_grow(arr);
     }
-    return arr with {
-        contents: ear_set2(arr.contents, arr.chunk, index, value)
-    };
-}
 
-func ear_set2(tree: [8]any, chunk: uint, index: uint, value: uint) -> [8]any {
-    if (chunk == 1) {
-        return tree with { [index] = value };
+    let tree = arr.contents;
+    let chunk = arr.chunk;
+    let unwinder = None<Unwinder>;
+    loop {
+        if (chunk == 1) {
+            tree = tree with { [index] = value };
+            loop {
+                if let Some(unw) = unwinder {
+                    tree = unw.tree with { [unw.slot] = tree };
+                    unwinder = unsafecast<option<Unwinder>>(unw.next);
+                } else {
+                    return arr with { contents: tree };
+                }
+            }
+        }
+        let slot = index/chunk;
+        unwinder = Some(struct {
+            tree: tree,
+            slot: slot,
+            next: unwinder,
+        });
+        tree = unsafecast<[8]any>(tree[slot]);
+        index = index % chunk;
+        chunk = chunk / 8;
     }
-    let slot = index/chunk;
-    return tree with {
-        [slot] = ear_set2(unsafecast<[8]any>(tree[slot]), chunk/8, index%chunk, value)
-    };
 }
 
 type opClosureFunc = func(any, uint) -> (uint, any)
@@ -442,6 +461,9 @@ func expandingIntArray_op(
     while (index >= arr.size) {
         arr = expandingIntArray_grow(arr);
     }
+    let tree = arr.contents;
+    let chunk = arr.chunk;
+
     let (tree, retVal) = ear_op2(arr.contents, arr.chunk, index, closure);
     return (
         arr with { contents: tree },

--- a/stdlib/bytearray.mini
+++ b/stdlib/bytearray.mini
@@ -379,11 +379,33 @@ func expandingIntArray_get(arr: ExpandingIntArray, index: uint) -> uint {
 }
 
 func expandingIntArray_getConsecutive(arr: ExpandingIntArray, index: uint) -> (uint, uint) {
-    // TODO: make this more efficient
-    return (
-        expandingIntArray_get(arr, index),
-        expandingIntArray_get(arr, index+1),
-    );
+    let tree = arr.contents;
+    let chunk = arr.chunk;
+
+    while (chunk > 1) {
+        let offset = index % chunk;
+        if ((offset+1) == chunk) {
+            let loSlot = index / chunk;
+            return (
+                ear_get_2(unsafecast<[8]any>(tree[loSlot]), chunk/8, chunk-1),
+                ear_get_2(unsafecast<[8]any>(tree[loSlot+1]), chunk/8, 0)
+            );
+        }
+        tree = unsafecast<[8]any>(tree[index/chunk]);
+        index = offset;
+        chunk = chunk / 8;
+    }
+
+    return (unsafecast<uint>(tree[index]), unsafecast<uint>(tree[index+1]));
+}
+
+func ear_get_2(tree: [8]any, chunk: uint, index: uint) -> uint {
+    while (chunk > 1) {
+        tree = unsafecast<[8]any>(tree[index/chunk]);
+        index = index % chunk;
+        chunk = chunk / 8;
+    }
+    return unsafecast<uint>(tree[index]);
 }
 
 func expandingIntArray_set(arr: ExpandingIntArray, index: uint, value: uint) -> ExpandingIntArray {

--- a/stdlib/bytearraytest.mini
+++ b/stdlib/bytearraytest.mini
@@ -136,6 +136,7 @@ func tests() -> uint {
 	    return 12;
 	}
 
+    asm(bytearray_marshalFull(setupFromUnmarshal()),) { debugprint };
     if (bytes32(0x4fc384a19926e9ff7ec8f2376a0d146dc273031df1db4d133236d209700e4780)
         != marshalledBytes_hash(bytearray_marshalFull(setupFromUnmarshal()))
     ) {
@@ -159,6 +160,12 @@ func tests() -> uint {
     let ba3 = bytearray_copy(ba, 0, bytearray_new(0), 0, 41);
     if (bytearray_marshalFull(ba2) != bytearray_marshalFull(ba3)) {
         return 16;
+    }
+
+    let ba = bytearray_new(0);
+    let i = 0;
+    while (i < 500) {
+        ba = bytearray_set256(ba, i*32, i);
     }
 
 	return 0;

--- a/stdlib/bytearraytest.mini
+++ b/stdlib/bytearraytest.mini
@@ -136,7 +136,6 @@ func tests() -> uint {
 	    return 12;
 	}
 
-    asm(bytearray_marshalFull(setupFromUnmarshal()),) { debugprint };
     if (bytes32(0x4fc384a19926e9ff7ec8f2376a0d146dc273031df1db4d133236d209700e4780)
         != marshalledBytes_hash(bytearray_marshalFull(setupFromUnmarshal()))
     ) {
@@ -154,18 +153,29 @@ func tests() -> uint {
     ) {
         return 15;
     }
-
     let ba = setupFromUnmarshal();
     let ba2 = bytearray_extract(ba, 0, 41);
     let ba3 = bytearray_copy(ba, 0, bytearray_new(0), 0, 41);
-    if (bytearray_marshalFull(ba2) != bytearray_marshalFull(ba3)) {
+    let mb2 = bytearray_marshalFull(ba2);
+    let mb3 = bytearray_marshalFull(ba3);
+    if (mb2 != mb3) {
         return 16;
     }
 
     let ba = bytearray_new(0);
     let i = 0;
-    while (i < 500) {
+    while (i < 5000) {
         ba = bytearray_set256(ba, i*32, i);
+        i = i+1;
+    }
+    i = 0;
+    let sum = 0;
+    while (i < 5000) {
+        sum = sum + bytearray_get256(ba, i*32);
+        i = i+1;
+    }
+    if (sum != (2500*4999)) {
+        return 17;
     }
 
 	return 0;

--- a/stdlib/rlptest.mini
+++ b/stdlib/rlptest.mini
@@ -48,7 +48,6 @@ import func bytesNeededToRepresentUint(val: uint) -> uint;
 
 
 impure func main(kind: uint, value: any) {
-    asm((kind, value),) { debugprint };
     if (kind == 0) {
         let ui = unsafecast<uint>(value);
         let ba = bytearray_new(0);

--- a/stdlib/rlptest.mini
+++ b/stdlib/rlptest.mini
@@ -48,6 +48,7 @@ import func bytesNeededToRepresentUint(val: uint) -> uint;
 
 
 impure func main(kind: uint, value: any) {
+    asm((kind, value),) { debugprint };
     if (kind == 0) {
         let ui = unsafecast<uint>(value);
         let ba = bytearray_new(0);


### PR DESCRIPTION
* Rewrite bytearray library to use a custom auto-expanding integer array-tree as its underlying storage, rather than the general-purpose sized array facility used previously.
* Also incorporate KVS data structure change (from other branch and PR)