### PR TITLE
Fix bug in ArbSys.withdrawEth

### DIFF
--- a/arb_os/arbsys.mini
+++ b/arb_os/arbsys.mini
@@ -33,6 +33,7 @@ import func evmCallFrame_getAccount(frame: EvmCallFrame, addr: address) -> Accou
 import func evmCallFrame_runningAsAddress(frame: EvmCallFrame) -> address;
 import func evmCallFrame_runningAsAccount(frame: EvmCallFrame) -> Account;
 import func evmCallFrame_getParent(frame: EvmCallFrame) -> option<EvmCallFrame>;
+import func evmCallFrame_getCaller(frame: EvmCallFrame) -> address;
 
 import impure func evmOp_return(memOffset: uint, memNbytes: uint);
 import impure func evmOp_revert(memOffset: uint, memNbytes: uint);
@@ -76,7 +77,6 @@ public impure func arbsys_txcall() {
             evmOp_revert(0, 0);
         }
         let funcCode = getFuncCode(calldata);
-
         if (funcCode == 0xa1db9782) {
             arbsys_withdrawErc20(topFrame, calldata);
         } elseif(funcCode == 0xf3e414f8) {
@@ -133,20 +133,19 @@ impure func arbsys_withdrawEth(topFrame: EvmCallFrame, calldata: ByteArray) {
     if (bytearray_size(calldata) != 36) {
         evmOp_revert(0, 0);
     }
-    if let Some(senderAddr) = getCallerAddress() {
-        let senderAcct = evmCallFrame_getAccount(topFrame, senderAddr);
-        let destAddr = address(bytearray_get256(calldata, 4));
-        let amount = evmCallFrame_getCallvalue(topFrame);
+    let senderAddr = evmCallFrame_getCaller(topFrame);
+    let senderAcct = evmCallFrame_getAccount(topFrame, senderAddr);
+    let destAddr = address(bytearray_get256(calldata, 4));
+    let amount = evmCallFrame_getCallvalue(topFrame);
 
-        if let Some(updatedAcct) = account_deductFromEthBalance(senderAcct, amount) {
-            if ( ! evmCallStack_setAccount(senderAddr, updatedAcct)) {
-                evmOp_revert(0, 0);
-            }
-            let messageData = bytearray_extract(calldata, 4, 32);
-            messageData = bytearray_set256(messageData, 32, amount);
-            sendMessage(0, senderAddr, messageData);
-            evmOp_return(0, 0);
+    if let Some(updatedAcct) = account_deductFromEthBalance(senderAcct, amount) {
+        if ( ! evmCallStack_setAccount(senderAddr, updatedAcct)) {
+            evmOp_revert(0, 0);
         }
+        let messageData = bytearray_extract(calldata, 4, 32);
+        messageData = bytearray_set256(messageData, 32, amount);
+        sendMessage(0, senderAddr, messageData);
+        evmOp_return(0, 0);
     }
 
     evmOp_revert(0, 0);
@@ -194,15 +193,6 @@ impure func arbsys_cloneContract(topFrame: EvmCallFrame, calldata: ByteArray) {
     } else {
         evmOp_revert(0, 0);
     }
-}
-
-impure func getCallerAddress() -> option<address> {
-    let topFrame = evmCallStack_topFrame()?;
-    return Some(
-        evmCallFrame_runningAsAddress(
-            evmCallFrame_getParent(topFrame)?
-        )
-    );
 }
 
 impure func sendMessage(msgType: uint, sender: address, data: ByteArray) {


### PR DESCRIPTION
Fix bug that was preventing Eth withdrawals.  ArbSys.withdrawEth was looking in the wrong place for the caller's identity.