### PR TITLE
Get storage at

### DIFF
--- a/arb_os/arbsys.mini
+++ b/arb_os/arbsys.mini
@@ -205,5 +205,11 @@ impure func arbsys_getStorageAt(topFrame: EvmCallFrame, calldata: ByteArray) {
     }
 
     let updatedMem = bytearray_set256(evmCallStack_getTopFrameMemoryOrDie(), 0, ret);
-    evmOp_return(0, 32);
+    let success = evmCallStack_setTopFrameMemory(updatedMem);
+
+    if (success) {
+        evmOp_return(0, 32);
+    } else {
+        evmOp_revert(0, 0);
+    }
 }


### PR DESCRIPTION
Add a `getStorageAt` method to `ArbSys`.  The method reads a value from the storage of any contract.  It can only be called by address zero (reverts if called by anyone else), to ensure that only the EthBridge can call it.