### PR TITLE
Add staking token address to chain init message

### DIFF
--- a/arb_os/chainParameters.mini
+++ b/arb_os/chainParameters.mini
@@ -16,6 +16,7 @@ type ChainParams = struct {
     arbGasSpeedLimit: uint,   // assumed max speed of nodes tracking this chain's VM
     maxExecutionSteps: uint,  // max number of steps in an assertion
     baseStake: uint,          // base stake of a validator, in wei
+    stakingToken: address,    // ERC-20 token used for staking; or zero if using ETH
     owner: address            // owner of the chain, who has admin privileges (or zero if there is no owner)
 }
 
@@ -34,7 +35,8 @@ public impure func chainParams_gotParamsMessage(sender: address, data: Marshalle
             arbGasSpeedLimit: bytearray_get256(ba, 32) * ticksPerSecond(),
             maxExecutionSteps: bytearray_get256(ba, 2*32),
             baseStake: bytearray_get256(ba, 3*32),
-            owner: address(bytearray_get256(ba, 4*32)),
+            stakingToken: address(bytearray_get256(ba, 4*32)),
+            owner: address(bytearray_get256(ba, 5*32)),
         });
     }
 }
@@ -65,10 +67,10 @@ public impure func chainParams_speedLimitPerSecond() -> uint {
     }
 }
 
-public impure func chainParams_baseStake() -> uint {
+public impure func chainParams_baseStake() -> (address, uint) {
     if let Some(params) = globalChainParams {
-        return params.baseStake;
+        return (params.stakingToken, params.baseStake);
     } else {
-        return 0;
+        return (address(0), 0);
     }
 }

--- a/doc/DataFormats.md
+++ b/doc/DataFormats.md
@@ -74,6 +74,7 @@ Type-specific data:
 * ArbGas speed limit, in ArbGas per second (uint)
 * maximum number of execution steps allowed in an assertion (uint)
 * minimum stake requirement, in Wei (uint)
+* address of the staking token, or zero if staking in ETH (address encoded as uint)
 * address of the chain's owner (address encoded as uint)
 * option data
 

--- a/src/run/runtime_env.rs
+++ b/src/run/runtime_env.rs
@@ -52,6 +52,7 @@ impl RuntimeEnvironment {
         buf.extend(Uint256::from_u64(100_000_000 / 1000).to_bytes_be()); // arbgas speed limit per tick
         buf.extend(Uint256::from_u64(10_000_000_000).to_bytes_be()); // max execution steps
         buf.extend(Uint256::from_u64(1000).to_bytes_be()); // base stake amount in wei
+        buf.extend(Uint256::zero().to_bytes_be()); // staking token address (zero means ETH)
         buf.extend(Uint256::zero().to_bytes_be()); // owner address
         buf
     }


### PR DESCRIPTION
This needs to be synchronized with a corresponding update to the main Arbitrum repo.