### PR TITLE
Check for over-large index in array call

### DIFF
--- a/stdlib/bytearray.mini
+++ b/stdlib/bytearray.mini
@@ -387,6 +387,9 @@ func expandingIntArray_get(arr: ExpandingIntArray, index: uint) -> uint {
 }
 
 func expandingIntArray_getConsecutive(arr: ExpandingIntArray, index: uint) -> (uint, uint) {
+    if (index+1 >= arr.size) {
+        return (expandingIntArray_get(arr, index), 0);
+    }
     let tree = arr.contents;
     let chunk = arr.chunk;
 


### PR DESCRIPTION
Previously in some corner cases, bytearray_get256 would panic due to out-of-range AVM tuple get.  This adds a bounds check to prevent that.