### PR TITLE
Add ability to assess extra ArbGas charges

### DIFF
--- a/arb_os/gasAccounting.mini
+++ b/arb_os/gasAccounting.mini
@@ -150,6 +150,26 @@ public impure func gasAccounting_endTxCharges() -> option<GasUsage> {
     );
 }
 
+public impure func gasAccounting_extraGasCharge(numArbGas: uint) {
+    // assess an extra gas charge on the current tx
+    // this lets us charge for things that use up system resources
+    // callers should assess the charge for a thing before they do the thing, because we can
+    //      only take the gas that the user has remaining
+
+    let gasLeft = asm() uint { getgas };
+    if (gasLeft >= asm (1, 255) uint { shl }) {
+        return;   // we're not currently charging a tx, so don't assess a charge
+    }
+
+    if (numArbGas >= gasLeft) {
+        // user can't cover the charge, so we'll take all but 1 of their gas,
+        //      ensuring that they'll get an out-of-gas error
+        numArbGas = gasLeft-1;
+    }
+
+    asm(gasLeft-numArbGas,) { setgas };
+}
+
 public impure func gasAccounting_pauseTxCharges() -> uint {
     // pause charging the currently running tx
     // return how many units of the tx's initial maxGas are still unused


### PR DESCRIPTION
Add a function that ArbOS components can use to assess extra ArbGas charges on transactions. 

This is meant for use with facilities that do things like allocate storage. An example is the address table used for compression.