### PR TITLE
Blake2f instruction errors if steps > 0xffff

### DIFF
--- a/src/run/emulator.rs
+++ b/src/run/emulator.rs
@@ -1936,9 +1936,13 @@ impl Machine {
                     }
                     AVMOpcode::Blake2f => {
                         let t = self.stack.pop_buffer(&self.state)?;
-                        self.stack.push_buffer(blake2bf_instruction(t));
-                        self.incr_pc();
-                        Ok(true)
+                        if let Some(res) = blake2bf_instruction(t) {
+                            self.stack.push_buffer(res);
+                            self.incr_pc();
+                            Ok(true)
+                        } else {
+                            Err(ExecutionError::new("too many steps in Blake2f", &self.state, None))
+                        }
                     }
                     AVMOpcode::Inbox => {
                         match self.runtime_env.get_from_inbox() {

--- a/src/run/emulator.rs
+++ b/src/run/emulator.rs
@@ -1941,7 +1941,11 @@ impl Machine {
                             self.incr_pc();
                             Ok(true)
                         } else {
-                            Err(ExecutionError::new("too many steps in Blake2f", &self.state, None))
+                            Err(ExecutionError::new(
+                                "too many steps in Blake2f",
+                                &self.state,
+                                None,
+                            ))
                         }
                     }
                     AVMOpcode::Inbox => {


### PR DESCRIPTION
Make the `blake2f` AVM instruction generate an error if the step count is greater than `0xffff`.  This is a safer way to deal with unexpected inputs, and consistent with the implementation being done in the C++ AVM.