### PR TITLE
Emulator Fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,9 +153,9 @@ jobs:
 
       - name: Build Arbitrum
         run: |
-          mkdir arbitrum/packages/arb-avm-cpp/debug/
+          mkdir arbitrum/packages/arb-avm-cpp/build/
           cd $_
-          cmake .. -DCMAKE_BUILD_TYPE=Debug
+          cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
           make -j
 
       - name: Test Node's C++ Database

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -105,8 +105,6 @@ struct TypeCheckedModule {
     imports: Vec<Import>,
     /// The path to the module
     path: Vec<String>,
-    /// The name of the module
-    name: String,
 }
 
 impl CompileStruct {
@@ -234,7 +232,6 @@ impl TypeCheckedModule {
         global_vars: Vec<GlobalVar>,
         imports: Vec<Import>,
         path: Vec<String>,
-        name: String,
     ) -> Self {
         Self {
             checked_funcs,
@@ -244,7 +241,6 @@ impl TypeCheckedModule {
             global_vars,
             imports,
             path,
-            name,
         }
     }
 
@@ -883,7 +879,7 @@ fn typecheck_programs(
                  string_table,
                  func_table,
                  path,
-                 name,
+                 name: _,
              }| {
                 let mut typecheck_issues = vec![];
                 let (mut checked_funcs, global_vars, string_table) =
@@ -959,7 +955,6 @@ fn typecheck_programs(
                         global_vars,
                         imports,
                         path,
-                        name,
                     ),
                     typecheck_issues,
                 ))

--- a/src/evm/abi.rs
+++ b/src/evm/abi.rs
@@ -28,6 +28,7 @@ pub struct AbiForContract {
     pub code_bytes: Vec<u8>,
     pub contract: ethabi::Contract,
     pub address: Uint256,
+    #[allow(dead_code)]
     name: String,
 }
 

--- a/src/evm/mod.rs
+++ b/src/evm/mod.rs
@@ -35,14 +35,6 @@ mod evmtest;
 mod live_code;
 pub mod preinstalled_contracts;
 
-#[derive(Clone)]
-pub struct CallInfo<'a> {
-    function_name: &'a str,
-    args: &'a [ethabi::Token],
-    payment: Uint256,
-    mutating: bool,
-}
-
 pub fn test_contract_path2(solidity_name: &str, json_name: &str) -> String {
     format!(
         "contracts/artifacts/arbos/test/{}.sol/{}.json",

--- a/src/mavm.rs
+++ b/src/mavm.rs
@@ -279,7 +279,7 @@ impl fmt::Display for CodePt {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Eq)]
 pub struct Buffer {
     root: Arc<BufferNode>,
     size: u128,
@@ -354,6 +354,12 @@ impl Buffer {
                 self.size
             },
         }
+    }
+}
+
+impl PartialEq for Buffer {
+    fn eq(&self, other: &Buffer) -> bool {
+        self.avm_hash() == other.avm_hash()
     }
 }
 

--- a/src/run/emulator.rs
+++ b/src/run/emulator.rs
@@ -2169,11 +2169,11 @@ impl Machine {
                     AVMOpcode::GetBuffer64 => {
                         let offset = self.stack.pop_usize(&self.state)?;
                         let buf = self.stack.pop_buffer(&self.state)?;
-                        if offset + 7 < offset {
+                        if offset.overflowing_add(7).1 {
                             return Err(ExecutionError::new(
                                 "buffer overflow",
                                 &self.state,
-                                Some(Value::Int(Uint256::from_usize(offset))),
+                                Some(Value::from(offset)),
                             ));
                         }
                         let mut res = [0u8; 8];
@@ -2187,11 +2187,11 @@ impl Machine {
                     AVMOpcode::GetBuffer256 => {
                         let offset = self.stack.pop_usize(&self.state)?;
                         let buf = self.stack.pop_buffer(&self.state)?;
-                        if offset + 31 < offset {
+                        if offset.overflowing_add(31).1 {
                             return Err(ExecutionError::new(
                                 "buffer overflow",
                                 &self.state,
-                                Some(Value::Int(Uint256::from_usize(offset))),
+                                Some(Value::from(offset)),
                             ));
                         }
                         let mut res = [0u8; 32];
@@ -2214,11 +2214,11 @@ impl Machine {
                     }
                     AVMOpcode::SetBuffer64 => {
                         let offset = self.stack.pop_usize(&self.state)?;
-                        if offset + 7 < offset {
+                        if offset.overflowing_add(7).1 {
                             return Err(ExecutionError::new(
                                 "buffer overflow",
                                 &self.state,
-                                Some(Value::Int(Uint256::from_usize(offset))),
+                                Some(Value::from(offset)),
                             ));
                         }
                         let val = self.stack.pop_uint(&self.state)?;
@@ -2234,11 +2234,11 @@ impl Machine {
                     }
                     AVMOpcode::SetBuffer256 => {
                         let offset = self.stack.pop_usize(&self.state)?;
-                        if offset + 31 < offset {
+                        if offset.overflowing_add(31).1 {
                             return Err(ExecutionError::new(
                                 "buffer overflow",
                                 &self.state,
-                                Some(Value::Int(Uint256::from_usize(offset))),
+                                Some(Value::from(offset)),
                             ));
                         }
                         let val = self.stack.pop_uint(&self.state)?;

--- a/src/run/runtime_env.rs
+++ b/src/run/runtime_env.rs
@@ -26,9 +26,11 @@ pub struct RuntimeEnvironment {
     pub sends: Vec<Vec<u8>>,
     pub next_inbox_seq_num: Uint256,
     pub caller_seq_nums: HashMap<Uint256, Uint256>,
+    #[allow(dead_code)]
     next_id: Uint256, // used to assign unique (but artificial) txids to messages
     pub recorder: RtEnvRecorder,
     compressor: TxCompressor,
+    #[allow(dead_code)]
     charging_policy: Option<(Uint256, Uint256, Uint256)>,
     num_wallets: u64,
     chain_init_message: Vec<u8>,
@@ -743,20 +745,28 @@ pub struct ArbosReceipt {
     request_id: Uint256,
     return_code: Uint256,
     return_data: Vec<u8>,
+    #[allow(dead_code)]
     evm_logs: Vec<EvmLog>,
     gas_used: Uint256,
+    #[allow(dead_code)]
     gas_price_wei: Uint256,
     pub provenance: ArbosRequestProvenance,
-    gas_so_far: Uint256,     // gas used so far in L1 block, including this tx
+    gas_so_far: Uint256, // gas used so far in L1 block, including this tx
+    #[allow(dead_code)]
     index_in_block: Uint256, // index of this tx in L1 block
-    logs_so_far: Uint256,    // EVM logs emitted so far in L1 block, NOT including this tx
+    #[allow(dead_code)]
+    logs_so_far: Uint256, // EVM logs emitted so far in L1 block, NOT including this tx
+    #[allow(dead_code)]
     fee_stats: Vec<Vec<Uint256>>,
 }
 
 #[derive(Clone, Debug)]
 pub struct ArbosRequestProvenance {
+    #[allow(dead_code)]
     l1_sequence_num: Uint256,
+    #[allow(dead_code)]
     parent_request_id: Option<Uint256>,
+    #[allow(dead_code)]
     index_in_parent: Option<Uint256>,
 }
 


### PR DESCRIPTION
This PR fixes a few corner cases in the rust emulator.

Additional changes are made to silence new warnings introduced by today's upgrade to Rust 1.57.