### PR TITLE
Remove use of Sideload from ArbOS

### DIFF
--- a/arb_os/gasAccounting.mini
+++ b/arb_os/gasAccounting.mini
@@ -266,10 +266,6 @@ public impure func getNextMsgFromCongestionAuction() -> (
     // For now, the gas auction is a no-op.  It just approves every message at zero gas price.
     let msg = unsafecast<IncomingRequest>(());   // value will be re-initialized before use
     loop {
-        if let Some(sideloadedTuple) = trySideload() {
-            return sideloadedTuple;
-        }
-
         if let Some(res) = queue_get(gasAccountingInfo.queuedFromBatch) {
             let (newQ, rawMsg) = res;
             gasAccountingInfo = gasAccountingInfo with {
@@ -335,32 +331,5 @@ public impure func getNextMsgFromCongestionAuction() -> (
                 return (msg, true, maxGas, 0);
             }
         }
-    }
-}
-
-// The following function exists to support sideloading.
-// Sideloading is a method used by validators to run non-mutating calls on their
-//     private clones of a chain's state. The sideload instruction is defined to push
-//     an empty tuple () onto the stack, which will cause this procedure to always
-//     return None when executed by an Arbitrum chain.
-// But a validator (or really any "full node" on an Arbitrum chain) wants to be able to
-//     run non-mutating calls on a private clone of the chain, so that it can get
-//     correct results from those non-mutating calls without having to use the more
-//     expensive public protocol. To do this, a validator will make a private clone of the
-//     chain's state, then "sideload" messages asking for the non-mutating calls into the
-//     private clone.
-// So in the private clone only, a validator can cause the sideload instruction to push
-//     onto the stack a pair (message, gasLimit).  This function will then return that
-//     pair, which will cause (the private clone of) the chain to run that call, with the
-//     given gasLimit and zero gas price.
-impure func trySideload() -> option<(IncomingRequest, bool, uint, uint)> {
-    let sideloadedVal = asm() any { sideload };
-    if (sideloadedVal == ()) {
-        // normal case; the official chain will always be in this case
-        return None;
-    } else {
-        // don't worry about the unsafecast; this can't execute on the official chain
-        let (msg, gasLimit) = unsafecast<(IncomingRequest, uint)>(sideloadedVal);
-        return Some((msg, true, gasLimit, 0));
     }
 }


### PR DESCRIPTION
ArbOS no longer needs to use `sideload` to support the callserver.   After the recent changes to the semantics of inboxes, the callserver can leverage the `inboxpeek` and `inbox` operations in ArbOS to inject messages as needed.