### PR TITLE
Include callvalue in params of nonmutating call

### DIFF
--- a/arb_os/evmCallStack.mini
+++ b/arb_os/evmCallStack.mini
@@ -181,6 +181,7 @@ type TxRequestData = struct {
     calleeAddr: address,
     value: uint,
     calldata: ByteArray,
+    nonMutating: bool,
     incomingRequest: IncomingRequest,
 }
 

--- a/arb_os/gasAccounting.mini
+++ b/arb_os/gasAccounting.mini
@@ -251,6 +251,7 @@ type TxRequestData = struct {
     calleeAddr: address,
     value: uint,
     calldata: ByteArray,
+    nonMutating: bool,
     incomingRequest: IncomingRequest,
 }
 

--- a/arb_os/inbox.mini
+++ b/arb_os/inbox.mini
@@ -158,6 +158,7 @@ type TxRequestData = struct {
     calleeAddr: address,
     value: uint,
     calldata: ByteArray,
+    nonMutating: bool,
     incomingRequest: IncomingRequest,
 }
 
@@ -272,6 +273,7 @@ func translateUnsignedTx(request: IncomingRequest) -> option<TxRequestData> {
             calleeAddr: address(destAddrAsUint),
             value: value,
             calldata: calldata,
+            nonMutating: (subtype == 2),
             incomingRequest: request
         }
     );
@@ -300,6 +302,7 @@ func translateBuddyDeployTx(request: IncomingRequest) -> option<TxRequestData> {
             calleeAddr: address(0),
             value: value,
             calldata: calldata,
+            nonMutating: false,
             incomingRequest: request
         }
     );

--- a/arb_os/main.mini
+++ b/arb_os/main.mini
@@ -87,6 +87,7 @@ type TxRequestData = struct {
     calleeAddr: address,
     value: uint,
     calldata: ByteArray,
+    nonMutating: bool,
     incomingRequest: IncomingRequest,
 }
 

--- a/arb_os/messages.mini
+++ b/arb_os/messages.mini
@@ -216,6 +216,7 @@ type TxRequestData = struct {
     calleeAddr: address,
     value: uint,
     calldata: ByteArray,
+    nonMutating: bool,
     incomingRequest: IncomingRequest,
 }
 
@@ -279,7 +280,7 @@ public impure func handleL2Request(
     } else {
         // this is a non-constructor call
         let callKind = 0;
-        if (request.incomingRequest.kind == 2) {
+        if (request.nonMutating) {
             callKind = 3;  // staticcall
         }
 

--- a/arb_os/signedTx.mini
+++ b/arb_os/signedTx.mini
@@ -55,6 +55,7 @@ type TxRequestData = struct {
     calleeAddr: address,
     value: uint,
     calldata: ByteArray,
+    nonMutating: bool,
     incomingRequest: IncomingRequest,
 }
 
@@ -97,6 +98,7 @@ public impure func translateSignedTx(req: IncomingRequest) -> option<TxRequestDa
             calleeAddr: signedTx.to,
             value: signedTx.value,
             calldata: signedTx.data,
+            nonMutating: false,
             incomingRequest: req with {
                 sender: signer
             } with {

--- a/arb_os/tokens.mini
+++ b/arb_os/tokens.mini
@@ -32,6 +32,7 @@ type TxRequestData = struct {
     calleeAddr: address,
     value: uint,
     calldata: ByteArray,
+    nonMutating: bool,
     incomingRequest: IncomingRequest,
 }
 
@@ -82,6 +83,7 @@ public impure func tokens_erc20deposit(
             calleeAddr: tokenAddress,
             value: 0,
             calldata: calldata,
+            nonMutating: false,
             incomingRequest: fullMsg,
         }
     );  // should never return
@@ -136,6 +138,7 @@ public impure func tokens_erc721deposit(
             calleeAddr: tokenAddress,
             value: 0,
             calldata: calldata,
+            nonMutating: false,
             incomingRequest: fullMsg,
         }
     );  // should never return


### PR DESCRIPTION
Non-mutating call messages (L2 messages) now include a callvalue field, at the same position as in contract calls.

(Note that the format documentation needs to be updated in the Arbitrum repo when this is imported there.)