### PR TITLE
Pass caller's EVM-logs-so-far to callee

### DIFF
--- a/arb_os/evmCallStack.mini
+++ b/arb_os/evmCallStack.mini
@@ -384,7 +384,7 @@ public impure func evmCallStack_doCall(
         callvalue: balance,
         returnInfo: None<ReturnInfo>,
         memory: bytearray_new(0),
-        evmLogs: evmlogs_empty(),
+        evmLogs: topFrame.evmLogs,
         selfDestructQueue: topFrame.selfDestructQueue,
         resumeInfo: None<ResumeInfo>,
         parent: Some(topFrame)


### PR DESCRIPTION
When contract A calls contract B, the caller's accumulated EVM logs are now copied into the callee's EVM stack frame.  If the call succeeds, the logs will be copied back into the caller's frame (including any log items added by the callee.

Previously we were not passing the caller's logs properly to the callee.