### PR TITLE
Fix ecrecover precompile

### DIFF
--- a/arb_os/precompiles.mini
+++ b/arb_os/precompiles.mini
@@ -60,13 +60,13 @@ public impure func precompile_0x01() {  // ecrecover
             evmOp_revert(0, 0);
         }
         let h = bytearray_get256(calldata, 0);
-        let v = bytearray_getByte(calldata, 32);
+        let v = bytearray_get256(calldata, 32);
         let r = bytearray_get256(calldata, 2*32);
         let s = bytearray_get256(calldata, 3*32);
         let addr = asm(r, s, v-27, h) address { ecrecover };
 
         let success = evmCallStack_setTopFrameMemory(
-            bytearray_set256(bytearray_new(0), 0, 32)
+            bytearray_set256(bytearray_new(0), 0, uint(addr))
         );
         if (success) {
             evmOp_return(0, 32);


### PR DESCRIPTION
This PR fixes the behavior of the ECRecover precompile. The precompile was previously broken and this fix has been verified against both geth and web3,js signing.