### PR TITLE
Replace exp instructions with cheaper shift and byte instructions

### DIFF
--- a/arb_os/arbsys.mini
+++ b/arb_os/arbsys.mini
@@ -98,7 +98,7 @@ public impure func arbsys_txcall() {
 }
 
 func getFuncCode(ba: ByteArray) -> uint {
-    return bytearray_get256(ba, 0) / (asm(2, 224) uint { exp });
+    return asm(224, bytearray_get256(ba, 0)) uint { shr };
 }
 
 impure func arbsys_withdrawErc20(topFrame: EvmCallFrame, calldata: ByteArray) {

--- a/arb_os/gasAccounting.mini
+++ b/arb_os/gasAccounting.mini
@@ -101,8 +101,8 @@ public impure func gasAccounting_startTxCharges(
     // Start charging a new Tx for ArbGas usage
     // The caller should already have verified that the payer has enough funds, but we'll return None if not.
 
-    if (maxGas >= asm(2, 255) uint { exp }) {
-        maxGas = asm(2, 255) uint { exp } - 1;   // make sure
+    if (maxGas >= asm(255, 1) uint { shl }) {
+        maxGas = asm(255, 1) uint { shl } - 1;
     }
 
     // take funds from the payer, enough to pay for maxGas at gasPrice
@@ -223,7 +223,7 @@ impure func switchToChargingOS() -> uint {
     // switch to charging the OS for gas, if we aren't already
     // return amount of the tx's gas that was left over in ArbGasRemaining
     let gasRemaining = asm() uint { getgas };
-    if (gasRemaining >= asm(2, 255) uint { exp }) {
+    if (gasRemaining >= asm(255, 1) uint { shl }) {
         // we were already charging the OS, tx has nothing remaining
         return 0;
     } else {

--- a/stdlib/bytearray.mini
+++ b/stdlib/bytearray.mini
@@ -54,7 +54,7 @@ public func marshalledBytes_firstByte(mb: MarshalledBytes) -> uint {
         contents = unsafecast<MarshalledBytesCell>(contents.rest);
         nbytes = nbytes-32;
     }
-    return contents.first / asm(2, 248) uint { exp };
+    return asm(256-8, contents.first) uint { shr };
 }
 
 public func marshalledBytes_hash(mb: MarshalledBytes) -> bytes32 {
@@ -130,7 +130,7 @@ public func bytearray_getByte(ba: ByteArray, offset: uint) -> uint {
     }
     offset = offset + ba.sliceOffset;
     let word = expandingIntArray_get(ba.contents, offset/32);
-    return (word / (asm (256, 31-(offset & 0x1f)) uint { exp })) & 0xff;
+    return asm(offset & 0x1f, word) uint { byte };
 }
 
 // bytearray_get64 reads a chunk of 8 bytes from a ByteArray
@@ -149,16 +149,16 @@ public func bytearray_get64(ba: ByteArray, offset: uint) -> uint {
     let alignment = offset % 32;
     if (alignment <= 24) {
         let word = expandingIntArray_get(ba.contents, offset/32);
-        let ret = (word / asm(256, 24-alignment) uint { exp }) & 0xffffffffffffffff;
+        let ret = asm(8*(24-alignment), word) uint { shr } & 0xffffffffffffffff;
         if (bytesToTrim > 0) {
-            ret = ret & ~((asm(256, bytesToTrim) uint { exp }) - 1);
+            ret = ret & ~(asm(8*bytesToTrim, 1) uint { shl } - 1);
         }
         return ret;
     } else {
         let res = bytearray_get256(ba, offset-ba.sliceOffset);
         let ret = res / 0x1000000000000000000000000000000000000000000000000;
         if (bytesToTrim > 0) {
-            ret = ret & ~((asm(256, bytesToTrim) uint { exp }) - 1);
+            ret = ret & ~(asm(8*bytesToTrim, 1) uint { shl } - 1);
         }
         return ret;
     }
@@ -179,16 +179,16 @@ public func bytearray_get256(ba: ByteArray, offset: uint) -> uint {
     if (alignment == 0) {
         let ret = expandingIntArray_get(ba.contents, lowWordIndex);
         if (bytesToTrim > 0) {
-            ret = ret & ~((asm(256, bytesToTrim) uint { exp }) - 1);
+            ret = ret & ~(asm(8*bytesToTrim, 1) uint { shl } - 1);
         }
         return ret;
     } else {
         let (lowWord, hiWord) = expandingIntArray_getConsecutive(ba.contents, lowWordIndex);
-        let shiftFactor = asm(256, alignment) uint { exp };
-        let invShiftFactor = asm(256, 32-alignment) uint { exp };
+        let shiftFactor = asm(8*alignment, 1) uint { shl };
+        let invShiftFactor = asm(8*(32-alignment), 1) uint { shl };
         let ret = (hiWord/invShiftFactor) | (lowWord*shiftFactor);
         if (bytesToTrim > 0) {
-            ret = ret & ~((asm(256, bytesToTrim) uint { exp }) - 1);
+            ret = ret & ~(asm(8*bytesToTrim, 1) uint { shl } - 1);
         }
         return ret;
     }
@@ -312,7 +312,7 @@ public func bytearray_extract(from: ByteArray, offset: uint, nbytes: uint) -> By
 
 func basb_closure_func(args: (uint, uint), oldval: uint) -> (uint, uint) { // returns (newval, junk)
     let (subidx, newbval,) = args;
-    let shiftFac = asm (2, 8*subidx) uint { exp };
+    let shiftFac = asm(8*subidx, 1) uint { shl };
     let mask = 0xff * shiftFac;
     let pasteIn = (newbval & 0xff) * shiftFac;
     return (
@@ -323,7 +323,7 @@ func basb_closure_func(args: (uint, uint), oldval: uint) -> (uint, uint) { // re
 
 func bas64_single_closure_func(args: (uint, uint), oldval: uint) -> (uint, uint) { // returns (newval, junk)
     let (subidx, newbval,) = args;
-    let shiftFac = asm (2, 8*subidx) uint { exp };
+    let shiftFac = asm(8*subidx, 1) uint { shl };
     let mask = 0xffffffffffffffff * shiftFac;
     let pasteIn = (newbval & 0xff) * shiftFac;
     return (
@@ -335,7 +335,7 @@ func bas64_single_closure_func(args: (uint, uint), oldval: uint) -> (uint, uint)
 func basmulti_hi_closure_func(args: (uint, uint), oldval: uint) -> (uint, uint) { // returns (newval, junk)
     let (alignment, value,) = args; 
     let revAlignment = 32-alignment;
-    let factor = asm(2, 8*revAlignment) uint { exp };
+    let factor = asm(8*revAlignment, 1) uint { shl };
     let newVal = (value*factor) | (oldval & (factor-1));
     return (newVal, 0,);
 }
@@ -343,8 +343,8 @@ func basmulti_hi_closure_func(args: (uint, uint), oldval: uint) -> (uint, uint) 
 func bas64_low_closure_func(args: (uint, uint), oldval: uint) -> (uint, uint) { // returns (newval, junk)
     let (alignment, value,) = args; 
     let revAlignment = 8-alignment;
-    let factor = asm(2, 8*alignment) uint { exp };
-    let invFactor = asm(2, 8*revAlignment) uint { exp };
+    let factor = asm(8*alignment, 1) uint { shl };
+    let invFactor = asm(8*revAlignment, 1) uint { shl };
     let newVal = (value/factor) | (oldval & (invFactor * ~0));
     return (newVal, 0,);
 }
@@ -352,8 +352,8 @@ func bas64_low_closure_func(args: (uint, uint), oldval: uint) -> (uint, uint) { 
 func bas256_low_closure_func(args: (uint, uint), oldval: uint) -> (uint, uint) { // returns (newval, junk)
     let (alignment, value,) = args; 
     let revAlignment = 32-alignment;
-    let factor = asm(2, 8*alignment) uint { exp };
-    let invFactor = asm(2, 8*revAlignment) uint { exp };
+    let factor = asm(8*alignment, 1) uint { shl };
+    let invFactor = asm(8*revAlignment, 1) uint { shl };
     let newVal = (value/factor) | (oldval & (invFactor * ~0));
     return (newVal, 0,);
 }

--- a/stdlib/bytestream.mini
+++ b/stdlib/bytestream.mini
@@ -90,7 +90,7 @@ public func bytestream_getByte(bs: ByteStream) -> option<(ByteStream, uint)> {
         }
         return Some((
             bs with { currentOffset: bs.currentOffset+1 },
-            (cache / asm (2, 8*(31-offsetMod32)) uint { exp }) & 0xff
+            asm(offsetMod32, cache) uint { byte }
         ));
     }
 }

--- a/stdlib/rlp.mini
+++ b/stdlib/rlp.mini
@@ -54,7 +54,7 @@ public func rlp_encodeUint(val: uint, ba: ByteArray, offset: uint) -> (ByteArray
         offset = offset + 1;
         while (length > 0) {
             length = length-1;
-            ba = bytearray_setByte(ba, offset, (val / asm(256, length) uint { exp }) & 0xff);
+            ba = bytearray_setByte(ba, offset, (asm(8*length, val) uint { shr }) & 0xff);
             offset = offset+1;
         }
         return (ba, origLen+1);
@@ -100,7 +100,7 @@ public func rlp_encodeBytes(
     let i = sizeOfSize;
     while (i > 0) {
         i = i-1;
-        outBytes = bytearray_setByte(outBytes, outOffset, (nbytes / asm(256, i) uint { exp }) & 0xff);
+        outBytes = bytearray_setByte(outBytes, outOffset, asm(8*i, nbytes) uint { shr } & 0xff);
         outOffset = outOffset + 1;
     }
     return (
@@ -161,7 +161,7 @@ public func rlp_encodeList(
         let i = sizeOfSize;
         while (i > 0) {
             i = i-1;
-            let b = (totalSize / asm(256, i) uint { exp }) & 0xff;
+            let b = asm(8*i, totalSize) uint { shr } & 0xff;
             outBytes = bytearray_setByte(outBytes, outOffset, b);
             outOffset = outOffset+1;
         }
@@ -303,7 +303,7 @@ public func bytesNeededToRepresentUint(val: uint) -> uint {
     let ret = 0;
     let bytes = 16;
     while (bytes > 0) {
-        let threshold = asm(256, bytes) uint { exp };
+        let threshold = asm(8*bytes, 1) uint { shl };
         if (val >= threshold) {
             ret = ret + bytes;
             val = val / threshold;


### PR DESCRIPTION
Throughout ArbOS, replace `exp` instructions which we were previously using for bit shifting with the new shift instructions (and occasionally a `byte` instruction).

This will be a draft PR until the PR that adds those instructions is merged.